### PR TITLE
Add experimental support for Octave

### DIFF
--- a/build/linux/Makefile.in
+++ b/build/linux/Makefile.in
@@ -5,6 +5,7 @@ boostutf=@HAVEBOOSTUTF@
 
 
 MATLAB_ROOT=@MATLAB_ROOT@
+octave=@HAVEOCTAVE@
 
 TARGETS=libastra.la
 
@@ -14,6 +15,10 @@ endif
 
 ifeq ($(python),yes)
 TARGETS+=py
+endif
+
+ifeq ($(octave),yes)
+TARGETS+=oct
 endif
 
 all: $(TARGETS)
@@ -44,6 +49,16 @@ NVCCFLAGS += @NVCCFLAGS_EXTRA@ @CPPFLAGS_CUDA@ -I$(srcdir)/../.. -I$(srcdir)/../
 LDFLAGS   += @LDFLAGS_CUDA@
 LIBS      += -lcudart -lcufft
 NVCC       = @NVCC@
+endif
+
+ifeq ($(octave),yes)
+OCTLDFLAGS:=$(LDFLAGS)
+CPPFLAGS += @OCTAVE_CPPFLAGS@
+ifeq ($(cuda),yes)
+OCTFLAGS=-DASTRA_CUDA
+else
+OCTFLAGS=
+endif
 endif
 
 ifeq ($(matlab),yes)
@@ -259,6 +274,20 @@ ifeq ($(python),yes)
 MATLAB_MEX+=matlab/mex/astra_mex_plugin_c.$(MEXSUFFIX)
 endif
 
+OCTAVE_CXX_OBJECTS=\
+	matlab/mex/octave_support.o
+
+OCTAVE_MEX=\
+	matlab/mex/astra_mex_algorithm_c.mex \
+	matlab/mex/astra_mex_data2d_c.mex \
+	matlab/mex/astra_mex_c.mex \
+	matlab/mex/astra_mex_matrix_c.mex \
+	matlab/mex/astra_mex_projector_c.mex \
+	matlab/mex/astra_mex_projector3d_c.mex \
+	matlab/mex/astra_mex_log_c.mex \
+	matlab/mex/astra_mex_data3d_c.mex \
+	matlab/mex/astra_mex_direct_c.mex
+
 OBJECT_DIRS = src/ tests/ cuda/2d/ cuda/3d/ matlab/mex/ ./
 DEPDIRS = $(addsuffix $(DEPDIR),$(OBJECT_DIRS))
 -include $(wildcard $(addsuffix /*.d,$(DEPDIRS)))
@@ -293,6 +322,13 @@ python-root-install: libastra.la
 
 endif
 
+
+ifeq ($(octave),yes)
+oct: $(OCTAVE_MEX)
+
+%.mex: %.o $(MATLAB_CXX_OBJECTS) $(OCTAVE_CXX_OBJECTS) libastra.la
+	mkoctfile --mex $(OCTFLAGS) $(OCTLDFLAGS) $(LIBS) -L.libs -lastra --output $* $*.o $(MATLAB_CXX_OBJECTS) $(OCTAVE_CXX_OBJECTS)
+endif
 
 libastra.la: $(ALL_OBJECTS)
 	./libtool --mode=link --tag=CXX $(LD) -rpath $(LIBDIR) -o $@ $(LDFLAGS) $(LIBS) $+
@@ -374,7 +410,7 @@ distclean: clean
 	rm -rf $(srcdir)/autom4te.cache
 	rm -f $(srcdir)/configure Makefile
 
-install: install-libraries install-matlab install-python
+install: install-libraries install-matlab install-python install-octave
 
 install-libraries: libastra.la
 	$(INSTALL_SH) -m 755 -d @libdir@
@@ -411,6 +447,19 @@ install-python: py
 # TODO: docs
 else
 install-python:
+endif
+
+ifeq ($(octave),yes)
+# TODO: This install location doesn't work well for /usr or /usr/local
+install-octave: $(OCTAVE_MEX)
+	$(INSTALL_SH) -m 755 -d @prefix@/octave
+	$(INSTALL_SH) -m 755 -d @prefix@/octave/mex
+	$(INSTALL_SH) -m 755 -d @prefix@/octave/tools
+	$(INSTALL_SH) -m 644 $(OCTAVE_MEX) @prefix@/octave/mex
+	$(INSTALL_SH) -m 644 $(srcdir)/../../matlab/tools/*.m @prefix@/octave/tools
+# TODO: docs
+else
+install-octave:
 endif
 
 

--- a/build/linux/configure.ac
+++ b/build/linux/configure.ac
@@ -175,6 +175,28 @@ fi
 
 AC_SUBST(HAVEMATLAB)
 
+# octave
+
+AC_ARG_ENABLE(octave, [[  --disable-octave      disable Octave support]])
+if test x"$enable_octave" != xno; then
+  AC_PATH_PROG([HAVEOCTAVE], [octave-config], [no], [$PATH])
+  AC_MSG_CHECKING([for octave])
+  if test x"HAVEOCTAVE" != xno -a $HAVEMATLAB = yes; then
+    HAVEOCTAVE=no
+    AC_MSG_RESULT([no (since Matlab support is enabled)])
+  else
+    if test x"$HAVEOCTAVE" != xno; then
+      OCTAVE_CPPFLAGS="-I`octave-config -p OCTINCLUDEDIR`"
+      AC_SUBST(OCTAVE_CPPFLAGS)
+      HAVEOCTAVE=yes
+    fi
+    AC_MSG_RESULT($HAVEOCTAVE)
+  fi
+else
+  HAVEOCTAVE=no
+fi
+AC_SUBST(HAVEOCTAVE)
+
 # python
 
 AC_ARG_WITH(python, [[  --with-python=path      path of Python binary (optional)]],,)
@@ -271,6 +293,7 @@ echo
 echo "Summary of ASTRA Toolbox build options:"
 echo "  CUDA   : $HAVECUDA"
 echo "  Matlab : $HAVEMATLAB"
+echo "  Octave : $HAVEOCTAVE"
 echo "  Python : $HAVEPYTHON"
 echo
 echo "  prefix : $prefix"

--- a/matlab/mex/mexDataManagerHelpFunctions.cpp
+++ b/matlab/mex/mexDataManagerHelpFunctions.cpp
@@ -79,7 +79,7 @@ public:
 		m_pLink = mxCreateSharedDataCopy(_pArray);
 		//fprintf(stderr, "SharedDataCopy:\narray: %p\tdata: %p\n", (void*)m_pLink, (void*)mxGetData(m_pLink));
 		mexMakeArrayPersistent(m_pLink);
-		m_fPtr = (float *)mxGetData(m_pLink);
+		m_fPtr = (float *)mxGetData(_pArray);
 		m_fPtr += iOffset;
 	}
 	virtual ~CFloat32CustomMemoryMatlab3D() {

--- a/matlab/mex/mexDataManagerHelpFunctions.cpp
+++ b/matlab/mex/mexDataManagerHelpFunctions.cpp
@@ -42,10 +42,10 @@ $Id$
 #ifdef USE_MATLAB_UNDOCUMENTED
 extern "C" {
 mxArray *mxCreateSharedDataCopy(const mxArray *pr);
-bool mxUnshareArray(const mxArray *pr, const bool noDeepCopy);
-mxArray *mxUnreference(const mxArray *pr);
+bool mxUnshareArray(mxArray *pr, bool noDeepCopy);
+mxArray *mxUnreference(mxArray *pr);
 #if 0
-// Unsupported in Matlab R2014b
+// Unsupported in Matlab R2014b and later
 bool mxIsSharedArray(const mxArray *pr);
 #endif
 }
@@ -66,12 +66,12 @@ public:
 		// First unshare the input array, so that we may modify it.
 		if (bUnshare) {
 #if 0
-			// Unsupported in Matlab R2014b
+			// Unsupported in Matlab R2014b and later
 			if (mxIsSharedArray(_pArray)) {
 				fprintf(stderr, "Performance note: unsharing shared array in link\n");
 			}
 #endif
-			mxUnshareArray(_pArray, false);
+			mxUnshareArray(const_cast<mxArray*>(_pArray), false);
 			//fprintf(stderr, "Unshared:\narray: %p\tdata: %p\n", (void*)_pArray, (void*)mxGetData(_pArray));
 		}
 		// Then create a (persistent) copy so the data won't be deleted

--- a/matlab/mex/octave_support.cpp
+++ b/matlab/mex/octave_support.cpp
@@ -1,0 +1,44 @@
+/*
+-----------------------------------------------------------------------
+Copyright: 2010-2016, iMinds-Vision Lab, University of Antwerp
+           2014-2016, CWI, Amsterdam
+
+Contact: astra@uantwerpen.be
+Website: http://sf.net/projects/astra-toolbox
+
+This file is part of the ASTRA Toolbox.
+
+
+The ASTRA Toolbox is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The ASTRA Toolbox is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
+
+-----------------------------------------------------------------------
+*/
+
+#include <oct.h>
+
+extern "C" {
+
+bool utIsInterruptPending() {
+	return octave_signal_caught;
+}
+
+mxArray *mxCreateSharedDataCopy(const mxArray *) {
+	return 0;
+}
+
+bool mxUnshareArray(mxArray *, bool) {
+	return false;
+}
+
+}


### PR DESCRIPTION
This needs testing, especially the `data3d('link')` support, both in Octave and in Matlab.

Based on initial patch by @kalvdans at #13.