### PR TITLE
Split conda package into c++ lib and python parts

### DIFF
--- a/build/linux/Makefile.in
+++ b/build/linux/Makefile.in
@@ -150,6 +150,7 @@ BASE_OBJECTS=\
 	src/ParallelProjectionGeometry3D.lo \
 	src/ParallelVecProjectionGeometry3D.lo \
 	src/PlatformDepSystemCode.lo \
+	src/PluginAlgorithm.lo \
 	src/ProjectionGeometry2D.lo \
 	src/ProjectionGeometry3D.lo \
 	src/Projector2D.lo \
@@ -255,7 +256,6 @@ MATLAB_MEX=\
 	matlab/mex/astra_mex_direct_c.$(MEXSUFFIX)
 
 ifeq ($(python),yes)
-ALL_OBJECTS+=src/PluginAlgorithm.lo
 MATLAB_MEX+=matlab/mex/astra_mex_plugin_c.$(MEXSUFFIX)
 endif
 

--- a/python/conda/build.sh
+++ b/python/conda/build.sh
@@ -5,12 +5,4 @@ if [ $MAKEOPTS == '<UNDEFINED>' ]
   then
     MAKEOPTS=""
 fi
-make $MAKEOPTS install-libraries
 make $MAKEOPTS python-root-install
-LIBPATH=lib
-if [ $ARCH == 64 ]
-  then
-    LIBPATH+=64
-fi
-cp -P $CUDA_ROOT/$LIBPATH/libcudart.so.* $PREFIX/lib
-cp -P $CUDA_ROOT/$LIBPATH/libcufft.so.* $PREFIX/lib

--- a/python/conda/libastra/build.sh
+++ b/python/conda/libastra/build.sh
@@ -1,0 +1,15 @@
+cd build/linux
+./autogen.sh
+./configure --with-python --with-cuda=$CUDA_ROOT --prefix=$PREFIX
+if [ $MAKEOPTS == '<UNDEFINED>' ]
+  then
+    MAKEOPTS=""
+fi
+make $MAKEOPTS install-libraries
+LIBPATH=lib
+if [ $ARCH == 64 ]
+  then
+    LIBPATH+=64
+fi
+cp -P $CUDA_ROOT/$LIBPATH/libcudart.so.* $PREFIX/lib
+cp -P $CUDA_ROOT/$LIBPATH/libcufft.so.* $PREFIX/lib

--- a/python/conda/libastra/build.sh
+++ b/python/conda/libastra/build.sh
@@ -1,6 +1,6 @@
 cd build/linux
 ./autogen.sh
-./configure --with-python --with-cuda=$CUDA_ROOT --prefix=$PREFIX
+./configure --with-cuda=$CUDA_ROOT --prefix=$PREFIX
 if [ $MAKEOPTS == '<UNDEFINED>' ]
   then
     MAKEOPTS=""

--- a/python/conda/libastra/meta.yaml
+++ b/python/conda/libastra/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: astra-toolbox
+  name: libastra
   version: '1.8b'
 
 source:
@@ -11,26 +11,6 @@ build:
   script_env:
     - CUDA_ROOT
     - MAKEOPTS
-
-test:
-  imports:
-    - astra
-
-requirements:
-  build:
-    - python
-    - cython >=0.13
-    - numpy
-    - scipy
-    - six
-
-  run:
-    - python
-    - numpy
-    - scipy
-    - six
-    - libastra ==1.8b
-
 
 about:
   home: http://www.astra-toolbox.com


### PR DESCRIPTION
After cd395d2af23530f9da471fd6c512e9890c08f69d, the C++ library does not depend on libpython anymore, so we can split the conda package into two parts: a C++ library part that does not depend on the specific python version used (libastra), and the python interface that does depend on it (astra-toolbox). The advantage is that we don't need to distribute multiple versions of the c++ library with CUDA dependencies (which is quite a big tarball) for each combination of python version and numpy version.

The current conda build script uses the latest master branch, and should be changed to specifically use the correct git tag when the next version of astra will be released.