### PR TITLE
Add option to specify custom filter for FDK

### DIFF
--- a/cuda/3d/astra3d.cu
+++ b/cuda/3d/astra3d.cu
@@ -1311,7 +1311,7 @@ bool astraCudaFDK(float* pfVolume, const float* pfProjections,
                   const CVolumeGeometry3D* pVolGeom,
                   const CConeProjectionGeometry3D* pProjGeom,
                   bool bShortScan,
-                  int iGPUIndex, int iVoxelSuperSampling)
+                  int iGPUIndex, int iVoxelSuperSampling, const float* filter)
 {
 	SDimensions3D dims;
 
@@ -1369,7 +1369,7 @@ bool astraCudaFDK(float* pfVolume, const float* pfProjections,
 	// TODO: Offer interface for SrcZ, DetZ
 	ok &= FDK(D_volumeData, D_projData, fOriginSourceDistance,
 	          fOriginDetectorDistance, 0, 0, fDetUSize, fDetVSize,
-	          dims, pfAngles, bShortScan);
+	          dims, pfAngles, bShortScan, filter);
 
 	ok &= copyVolumeFromDevice(pfVolume, D_volumeData, dims, dims.iVolX);
 

--- a/cuda/3d/astra3d.h
+++ b/cuda/3d/astra3d.h
@@ -314,7 +314,7 @@ _AstraExport bool astraCudaFDK(float* pfVolume, const float* pfProjections,
                   const CVolumeGeometry3D* pVolGeom,
                   const CConeProjectionGeometry3D* pProjGeom,
                   bool bShortScan,
-                  int iGPUIndex, int iVoxelSuperSampling);
+                  int iGPUIndex, int iVoxelSuperSampling, const float* filter);
 
 
 }

--- a/cuda/3d/fdk.cu
+++ b/cuda/3d/fdk.cu
@@ -394,7 +394,8 @@ bool FDK(cudaPitchedPtr D_volumeData,
          cudaPitchedPtr D_projData,
          float fSrcOrigin, float fDetOrigin,
          float fSrcZ, float fDetZ, float fDetUSize, float fDetVSize,
-         const SDimensions3D& dims, const float* angles, bool bShortScan)
+         const SDimensions3D& dims, const float* angles, bool bShortScan,
+	     const float* filter)
 {
 	bool ok;
 	// Generate filter
@@ -412,7 +413,14 @@ bool FDK(cudaPitchedPtr D_volumeData,
 	cufftComplex *pHostFilter = new cufftComplex[dims.iProjAngles * iHalfFFTSize];
 	memset(pHostFilter, 0, sizeof(cufftComplex) * dims.iProjAngles * iHalfFFTSize);
 
-	genFilter(FILTER_RAMLAK, 1.0f, dims.iProjAngles, pHostFilter, iPaddedDetCount, iHalfFFTSize);
+	if (filter==NULL){
+		genFilter(FILTER_RAMLAK, 1.0f, dims.iProjAngles, pHostFilter, iPaddedDetCount, iHalfFFTSize);
+	}else{
+		for(int i=0;i<dims.iProjAngles * iHalfFFTSize;i++){
+			pHostFilter[i].x = filter[i];
+			pHostFilter[i].y = 0;
+		}
+	}
 
 
 	allocateComplexOnDevice(dims.iProjAngles, iHalfFFTSize, &D_filter);

--- a/cuda/3d/fdk.h
+++ b/cuda/3d/fdk.h
@@ -43,7 +43,8 @@ bool FDK(cudaPitchedPtr D_volumeData,
          cudaPitchedPtr D_projData,
          float fSrcOrigin, float fDetOrigin,
          float fSrcZ, float fDetZ, float fDetUSize, float fDetVSize,
-         const SDimensions3D& dims, const float* angles, bool bShortScan);
+         const SDimensions3D& dims, const float* angles, bool bShortScan,
+         const float* filter);
 
 
 }

--- a/include/astra/CudaFDKAlgorithm3D.h
+++ b/include/astra/CudaFDKAlgorithm3D.h
@@ -151,6 +151,7 @@ protected:
 
 	int m_iGPUIndex;
 	int m_iVoxelSuperSampling;
+	int m_iFilterDataId;
 	bool m_bShortScan;
 
 	void initializeFromProjector();


### PR DESCRIPTION
This PR adds an option to specify a custom filter for FDK using a 2D geometry, like:

``` python
pg = astra.create_proj_geom('cone', 1, 1, 128, 128, np.linspace(0,2*np.pi,64,False), 5*128, 0)
vg = astra.create_vol_geom(128,128,128)
pid = astra.create_projector('cuda3d',pg,vg)
w = astra.OpTomo(pid)

# Standard FDK
r = w.reconstruct('FDK_CUDA', s)

# Custom filter
pgf = astra.create_proj_geom('parallel',1.0,129,np.linspace(0,2*np.pi,64,False))
fid = astra.data2d.create('-sino', pgf, np.ones((64,129)))
r = w.reconstruct('FDK_CUDA',s,extraOptions={'FilterSinogramId':fid})
```

This will make it possible to try advanced filter-based method with FDK.
