### PR TITLE
Minor string parsing changes

### DIFF
--- a/include/astra/Utilities.h
+++ b/include/astra/Utilities.h
@@ -85,6 +85,9 @@ _AstraExport std::string doubleToString(double f);
 template<typename T>
 _AstraExport std::string toString(T f);
 
+
+_AstraExport void splitString(std::vector<std::string> &items, const std::string& s, const char *delim);
+
 }
 
 

--- a/matlab/mex/mexHelpFunctions.cpp
+++ b/matlab/mex/mexHelpFunctions.cpp
@@ -33,11 +33,6 @@ $Id$
 #include "mexHelpFunctions.h"
 #include "astra/Utilities.h"
 
-#include <algorithm>
-#include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/classification.hpp>
-
 using namespace std;
 using namespace astra;
 
@@ -362,8 +357,8 @@ mxArray* stringToMxArray(std::string input)
 		// split rows
 		std::vector<std::string> row_strings;
 		std::vector<std::string> col_strings;
-		boost::split(row_strings, input, boost::is_any_of(";"));
-		boost::split(col_strings, row_strings[0], boost::is_any_of(","));
+		StringUtil::splitString(row_strings, input, ";");
+		StringUtil::splitString(col_strings, row_strings[0], ",");
 
 		// get dimensions
 		int rows = row_strings.size();
@@ -375,7 +370,7 @@ mxArray* stringToMxArray(std::string input)
 
 		// loop elements
 		for (unsigned int row = 0; row < rows; row++) {
-			boost::split(col_strings, row_strings[row], boost::is_any_of(","));
+			StringUtil::splitString(col_strings, row_strings[row], ",");
 			// check size
 			for (unsigned int col = 0; col < col_strings.size(); col++) {
 				out[col*rows + row] = StringUtil::stringToFloat(col_strings[col]);
@@ -389,7 +384,7 @@ mxArray* stringToMxArray(std::string input)
 
 		// split
 		std::vector<std::string> items;
-		boost::split(items, input, boost::is_any_of(","));
+		StringUtil::splitString(items, input, ",");
 
 		// init matrix
 		mxArray* pVector = mxCreateDoubleMatrix(1, items.size(), mxREAL);

--- a/matlab/mex/mexHelpFunctions.cpp
+++ b/matlab/mex/mexHelpFunctions.cpp
@@ -402,16 +402,13 @@ mxArray* stringToMxArray(std::string input)
 		return pVector;
 	}
 	
-	// number
-	char* end;
-	double content = ::strtod(input.c_str(), &end);
-	bool isnumber = !*end;
-	if (isnumber) {
-		return mxCreateDoubleScalar(content);
+	try {
+		// number
+		return mxCreateDoubleScalar(StringUtil::stringToDouble(input));
+	} catch (const StringUtil::bad_cast &) {
+		// string
+		return mxCreateString(input.c_str());
 	}
-	
-	// string
-	return mxCreateString(input.c_str());
 }
 //-----------------------------------------------------------------------------------------
 // turn a c++ map into a matlab struct

--- a/python/astra/src/PythonPluginAlgorithm.cpp
+++ b/python/astra/src/PythonPluginAlgorithm.cpp
@@ -31,8 +31,6 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/Logging.h"
 #include "astra/Utilities.h"
-#include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/split.hpp>
 #include <iostream>
 #include <fstream>
 #include <string>
@@ -146,7 +144,7 @@ CPythonPluginAlgorithmFactory::~CPythonPluginAlgorithmFactory(){
 
 PyObject * getClassFromString(std::string str){
     std::vector<std::string> items;
-    boost::split(items, str, boost::is_any_of("."));
+    StringUtil::splitString(items, str, ".");
     PyObject *pyclass = PyImport_ImportModule(items[0].c_str());
     if(pyclass==NULL){
         logPythonError();
@@ -303,10 +301,10 @@ PyObject * pyStringFromString(std::string str){
 PyObject* stringToPythonValue(std::string str){
     if(str.find(";")!=std::string::npos){
         std::vector<std::string> rows, row;
-        boost::split(rows, str, boost::is_any_of(";"));
+        StringUtil::splitString(rows, str, ";");
         PyObject *mat = PyList_New(rows.size());
         for(unsigned int i=0; i<rows.size(); i++){
-            boost::split(row, rows[i], boost::is_any_of(","));
+            StringUtil::splitString(row, rows[i], ",");
             PyObject *rowlist = PyList_New(row.size());
             for(unsigned int j=0;j<row.size();j++){
                 PyList_SetItem(rowlist, j, PyFloat_FromDouble(StringUtil::stringToDouble(row[j])));
@@ -317,7 +315,7 @@ PyObject* stringToPythonValue(std::string str){
     }
     if(str.find(",")!=std::string::npos){
         std::vector<std::string> vec;
-        boost::split(vec, str, boost::is_any_of(","));
+        StringUtil::splitString(vec, str, ",");
         PyObject *veclist = PyList_New(vec.size());
         for(unsigned int i=0;i<vec.size();i++){
             PyList_SetItem(veclist, i, PyFloat_FromDouble(StringUtil::stringToDouble(vec[i])));

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -28,10 +28,6 @@ $Id$
 
 #include "astra/Utilities.h"
 
-#include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/classification.hpp>
-
 #include <sstream>
 #include <locale>
 #include <iomanip>
@@ -84,18 +80,16 @@ std::vector<double> stringToDoubleVector(const std::string &s)
 template<typename T>
 std::vector<T> stringToVector(const std::string& s)
 {
-	// split
-	std::vector<std::string> items;
-	boost::split(items, s, boost::is_any_of(",;"));
-
-	// init list
 	std::vector<T> out;
-	out.resize(items.size());
+	size_t current = 0;
+	size_t next;
+	do {
+		next = s.find_first_of(",;", current);
+		std::string t = s.substr(current, next - current);
+		out.push_back(stringTo<T>(t));
+		current = next + 1;
+	} while (next != std::string::npos);
 
-	// loop elements
-	for (unsigned int i = 0; i < items.size(); i++) {
-		out[i] = stringTo<T>(items[i]);
-	}
 	return out;
 }
 
@@ -120,6 +114,18 @@ std::string doubleToString(double f)
 template<> std::string toString(float f) { return floatToString(f); }
 template<> std::string toString(double f) { return doubleToString(f); }
 
+void splitString(std::vector<std::string> &items, const std::string& s,
+                 const char *delim)
+{
+	items.clear();
+	size_t current = 0;
+	size_t next;
+	do {
+		next = s.find_first_of(",;", current);
+		items.push_back(s.substr(current, next - current));
+		current = next + 1;
+	} while (next != std::string::npos);
+}
 
 }
 


### PR DESCRIPTION
This changes a leftover use of `strtod` to `StringUtil::stringToDouble`, and replaces use of `boost::split` by a new `StringUtil::splitString` (`boost::split` was causing inexplicable undefined behaviour on some setups.)