### PR TITLE
Reverse output of astra.data3d.dimensions

### DIFF
--- a/python/astra/data3d_c.pyx
+++ b/python/astra/data3d_c.pyx
@@ -264,7 +264,7 @@ def store(i,data):
 
 def dimensions(i):
     cdef CFloat32Data3D * pDataObject = getObject(i)
-    return (pDataObject.getWidth(),pDataObject.getHeight(),pDataObject.getDepth())
+    return (pDataObject.getDepth(),pDataObject.getHeight(),pDataObject.getWidth())
 
 def delete(ids):
     try:


### PR DESCRIPTION
This makes the output directly usable in numpy commands like zeros, reshape.

We were not using data3d.dimensions ourselves, as far as I can tell.