### PR TITLE
Change flatten to ravel in Python code

### DIFF
--- a/python/astra/optomo.py
+++ b/python/astra/optomo.py
@@ -125,7 +125,7 @@ class OpTomo(scipy.sparse.linalg.LinearOperator):
 
         algorithm.delete(fp_id)
         self.data_mod.delete([vid,sid])
-        return s.flatten()
+        return s.ravel()
 
     def rmatvec(self,s):
         """Implements the transpose operator.
@@ -147,7 +147,7 @@ class OpTomo(scipy.sparse.linalg.LinearOperator):
 
         algorithm.delete(bp_id)
         self.data_mod.delete([vid,sid])
-        return v.flatten()
+        return v.ravel()
 
     def __mul__(self,v):
         """Provides easy forward operator by *.

--- a/samples/python/s009_projection_matrix.py
+++ b/samples/python/s009_projection_matrix.py
@@ -46,7 +46,7 @@ W = astra.matrix.get(matrix_id)
 # Manually use this projection matrix to do a projection:
 import scipy.io
 P = scipy.io.loadmat('phantom.mat')['phantom256']
-s = W.dot(P.flatten())
+s = W.dot(P.ravel())
 s = np.reshape(s, (len(proj_geom['ProjectionAngles']),proj_geom['DetectorCount']))
 
 import pylab

--- a/samples/python/s015_fp_bp.py
+++ b/samples/python/s015_fp_bp.py
@@ -46,12 +46,12 @@ class astra_wrap(object):
     def matvec(self,v):
         sid, s = astra.create_sino(np.reshape(v,(vol_geom['GridRowCount'],vol_geom['GridColCount'])),self.proj_id)
         astra.data2d.delete(sid)
-        return s.flatten()
+        return s.ravel()
     
     def rmatvec(self,v):
         bid, b = astra.create_backprojection(np.reshape(v,(len(proj_geom['ProjectionAngles']),proj_geom['DetectorCount'],)),self.proj_id)
         astra.data2d.delete(bid)
-        return b.flatten()
+        return b.ravel()
 
 vol_geom = astra.create_vol_geom(256, 256)
 proj_geom = astra.create_proj_geom('parallel', 1.0, 384, np.linspace(0,np.pi,180,False))
@@ -65,7 +65,7 @@ proj_id = astra.create_projector('cuda',proj_geom,vol_geom)
 sinogram_id, sinogram = astra.create_sino(P, proj_id)
 
 # Reshape the sinogram into a vector
-b = sinogram.flatten()
+b = sinogram.ravel()
 
 # Call lsqr with ASTRA FP and BP
 import scipy.sparse.linalg

--- a/samples/python/s017_OpTomo.py
+++ b/samples/python/s017_OpTomo.py
@@ -50,7 +50,7 @@ pylab.figure(2)
 pylab.imshow(sinogram)
 
 # Run the lsqr linear solver
-output = scipy.sparse.linalg.lsqr(W, sinogram.flatten(), iter_lim=150)
+output = scipy.sparse.linalg.lsqr(W, sinogram.ravel(), iter_lim=150)
 rec = output[0].reshape([256, 256])
 
 pylab.figure(3)


### PR DESCRIPTION
Following the discussion in #47, this PR changes `flatten` to `ravel` in the Python code to remove unnecessary copies of data. The most important change is in `OpTomo`, where it will probably result in a significant speedup for large data. The other changes are in the samples, where it doesn't really make a difference.