### PR TITLE
Install Python bindings in correct dist-packages directory

### DIFF
--- a/build/linux/Makefile.in
+++ b/build/linux/Makefile.in
@@ -391,17 +391,13 @@ install-matlab:
 endif
 
 ifeq ($(python),yes)
-# TODO: This install location doesn't work well for /usr or /usr/local
+sitepkg=@prefix@/lib/python@PYTHON_VERSION@/dist-packages
 install-python: py
-	$(INSTALL_SH) -m 755 -d @prefix@/python
-	$(INSTALL_SH) -m 755 -d @prefix@/python/astra
-	$(INSTALL_SH) -m 644 python/finalbuild/astra/*.so @prefix@/python/astra
-	$(INSTALL_SH) -m 644 python/finalbuild/astra/*.py @prefix@/python/astra
-	$(INSTALL_SH) -m 644 python/finalbuild/*.egg-info @prefix@/python/
-	@echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-	@echo "To use ASTRA in Python, add @prefix@/python/ to your PYTHONPATH"
-	@echo "and @libdir@ to your LD_LIBRARY_PATH."
-	@echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+	$(INSTALL_SH) -m 755 -d $(sitepkg)
+	$(INSTALL_SH) -m 755 -d $(sitepkg)/astra
+	$(INSTALL_SH) -m 644 python/finalbuild/astra/*.so $(sitepkg)/astra
+	$(INSTALL_SH) -m 644 python/finalbuild/astra/*.py $(sitepkg)/astra
+	$(INSTALL_SH) -m 644 python/finalbuild/*.egg-info $(sitepkg)
 # TODO: docs
 else
 install-python:

--- a/build/linux/configure.ac
+++ b/build/linux/configure.ac
@@ -194,6 +194,12 @@ if test x"$with_python" != x -a x"$with_python" != xno; then
   AC_MSG_RESULT([$PYTHON])
   HAVEPYTHON=yes
   AC_SUBST(PYTHON)
+
+  AC_MSG_CHECKING(for Python version)
+  PYTHON_VERSION=`$PYTHON -c "import sys; print (sys.version[[:3]])"`
+  AC_MSG_RESULT([$PYTHON_VERSION])
+  AC_SUBST(PYTHON_VERSION)
+
   AC_MSG_CHECKING(for numpy module)
   ASTRA_TRY_PYTHON([import numpy],,HAVEPYTHON=no)
   if test x$HAVEPYTHON = xno; then


### PR DESCRIPTION
This patch will install the Python bindings in a directory which is searched by default by the Python interpreter.

I have tested it with --with-python=python3 and --with-python=python flags to ./configure, which on my machine yields /usr/local/lib/python3.4/dist-packages respective /usr/local/lib/python2.7/dist-packages .