### PR TITLE
Avoid defining singleton construction in header file

### DIFF
--- a/include/astra/Singleton.h
+++ b/include/astra/Singleton.h
@@ -86,14 +86,14 @@ class Singleton {
 // libastra. This situation would cause issues when .mex files are unloaded.
 
 #define DEFINE_SINGLETON(T) \
-template<> void Singleton<T >::construct() { m_singleton = new T(); } \
+template<> void Singleton<T >::construct() { assert(!m_singleton); m_singleton = new T(); } \
 template<> T* Singleton<T >::m_singleton = 0
 
 
 // This is a hack to support statements like
 // DEFINE_SINGLETON2(CTemplatedClass<C1, C2>);
 #define DEFINE_SINGLETON2(A,B) \
-template<> void Singleton<A,B >::construct() { m_singleton = new A,B(); } \
+template<> void Singleton<A,B >::construct() { assert(!m_singleton); m_singleton = new A,B(); } \
 template<> A,B* Singleton<A,B >::m_singleton = 0
 
 } // end namespace

--- a/include/astra/Singleton.h
+++ b/include/astra/Singleton.h
@@ -57,15 +57,17 @@ class Singleton {
 			m_singleton = 0;
 		}
 
+		static void construct();
+
 		// get singleton
 		static T& getSingleton() {
 			if (!m_singleton)
-				m_singleton = new T();
+				construct();
 			return *m_singleton;
 		}
 		static T* getSingletonPtr() {
 			if (!m_singleton)
-				m_singleton = new T();
+				construct();
 			return m_singleton;
 		}
 
@@ -76,11 +78,23 @@ class Singleton {
 
 };
 
-#define DEFINE_SINGLETON(T) template<> T* Singleton<T >::m_singleton = 0
+// We specifically avoid defining construct() in the header.
+// That way, the call to new is always executed by code inside libastra.
+// This avoids the situation where a singleton gets created by a copy
+// of the constructor linked into an object file outside of libastra, such
+// as a .mex file, which would then also cause the vtable to be outside of
+// libastra. This situation would cause issues when .mex files are unloaded.
+
+#define DEFINE_SINGLETON(T) \
+template<> void Singleton<T >::construct() { m_singleton = new T(); } \
+template<> T* Singleton<T >::m_singleton = 0
+
 
 // This is a hack to support statements like
 // DEFINE_SINGLETON2(CTemplatedClass<C1, C2>);
-#define DEFINE_SINGLETON2(A,B) template<> A,B* Singleton<A,B >::m_singleton = 0
+#define DEFINE_SINGLETON2(A,B) \
+template<> void Singleton<A,B >::construct() { m_singleton = new A,B(); } \
+template<> A,B* Singleton<A,B >::m_singleton = 0
 
 } // end namespace
 


### PR DESCRIPTION
That way, the call to new is always executed by code inside libastra.
This avoids the situation where a singleton gets created by a copy
of the constructor linked into an object file outside of libastra, such
as a .mex file, which would then also cause the vtable to be outside of
libastra. This situation would cause issues when .mex files are unloaded.