### PR TITLE
Add Travis CI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: python
+
+python:
+  - "2.7"
+  - "3.5"
+
+os:
+  - linux
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - libboost-all-dev
+env:
+    - CUDA=yes
+    - CUDA=no
+
+before_install:
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update conda
+  - if [ $CUDA == yes ]; then wget http://developer.download.nvidia.com/compute/cuda/6_0/rel/installers/cuda_6.0.37_linux_64.run; fi
+  - if [ $CUDA == yes ]; then bash cuda_6.0.37_linux_64.run -toolkit -toolkitpath=$HOME/cuda/ -silent; fi
+
+install:
+  - conda install python=$TRAVIS_PYTHON_VERSION six numpy scipy cython
+  - conda info -a
+  - cd build/linux
+  - ./autogen.sh
+  - if [ $CUDA == yes ]; then ./configure --prefix=$HOME/astra --with-python --with-cuda=$HOME/cuda/; else ./configure --prefix=$HOME/astra --with-python; fi
+  - make -j 4
+  - make install
+
+script:
+  - LD_LIBRARY_PATH=$HOME/astra/lib/:$HOME/cuda/lib64/:$HOME/cuda/lib/:$LD_LIBRARY_PATH PYTHONPATH=$HOME/astra/python/:$PYTHONPATH python -c "import astra"


### PR DESCRIPTION
This PR add travis CI support to ASTRA. When the ASTRA github repository has been connected to a travis account, it will automatically build pushed commits and pull requests, and report whether it correctly builds in github itself. It will build 4 versions: python 2.7/3.5 and CUDA/non-CUDA. The CUDA builds take a bit long (about 10-15 minutes), since it has to download and install the CUDA SDK. It currently only tests whether an `import astra` works in Python, but we might want to add a test suite if we have one later.

This will help prevent problems like #27 by catching error earlier.