### PR TITLE
Fix experimental.pyx for non-CUDA compilation

### DIFF
--- a/python/astra/experimental.pyx
+++ b/python/astra/experimental.pyx
@@ -28,57 +28,59 @@
 
 include "config.pxi"
 
-import six
-from .PyIncludes cimport *
-from libcpp.vector cimport vector
+IF HAVE_CUDA==True:
 
-cdef extern from "astra/CompositeGeometryManager.h" namespace "astra":
-    cdef cppclass CCompositeGeometryManager:
-        bool doFP(CProjector3D *, vector[CFloat32VolumeData3DMemory *], vector[CFloat32ProjectionData3DMemory *])
-        bool doBP(CProjector3D *, vector[CFloat32VolumeData3DMemory *], vector[CFloat32ProjectionData3DMemory *])
+    import six
+    from .PyIncludes cimport *
+    from libcpp.vector cimport vector
 
-cdef extern from *:
-    CFloat32VolumeData3DMemory * dynamic_cast_vol_mem "dynamic_cast<astra::CFloat32VolumeData3DMemory*>" (CFloat32Data3D * ) except NULL
-    CFloat32ProjectionData3DMemory * dynamic_cast_proj_mem "dynamic_cast<astra::CFloat32ProjectionData3DMemory*>" (CFloat32Data3D * ) except NULL
+    cdef extern from "astra/CompositeGeometryManager.h" namespace "astra":
+        cdef cppclass CCompositeGeometryManager:
+            bool doFP(CProjector3D *, vector[CFloat32VolumeData3DMemory *], vector[CFloat32ProjectionData3DMemory *])
+            bool doBP(CProjector3D *, vector[CFloat32VolumeData3DMemory *], vector[CFloat32ProjectionData3DMemory *])
 
-cimport PyProjector3DManager
-from .PyProjector3DManager cimport CProjector3DManager
-cimport PyData3DManager
-from .PyData3DManager cimport CData3DManager
+    cdef extern from *:
+        CFloat32VolumeData3DMemory * dynamic_cast_vol_mem "dynamic_cast<astra::CFloat32VolumeData3DMemory*>" (CFloat32Data3D * ) except NULL
+        CFloat32ProjectionData3DMemory * dynamic_cast_proj_mem "dynamic_cast<astra::CFloat32ProjectionData3DMemory*>" (CFloat32Data3D * ) except NULL
 
-cdef CProjector3DManager * manProj = <CProjector3DManager * >PyProjector3DManager.getSingletonPtr()
-cdef CData3DManager * man3d = <CData3DManager * >PyData3DManager.getSingletonPtr()
+    cimport PyProjector3DManager
+    from .PyProjector3DManager cimport CProjector3DManager
+    cimport PyData3DManager
+    from .PyData3DManager cimport CData3DManager
 
-def do_composite(projector_id, vol_ids, proj_ids, t):
-    cdef vector[CFloat32VolumeData3DMemory *] vol
-    cdef CFloat32VolumeData3DMemory * pVolObject
-    cdef CFloat32ProjectionData3DMemory * pProjObject
-    for v in vol_ids:
-        pVolObject = dynamic_cast_vol_mem(man3d.get(v))
-        if pVolObject == NULL:
-            raise Exception("Data object not found")
-        if not pVolObject.isInitialized():
-            raise Exception("Data object not initialized properly")
-        vol.push_back(pVolObject)
-    cdef vector[CFloat32ProjectionData3DMemory *] proj
-    for v in proj_ids:
-        pProjObject = dynamic_cast_proj_mem(man3d.get(v))
-        if pProjObject == NULL:
-            raise Exception("Data object not found")
-        if not pProjObject.isInitialized():
-            raise Exception("Data object not initialized properly")
-        proj.push_back(pProjObject)
-    cdef CCompositeGeometryManager m
-    cdef CProjector3D * projector = manProj.get(projector_id) # may be NULL
-    if t == "FP":
-        if not m.doFP(projector, vol, proj):
-            raise Exception("Failed to perform FP")
-    else:
-        if not m.doBP(projector, vol, proj):
-            raise Exception("Failed to perform BP")
+    cdef CProjector3DManager * manProj = <CProjector3DManager * >PyProjector3DManager.getSingletonPtr()
+    cdef CData3DManager * man3d = <CData3DManager * >PyData3DManager.getSingletonPtr()
 
-def do_composite_FP(projector_id, vol_ids, proj_ids):
-    do_composite(projector_id, vol_ids, proj_ids, "FP")
+    def do_composite(projector_id, vol_ids, proj_ids, t):
+        cdef vector[CFloat32VolumeData3DMemory *] vol
+        cdef CFloat32VolumeData3DMemory * pVolObject
+        cdef CFloat32ProjectionData3DMemory * pProjObject
+        for v in vol_ids:
+            pVolObject = dynamic_cast_vol_mem(man3d.get(v))
+            if pVolObject == NULL:
+                raise Exception("Data object not found")
+            if not pVolObject.isInitialized():
+                raise Exception("Data object not initialized properly")
+            vol.push_back(pVolObject)
+        cdef vector[CFloat32ProjectionData3DMemory *] proj
+        for v in proj_ids:
+            pProjObject = dynamic_cast_proj_mem(man3d.get(v))
+            if pProjObject == NULL:
+                raise Exception("Data object not found")
+            if not pProjObject.isInitialized():
+                raise Exception("Data object not initialized properly")
+            proj.push_back(pProjObject)
+        cdef CCompositeGeometryManager m
+        cdef CProjector3D * projector = manProj.get(projector_id) # may be NULL
+        if t == "FP":
+            if not m.doFP(projector, vol, proj):
+                raise Exception("Failed to perform FP")
+        else:
+            if not m.doBP(projector, vol, proj):
+                raise Exception("Failed to perform BP")
 
-def do_composite_BP(projector_id, vol_ids, proj_ids):
-    do_composite(projector_id, vol_ids, proj_ids, "BP")
+    def do_composite_FP(projector_id, vol_ids, proj_ids):
+        do_composite(projector_id, vol_ids, proj_ids, "FP")
+
+    def do_composite_BP(projector_id, vol_ids, proj_ids):
+        do_composite(projector_id, vol_ids, proj_ids, "BP")


### PR DESCRIPTION
This is a fix for issue #21 . It simply removes all code in experimental.pyx when not building with CUDA.