### PR TITLE
Use CXX for Python compilation as well

### DIFF
--- a/build/linux/Makefile.in
+++ b/build/linux/Makefile.in
@@ -281,13 +281,13 @@ ifeq ($(python),yes)
 py: libastra.la
 	$(MKDIR) python/build
 	$(MKDIR) python/finalbuild
-	cd $(srcdir)/../../python; CPPFLAGS="${PYCPPFLAGS}" LDFLAGS="${PYLDFLAGS}" $(PYTHON) builder.py build --build-base=$(abs_top_builddir)/python/build install \
+	cd $(srcdir)/../../python; CXX="${CXX}" CC="${CXX}" CPPFLAGS="${PYCPPFLAGS}" LDFLAGS="${PYLDFLAGS}" $(PYTHON) builder.py build --build-base=$(abs_top_builddir)/python/build install \
 	--install-base=$(abs_top_builddir)/python/finalbuild --install-headers=$(abs_top_builddir)/python/finalbuild --install-purelib=$(abs_top_builddir)/python/finalbuild \
 	--install-platlib=$(abs_top_builddir)/python/finalbuild --install-scripts=$(abs_top_builddir)/python/finalbuild --install-data=$(abs_top_builddir)/python/finalbuild
 
 python-root-install: libastra.la
 	$(MKDIR) python/build
-	cd $(srcdir)/../../python; CPPFLAGS="${PYCPPFLAGS}" LDFLAGS="${PYLDFLAGS}" $(PYTHON) builder.py build --build-base=$(abs_top_builddir)/python/build install
+	cd $(srcdir)/../../python; CXX="${CXX}" CC="${CXX}" CPPFLAGS="${PYCPPFLAGS}" LDFLAGS="${PYLDFLAGS}" $(PYTHON) builder.py build --build-base=$(abs_top_builddir)/python/build install
 
 endif
 

--- a/build/linux/Makefile.in
+++ b/build/linux/Makefile.in
@@ -281,12 +281,14 @@ ifeq ($(python),yes)
 py: libastra.la
 	$(MKDIR) python/build
 	$(MKDIR) python/finalbuild
+	# Note: setting CC to CXX is intentional. Python uses CC for compilation even if input is C++.
 	cd $(srcdir)/../../python; CXX="${CXX}" CC="${CXX}" CPPFLAGS="${PYCPPFLAGS}" LDFLAGS="${PYLDFLAGS}" $(PYTHON) builder.py build --build-base=$(abs_top_builddir)/python/build install \
 	--install-base=$(abs_top_builddir)/python/finalbuild --install-headers=$(abs_top_builddir)/python/finalbuild --install-purelib=$(abs_top_builddir)/python/finalbuild \
 	--install-platlib=$(abs_top_builddir)/python/finalbuild --install-scripts=$(abs_top_builddir)/python/finalbuild --install-data=$(abs_top_builddir)/python/finalbuild
 
 python-root-install: libastra.la
 	$(MKDIR) python/build
+	# Note: setting CC to CXX is intentional. Python uses CC for compilation even if input is C++.
 	cd $(srcdir)/../../python; CXX="${CXX}" CC="${CXX}" CPPFLAGS="${PYCPPFLAGS}" LDFLAGS="${PYLDFLAGS}" $(PYTHON) builder.py build --build-base=$(abs_top_builddir)/python/build install
 
 endif

--- a/python/astra/extrautils.pyx
+++ b/python/astra/extrautils.pyx
@@ -22,6 +22,8 @@
 # along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 #
 # -----------------------------------------------------------------------
+# distutils: language = c++
+
 
 def clipCircle(img):
 	cdef int i,j


### PR DESCRIPTION
In the current master, only the C++ library will be compiled with the `CXX` variable that is set during the `configure` call, which will lead to problems when the `CXX` gcc version is incompatible with the default gcc version (see #44 for an example). This PR fixes this problem by passing the `CXX` setting to the python compilation call.