### PR TITLE
Overhaul package installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ install:
   - conda info -a
   - cd build/linux
   - ./autogen.sh
-  - if [ $CUDA == yes ]; then ./configure --prefix=$HOME/astra --with-python --with-cuda; else ./configure --prefix=$HOME/astra --with-python --without-cuda; fi
+  - if [ $CUDA == yes ]; then ./configure --prefix=$HOME/astra --with-python --with-cuda --with-install-type=module; else ./configure --prefix=$HOME/astra --with-python --without-cuda --with-install-type=module; fi
   - make -j 4
   - make install
 
 script:
-  - LD_LIBRARY_PATH=$HOME/astra/lib/:$LD_LIBRARY_PATH PYTHONPATH=$HOME/astra/python/:$PYTHONPATH python -c "import astra"
+  - python -c "import astra"

--- a/README.md
+++ b/README.md
@@ -19,33 +19,55 @@ See the MATLAB and Python code samples in samples/ and on http://sf.net/projects
 
 ### Windows, binary
 
-Add the mex and tools subdirectories to your MATLAB path and the Python module to your Python path..
+Add the mex and tools subdirectories to your MATLAB path, or copy
+the Python astra module to your Python site-packages directory.
 
 ### Linux, from source
 
-Requirements: g++, boost, CUDA (driver+toolkit), Matlab and/or Python (2.7 or 3.x)
+#### For Matlab
+
+Requirements: g++, boost, CUDA (5.5 or higher), Matlab (R2012a or higher)
 
 ```
 cd build/linux
 ./autogen.sh   # when building a git version
 ./configure --with-cuda=/usr/local/cuda \
             --with-matlab=/usr/local/MATLAB/R2012a \
-            --with-python \
-            --prefix=/usr/local/astra
+            --prefix=$HOME/astra \
+            --with-install-type=module
 make
 make install
 ```
-Add /usr/local/astra/lib to your LD_LIBRARY_PATH.
-Add /usr/local/astra/matlab and its subdirectories (tools, mex)
-  to your matlab path.
-Add /usr/local/astra/python to your PYTHONPATH.
+Add $HOME/astra/matlab and its subdirectories (tools, mex) to your matlab path.
+
+If you want to build the Octave interface instead of the Matlab interface,
+specify --enable-octave instead of --with-matlab=... . The Octave files
+will be installed into $HOME/astra/octave .
 
 
 NB: Each matlab version only supports a specific range of g++ versions.
 Despite this, if you have a newer g++ and if you get errors related to missing
 GLIBCXX_3.4.xx symbols, it is often possible to work around this requirement
 by deleting the version of libstdc++ supplied by matlab in
-MATLAB_PATH/bin/glnx86 or MATLAB_PATH/bin/glnxa64 (at your own risk).
+MATLAB_PATH/bin/glnx86 or MATLAB_PATH/bin/glnxa64 (at your own risk),
+or setting LD_PRELOAD=/usr/lib64/libstdc++.so.6 (or similar) when starting
+matlab.
+
+#### For Python
+
+Requirements: g++, boost, CUDA (5.5 or higher), Python (2.7 or 3.x)
+
+```
+cd build/linux
+./autogen.sh   # when building a git version
+./configure --with-cuda=/usr/local/cuda \
+            --with-python \
+            --with-install-type=module
+make
+make install
+```
+
+This will install Astra into your current Python environment.
 
 
 ### Windows, from source using Visual Studio 2008

--- a/README.txt
+++ b/README.txt
@@ -50,27 +50,51 @@ to your Python path.
 Linux, from source:
 --------------------
 
-Requirements: g++, boost, CUDA (driver+toolkit), Matlab and/or Python (2.7 or 3.x)
+For Matlab:
+
+Requirements: g++, boost, CUDA (5.5 or higher), Matlab (R2012a or higher)
 
 cd build/linux
 ./autogen.sh   # when building a git version
 ./configure --with-cuda=/usr/local/cuda \
             --with-matlab=/usr/local/MATLAB/R2012a \
-            --with-python \
-            --prefix=/usr/local/astra
+            --prefix=$HOME/astra \
+            --with-install-type=module
 make
 make install
-Add /usr/local/astra/lib to your LD_LIBRARY_PATH.
-Add /usr/local/astra/matlab and its subdirectories (tools, mex)
-  to your matlab path.
-Add /usr/local/astra/python to your PYTHONPATH.
+
+Add $HOME/astra/matlab and its subdirectories (tools, mex) to your matlab path.
+
+If you want to build the Octave interface instead of the Matlab interface,
+specify --enable-octave instead of --with-matlab=... . The Octave files
+will be installed into $HOME/astra/octave .
 
 
 NB: Each matlab version only supports a specific range of g++ versions.
 Despite this, if you have a newer g++ and if you get errors related to missing
 GLIBCXX_3.4.xx symbols, it is often possible to work around this requirement
 by deleting the version of libstdc++ supplied by matlab in
-MATLAB_PATH/bin/glnx86 or MATLAB_PATH/bin/glnxa64 (at your own risk).
+MATLAB_PATH/bin/glnx86 or MATLAB_PATH/bin/glnxa64 (at your own risk),
+or setting LD_PRELOAD=/usr/lib64/libstdc++.so.6 (or similar) when starting
+matlab.
+
+
+For Python:
+
+Requirements: g++, boost, CUDA (5.5 or higher), Python (2.7 or 3.x)
+
+cd build/linux
+./autogen.sh   # when building a git version
+./configure --with-cuda=/usr/local/cuda \
+            --with-python \
+            --with-install-type=module
+make
+make install
+
+This will install Astra into your current Python environment.
+
+
+
 
 
 Windows, from source using Visual Studio 2008:

--- a/build/linux/Makefile.in
+++ b/build/linux/Makefile.in
@@ -1,11 +1,18 @@
+install_type=@INSTALL_TYPE@
+
 cuda=@HAVECUDA@
 matlab=@HAVEMATLAB@
 python=@HAVEPYTHON@
 boostutf=@HAVEBOOSTUTF@
 
-
 MATLAB_ROOT=@MATLAB_ROOT@
 octave=@HAVEOCTAVE@
+
+MKDIR=mkdir -p
+CXX=@CXX@
+LD=@CXX@
+SHELL=@SHELL@
+INSTALL_SH=$(SHELL) $(srcdir)/install-sh
 
 TARGETS=libastra.la
 
@@ -25,6 +32,7 @@ all: $(TARGETS)
 
 prefix=@prefix@
 exec_prefix=@exec_prefix@
+datarootdir=@datarootdir@
 
 srcdir=@srcdir@
 abs_top_builddir=@abs_top_builddir@
@@ -43,6 +51,8 @@ LDFLAGS+=-g
 
 CPPFLAGS+=@CPPFLAGS_OS@
 
+BOOSTUTF_LIBS=@LIBS_BOOSTUTF@
+
 ifeq ($(cuda),yes)
 CPPFLAGS  += @CPPFLAGS_CUDA@ -DASTRA_CUDA
 NVCCFLAGS += @NVCCFLAGS_EXTRA@ @CPPFLAGS_CUDA@ -I$(srcdir)/../.. -I$(srcdir)/../../include -DASTRA_CUDA
@@ -51,58 +61,38 @@ LIBS      += -lcudart -lcufft
 NVCC       = @NVCC@
 endif
 
-ifeq ($(octave),yes)
-OCTLDFLAGS:=$(LDFLAGS)
-CPPFLAGS += @OCTAVE_CPPFLAGS@
-ifeq ($(cuda),yes)
-OCTFLAGS=-DASTRA_CUDA
-else
-OCTFLAGS=
-endif
-endif
-
 ifeq ($(matlab),yes)
+# TODO: Do we also want -fopenmp for octave?
 CPPFLAGS+=-I$(MATLAB_ROOT)/extern/include -DMATLAB_MEX_FILE
 CXXFLAGS+=-fopenmp
 LDFLAGS+=-fopenmp
 endif
 
+# MODLDFLAGS are the base LDFLAGS for matlab, octave, python modules
+MODLDFLAGS=$(LDFLAGS) -L$(abs_top_builddir)/.libs
+ifeq ($(install_type),module)
+MODLDFLAGS+=-Wl,-rpath,'\$$ORIGIN'
+endif
+
 ifeq ($(python),yes)
 PYTHON      = @PYTHON@
-PYLIBDIR = $(shell $(PYTHON) -c 'from distutils.sysconfig import get_config_var; import six; six.print_(get_config_var("LIBDIR"))')
-PYINCDIR = $(shell $(PYTHON) -c 'from distutils.sysconfig import get_python_inc; import six; six.print_(get_python_inc())')
+PYLIBDIR := $(shell $(PYTHON) -c 'from distutils.sysconfig import get_config_var; import six; six.print_(get_config_var("LIBDIR"))')
+PYINCDIR := $(shell $(PYTHON) -c 'from distutils.sysconfig import get_python_inc; import six; six.print_(get_python_inc())')
 PYLIBVER = `basename $(PYINCDIR)`
 CPPFLAGS += -DASTRA_PYTHON -I$(PYINCDIR)
 PYCPPFLAGS  := $(CPPFLAGS)
 PYCPPFLAGS  += -I../include
-PYLDFLAGS = $(LDFLAGS)
-PYLDFLAGS   += -L$(abs_top_builddir)/.libs
+PYLDFLAGS = $(MODLDFLAGS)
 endif
 
 # This is below where PYCPPFLAGS copies CPPFLAGS.  The python code is built
 # from a different directory, so these relative includes would be wrong.
 CPPFLAGS+=-I$(srcdir)/../.. -I$(srcdir)/../../include -I$(srcdir)/../../lib/include
 
-BOOST_CPPFLAGS=
-BOOST_LDFLAGS=
-
-BOOSTUTF_LIBS=@LIBS_BOOSTUTF@
-
-
-CPPFLAGS+=$(BOOST_CPPFLAGS)
-LDFLAGS+=$(BOOST_LDFLAGS)
-
-
-MKDIR=mkdir -p
-CXX=@CXX@
-LD=@CXX@
-SHELL=@SHELL@
-INSTALL_SH=$(SHELL) $(srcdir)/install-sh
-
 ifeq ($(matlab),yes)
 MEXFLAGS  = -cxx
-MEXLDFLAGS='$$LDFLAGS $(LDFLAGS)'
-MEXLIBS   = -L.libs -lut
+MEXLDFLAGS=\$$LDFLAGS $(MODLDFLAGS)
+MEXLIBS   = -lut
 MEXSUFFIX = @MEXSUFFIX@
 MEX       = @MEX@
 
@@ -111,13 +101,23 @@ MEXFLAGS += -DASTRA_CUDA
 endif
 
 ifeq ($(python),yes)
-MEXPYLDFLAGS='$$LDFLAGS $(LDFLAGS) -L$(PYLIBDIR)'
+# TODO: Why PYLIBDIR?
+MEXPYLDFLAGS=\$$LDFLAGS $(MODLDFLAGS) -L$(PYLIBDIR)
 MEXPYLIBS=$(MEXLIBS) -l$(PYLIBVER)
 endif
 
 endif
 
-LIBDIR=/usr/local/lib
+
+ifeq ($(octave),yes)
+OCTLDFLAGS:=$(MODLDFLAGS)
+CPPFLAGS += @OCTAVE_CPPFLAGS@
+ifeq ($(cuda),yes)
+OCTFLAGS=-DASTRA_CUDA
+else
+OCTFLAGS=
+endif
+endif
 
 DEPDIR=.deps
 
@@ -293,28 +293,28 @@ DEPDIRS = $(addsuffix $(DEPDIR),$(OBJECT_DIRS))
 -include $(wildcard $(addsuffix /*.d,$(DEPDIRS)))
 LIBDIRS = $(addsuffix .libs,./ src/ cuda/2d/ cuda/3d/)
 
+SONAME=$(shell . ${abs_top_builddir}/libastra.la; echo $$dlname)
 
 ifeq ($(matlab),yes)
 mex: $(MATLAB_MEX)
 
 %.$(MEXSUFFIX): %.o $(MATLAB_CXX_OBJECTS) libastra.la
-	$(MEX) LDFLAGS=$(MEXLDFLAGS) $(MEXFLAGS) $(LIBS) $(MEXLIBS) -lastra -output $* $*.o $(MATLAB_CXX_OBJECTS)
+	$(MEX) LDFLAGS="$(MEXLDFLAGS)" $(MEXFLAGS) $(LIBS) $(MEXLIBS) -lastra -output $* $*.o $(MATLAB_CXX_OBJECTS)
 
 ifeq ($(python),yes)
 matlab/mex/astra_mex_plugin_c.$(MEXSUFFIX): matlab/mex/astra_mex_plugin_c.o $(MATLAB_CXX_OBJECTS) libastra.la
-	$(MEX) LDFLAGS=$(MEXPYLDFLAGS) $(MEXFLAGS) $(LIBS) $(MEXPYLIBS) -lastra -output matlab/mex/astra_mex_plugin_c $< $(MATLAB_CXX_OBJECTS)
+	$(MEX) LDFLAGS="$(MEXPYLDFLAGS)" $(MEXFLAGS) $(LIBS) $(MEXPYLIBS) -lastra -output matlab/mex/astra_mex_plugin_c $< $(MATLAB_CXX_OBJECTS)
 endif
 endif
 
 ifeq ($(python),yes)
 py: libastra.la
 	$(MKDIR) python/build
-	# Note: setting CC to CXX is intentional. Python uses CC for compilation even if input is C++.
-	cd $(srcdir)/../../python; CXX="${CXX}" CC="${CXX}" CPPFLAGS="${PYCPPFLAGS}" LDFLAGS="${PYLDFLAGS}" $(PYTHON) builder.py build --build-base=$(abs_top_builddir)/python/build
-
-python-root-install: py
-	# Note: setting CC to CXX is intentional. Python uses CC for compilation even if input is C++.
-	cd $(srcdir)/../../python; CXX="${CXX}" CC="${CXX}" CPPFLAGS="${PYCPPFLAGS}" LDFLAGS="${PYLDFLAGS}" $(PYTHON) builder.py build --build-base=$(abs_top_builddir)/python/build install
+# TODO: Avoid writing into source dir
+	ln -s $(abs_top_builddir)/.libs/$(SONAME) $(srcdir)/../../python/astra
+# Note: setting CC to CXX is intentional. Python uses CC for compilation even if input is C++.
+	cd $(srcdir)/../../python; ASTRA_INSTALL_LIBRARY_AS_DATA=$(PYPKGDATA) CXX="${CXX}" CC="${CXX}" CPPFLAGS="${PYCPPFLAGS}" LDFLAGS='${PYLDFLAGS}' $(PYTHON) builder.py build --build-base=$(abs_top_builddir)/python/build
+	rm $(srcdir)/../../python/astra/$(SONAME)
 
 endif
 
@@ -327,7 +327,7 @@ oct: $(OCTAVE_MEX)
 endif
 
 libastra.la: $(ALL_OBJECTS)
-	./libtool --mode=link --tag=CXX $(LD) -rpath $(LIBDIR) -o $@ $(LDFLAGS) $(LIBS) $+
+	./libtool --mode=link --tag=CXX $(LD) -rpath @libdir@ -o $@ $(LDFLAGS) $(LIBS) $+
 
 %.o: %.cpp
 	$(MKDIR) $(*D)/$(DEPDIR)
@@ -406,32 +406,64 @@ distclean: clean
 	rm -rf $(srcdir)/autom4te.cache
 	rm -f $(srcdir)/configure Makefile
 
-install: install-libraries install-matlab install-python install-octave
-
 install-libraries: libastra.la
 	$(INSTALL_SH) -m 755 -d @libdir@
 	./libtool --mode=install $(INSTALL_SH) -m 644 libastra.la @libdir@
 	./libtool --mode=finish @libdir@
 
-ifeq ($(matlab),yes)
-# TODO: This install location doesn't work well for /usr or /usr/local
-install-matlab: $(MATLAB_MEX)
-	$(INSTALL_SH) -m 755 -d @prefix@/matlab
-	$(INSTALL_SH) -m 755 -d @prefix@/matlab/mex
-	$(INSTALL_SH) -m 755 -d @prefix@/matlab/tools
-	$(INSTALL_SH) -m 644 $(MATLAB_MEX) @prefix@/matlab/mex
-	$(INSTALL_SH) -m 644 $(srcdir)/../../matlab/tools/*.m @prefix@/matlab/tools
-# TODO: docs
-else
-install-matlab:
+
+# ------------------------
+# INSTALLATION
+# ------------------------
+
+ifeq ($(install_type),prefix)
+# libraries into @libdir@, python into site-packages, mex into @datadir@
+install: install-libraries install-matlab python-root-install install-octave
+
+PYPKGDATA=
+MATLABBASE=@datadir@/astra/matlab
+OCTAVEBASE=@datadir@/astra/octave
 endif
+
+ifeq ($(install_type),dir)
+# everything into @prefix@
+install: install-libraries install-matlab install-python install-octave
+
+PYPKGDATA=
+MATLABBASE=@prefix@/matlab
+OCTAVEBASE=@prefix@/octave
+PYTHONBASE=@prefix@/python
+endif
+
+ifeq ($(install_type),module)
+# python into site-packages, mex into @datadir@
+# library copied into python/mex directories
+# modules built with rpath=$ORIGIN
+install: install-matlab python-root-install install-octave
+
+PYPKGDATA=$(SONAME)
+MATLABBASE=@prefix@/matlab
+OCTAVEBASE=@prefix@/octave
+
+install-matlab-so: libastra.la
+	$(INSTALL_SH) -m 755 -d $(MATLABBASE)/mex
+	$(INSTALL_SH) -m 644 $(abs_top_builddir)/.libs/$(SONAME) $(MATLABBASE)/mex
+install-octave-so: libastra.la
+	$(INSTALL_SH) -m 755 -d $(OCTAVEBASE)/mex
+	$(INSTALL_SH) -m 644 $(abs_top_builddir)/.libs/$(SONAME) $(OCTAVEBASE)/mex
+else
+install-matlab-so:
+install-octave-so:
+endif
+
+
 
 ifeq ($(python),yes)
 # TODO: This install location doesn't work well for /usr or /usr/local
 install-python: py
 	$(MKDIR) python/finalbuild
 	# Note: setting CC to CXX is intentional. Python uses CC for compilation even if input is C++.
-	cd $(srcdir)/../../python; CXX="${CXX}" CC="${CXX}" CPPFLAGS="${PYCPPFLAGS}" LDFLAGS="${PYLDFLAGS}" $(PYTHON) builder.py build --build-base=$(abs_top_builddir)/python/build install \
+	cd $(srcdir)/../../python; ASTRA_INSTALL_LIBRARY_AS_DATA=$(PYPKGDATA) CXX="${CXX}" CC="${CXX}" CPPFLAGS="${PYCPPFLAGS}" LDFLAGS="${PYLDFLAGS}" $(PYTHON) builder.py build --build-base=$(abs_top_builddir)/python/build install \
 	--install-base=$(abs_top_builddir)/python/finalbuild --install-headers=$(abs_top_builddir)/python/finalbuild --install-purelib=$(abs_top_builddir)/python/finalbuild \
 	--install-platlib=$(abs_top_builddir)/python/finalbuild --install-scripts=$(abs_top_builddir)/python/finalbuild --install-data=$(abs_top_builddir)/python/finalbuild
 	$(INSTALL_SH) -m 755 -d @prefix@/python
@@ -441,23 +473,36 @@ install-python: py
 	$(INSTALL_SH) -m 644 python/finalbuild/astra/*.py @prefix@/python/astra
 	$(INSTALL_SH) -m 644 python/finalbuild/astra/plugins/*.py @prefix@/python/astra/plugins
 	$(INSTALL_SH) -m 644 python/finalbuild/*.egg-info @prefix@/python/
-	@echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-	@echo "To use ASTRA in Python, add @prefix@/python/ to your PYTHONPATH"
-	@echo "and @libdir@ to your LD_LIBRARY_PATH."
-	@echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 # TODO: docs
+
+python-root-install: py
+# Note: setting CC to CXX is intentional. Python uses CC for compilation even if input is C++.
+	cd $(srcdir)/../../python; ASTRA_INSTALL_LIBRARY_AS_DATA=$(PYPKGDATA) CXX="${CXX}" CC="${CXX}" CPPFLAGS="${PYCPPFLAGS}" LDFLAGS="${PYLDFLAGS}" $(PYTHON) builder.py build --build-base=$(abs_top_builddir)/python/build install
 else
+python-root-install:
 install-python:
 endif
 
+ifeq ($(matlab),yes)
+install-matlab: $(MATLAB_MEX) install-matlab-so
+	$(INSTALL_SH) -m 755 -d $(MATLABBASE)
+	$(INSTALL_SH) -m 755 -d $(MATLABBASE)/mex
+	$(INSTALL_SH) -m 755 -d $(MATLABBASE)/tools
+	$(INSTALL_SH) -m 644 $(MATLAB_MEX) $(MATLABBASE)/mex
+	$(INSTALL_SH) -m 644 $(srcdir)/../../matlab/tools/*.m $(MATLABBASE)/tools
+# TODO: docs
+else
+install-matlab:
+endif
+
+
 ifeq ($(octave),yes)
-# TODO: This install location doesn't work well for /usr or /usr/local
-install-octave: $(OCTAVE_MEX)
-	$(INSTALL_SH) -m 755 -d @prefix@/octave
-	$(INSTALL_SH) -m 755 -d @prefix@/octave/mex
-	$(INSTALL_SH) -m 755 -d @prefix@/octave/tools
-	$(INSTALL_SH) -m 644 $(OCTAVE_MEX) @prefix@/octave/mex
-	$(INSTALL_SH) -m 644 $(srcdir)/../../matlab/tools/*.m @prefix@/octave/tools
+install-octave: $(OCTAVE_MEX) install-octave-so
+	$(INSTALL_SH) -m 755 -d $(OCTAVEBASE)
+	$(INSTALL_SH) -m 755 -d $(OCTAVEBASE)/mex
+	$(INSTALL_SH) -m 755 -d $(OCTAVEBASE)/tools
+	$(INSTALL_SH) -m 644 $(OCTAVE_MEX) $(OCTAVEBASE)/mex
+	$(INSTALL_SH) -m 644 $(srcdir)/../../matlab/tools/*.m $(OCTAVEBASE)/tools
 # TODO: docs
 else
 install-octave:
@@ -475,7 +520,7 @@ $(srcdir)/configure: $(srcdir)/configure.ac
 	@echo "configure.ac has been changed. Regenerating configure script"
 	cd $(srcdir) && $(SHELL) ./autogen.sh
 
-.PHONY: all mex test clean distclean install install-libraries py python-root-install install-python install-octave
+.PHONY: all mex test clean distclean install install-libraries py python-root-install install-python install-octave install-matlab-so install-octave-so
 
 # don't remove intermediate files:
 .SECONDARY:

--- a/build/linux/Makefile.in
+++ b/build/linux/Makefile.in
@@ -83,6 +83,7 @@ CPPFLAGS += -DASTRA_PYTHON -I$(PYINCDIR)
 PYCPPFLAGS  := $(CPPFLAGS)
 PYCPPFLAGS  += -I../include
 PYLDFLAGS = $(MODLDFLAGS)
+MODPYLIBS=-l$(PYLIBVER)
 endif
 
 # This is below where PYCPPFLAGS copies CPPFLAGS.  The python code is built
@@ -100,12 +101,6 @@ ifeq ($(cuda),yes)
 MEXFLAGS += -DASTRA_CUDA
 endif
 
-ifeq ($(python),yes)
-# TODO: Why PYLIBDIR?
-MEXPYLDFLAGS=\$$LDFLAGS $(MODLDFLAGS) -L$(PYLIBDIR)
-MEXPYLIBS=$(MEXLIBS) -l$(PYLIBVER)
-endif
-
 endif
 
 
@@ -117,13 +112,9 @@ OCTFLAGS=-DASTRA_CUDA
 else
 OCTFLAGS=
 endif
-ifeq ($(python),yes)
-OCTPYLIBS=-l$(PYLIBVER)
-else
-OCTPYLIBS=
-endif
 
 endif
+
 
 DEPDIR=.deps
 
@@ -311,7 +302,7 @@ mex: $(MATLAB_MEX)
 
 ifeq ($(python),yes)
 matlab/mex/astra_mex_plugin_c.$(MEXSUFFIX): matlab/mex/astra_mex_plugin_c.o $(MATLAB_CXX_OBJECTS) libastra.la
-	$(MEX) LDFLAGS="$(MEXPYLDFLAGS)" $(MEXFLAGS) $(LIBS) $(MEXPYLIBS) -lastra -output matlab/mex/astra_mex_plugin_c $< $(MATLAB_CXX_OBJECTS)
+	$(MEX) LDFLAGS="$(MEXLDFLAGS)" $(MEXFLAGS) $(LIBS) $(MEXLIBS) $(MODPYLIBS) -lastra -output matlab/mex/astra_mex_plugin_c $< $(MATLAB_CXX_OBJECTS)
 endif
 endif
 
@@ -335,7 +326,7 @@ oct: $(OCTAVE_MEX)
 
 ifeq ($(python),yes)
 matlab/mex/astra_mex_plugin_c.mex: matlab/mex/astra_mex_plugin_c.o $(MATLAB_CXX_OBJECTS) $(OCTAVE_CXX_OBJECTS) libastra.la
-	mkoctfile --mex $(OCTFLAGS) $(OCTLDFLAGS) $(LIBS) $(OCTPYLIBS) -lastra --output matlab/mex/astra_mex_plugin_c $< $(MATLAB_CXX_OBJECTS) $(OCTAVE_CXX_OBJECTS)
+	mkoctfile --mex $(OCTFLAGS) $(OCTLDFLAGS) $(LIBS) $(MODPYLIBS) -lastra --output matlab/mex/astra_mex_plugin_c $< $(MATLAB_CXX_OBJECTS) $(OCTAVE_CXX_OBJECTS)
 endif
 endif
 

--- a/build/linux/Makefile.in
+++ b/build/linux/Makefile.in
@@ -117,6 +117,12 @@ OCTFLAGS=-DASTRA_CUDA
 else
 OCTFLAGS=
 endif
+ifeq ($(python),yes)
+OCTPYLIBS=-l$(PYLIBVER)
+else
+OCTPYLIBS=
+endif
+
 endif
 
 DEPDIR=.deps
@@ -270,10 +276,6 @@ MATLAB_MEX=\
 	matlab/mex/astra_mex_data3d_c.$(MEXSUFFIX) \
 	matlab/mex/astra_mex_direct_c.$(MEXSUFFIX)
 
-ifeq ($(python),yes)
-MATLAB_MEX+=matlab/mex/astra_mex_plugin_c.$(MEXSUFFIX)
-endif
-
 OCTAVE_CXX_OBJECTS=\
 	matlab/mex/octave_support.o
 
@@ -287,6 +289,12 @@ OCTAVE_MEX=\
 	matlab/mex/astra_mex_log_c.mex \
 	matlab/mex/astra_mex_data3d_c.mex \
 	matlab/mex/astra_mex_direct_c.mex
+
+ifeq ($(python),yes)
+MATLAB_MEX+=matlab/mex/astra_mex_plugin_c.$(MEXSUFFIX)
+OCTAVE_MEX+=matlab/mex/astra_mex_plugin_c.mex
+endif
+
 
 OBJECT_DIRS = src/ tests/ cuda/2d/ cuda/3d/ matlab/mex/ ./
 DEPDIRS = $(addsuffix $(DEPDIR),$(OBJECT_DIRS))
@@ -323,7 +331,12 @@ ifeq ($(octave),yes)
 oct: $(OCTAVE_MEX)
 
 %.mex: %.o $(MATLAB_CXX_OBJECTS) $(OCTAVE_CXX_OBJECTS) libastra.la
-	mkoctfile --mex $(OCTFLAGS) $(OCTLDFLAGS) $(LIBS) -L.libs -lastra --output $* $*.o $(MATLAB_CXX_OBJECTS) $(OCTAVE_CXX_OBJECTS)
+	mkoctfile --mex $(OCTFLAGS) $(OCTLDFLAGS) $(LIBS) -lastra --output $* $*.o $(MATLAB_CXX_OBJECTS) $(OCTAVE_CXX_OBJECTS)
+
+ifeq ($(python),yes)
+matlab/mex/astra_mex_plugin_c.mex: matlab/mex/astra_mex_plugin_c.o $(MATLAB_CXX_OBJECTS) $(OCTAVE_CXX_OBJECTS) libastra.la
+	mkoctfile --mex $(OCTFLAGS) $(OCTLDFLAGS) $(LIBS) $(OCTPYLIBS) -lastra --output matlab/mex/astra_mex_plugin_c $< $(MATLAB_CXX_OBJECTS) $(OCTAVE_CXX_OBJECTS)
+endif
 endif
 
 libastra.la: $(ALL_OBJECTS)

--- a/build/linux/Makefile.in
+++ b/build/linux/Makefile.in
@@ -76,8 +76,7 @@ endif
 
 ifeq ($(python),yes)
 PYTHON      = @PYTHON@
-PYLIBDIR := $(shell $(PYTHON) -c 'from distutils.sysconfig import get_config_var; import six; six.print_(get_config_var("LIBDIR"))')
-PYINCDIR := $(shell $(PYTHON) -c 'from distutils.sysconfig import get_python_inc; import six; six.print_(get_python_inc())')
+PYINCDIR := $(shell $(PYTHON) -c 'from __future__ import print_function; from distutils.sysconfig import get_python_inc; print(get_python_inc())')
 PYLIBVER = `basename $(PYINCDIR)`
 CPPFLAGS += -DASTRA_PYTHON -I$(PYINCDIR)
 PYCPPFLAGS  := $(CPPFLAGS)

--- a/build/linux/Makefile.in
+++ b/build/linux/Makefile.in
@@ -462,7 +462,6 @@ endif
 
 
 ifeq ($(python),yes)
-# TODO: This install location doesn't work well for /usr or /usr/local
 install-python: py
 	$(MKDIR) python/finalbuild
 	# Note: setting CC to CXX is intentional. Python uses CC for compilation even if input is C++.

--- a/build/linux/Makefile.in
+++ b/build/linux/Makefile.in
@@ -450,10 +450,10 @@ OCTAVEBASE=@prefix@/octave
 
 install-matlab-so: libastra.la
 	$(INSTALL_SH) -m 755 -d $(MATLABBASE)/mex
-	$(INSTALL_SH) -m 644 $(abs_top_builddir)/.libs/$(SONAME) $(MATLABBASE)/mex
+	$(INSTALL_SH) -m 755 $(abs_top_builddir)/.libs/$(SONAME) $(MATLABBASE)/mex
 install-octave-so: libastra.la
 	$(INSTALL_SH) -m 755 -d $(OCTAVEBASE)/mex
-	$(INSTALL_SH) -m 644 $(abs_top_builddir)/.libs/$(SONAME) $(OCTAVEBASE)/mex
+	$(INSTALL_SH) -m 755 $(abs_top_builddir)/.libs/$(SONAME) $(OCTAVEBASE)/mex
 else
 install-matlab-so:
 install-octave-so:
@@ -471,7 +471,7 @@ install-python: py
 	$(INSTALL_SH) -m 755 -d @prefix@/python
 	$(INSTALL_SH) -m 755 -d @prefix@/python/astra
 	$(INSTALL_SH) -m 755 -d @prefix@/python/astra/plugins
-	$(INSTALL_SH) -m 644 python/finalbuild/astra/*.so @prefix@/python/astra
+	$(INSTALL_SH) -m 755 python/finalbuild/astra/*.so @prefix@/python/astra
 	$(INSTALL_SH) -m 644 python/finalbuild/astra/*.py @prefix@/python/astra
 	$(INSTALL_SH) -m 644 python/finalbuild/astra/plugins/*.py @prefix@/python/astra/plugins
 	$(INSTALL_SH) -m 644 python/finalbuild/*.egg-info @prefix@/python/
@@ -490,7 +490,7 @@ install-matlab: $(MATLAB_MEX) install-matlab-so
 	$(INSTALL_SH) -m 755 -d $(MATLABBASE)
 	$(INSTALL_SH) -m 755 -d $(MATLABBASE)/mex
 	$(INSTALL_SH) -m 755 -d $(MATLABBASE)/tools
-	$(INSTALL_SH) -m 644 $(MATLAB_MEX) $(MATLABBASE)/mex
+	$(INSTALL_SH) -m 755 $(MATLAB_MEX) $(MATLABBASE)/mex
 	$(INSTALL_SH) -m 644 $(srcdir)/../../matlab/tools/*.m $(MATLABBASE)/tools
 # TODO: docs
 else
@@ -503,7 +503,7 @@ install-octave: $(OCTAVE_MEX) install-octave-so
 	$(INSTALL_SH) -m 755 -d $(OCTAVEBASE)
 	$(INSTALL_SH) -m 755 -d $(OCTAVEBASE)/mex
 	$(INSTALL_SH) -m 755 -d $(OCTAVEBASE)/tools
-	$(INSTALL_SH) -m 644 $(OCTAVE_MEX) $(OCTAVEBASE)/mex
+	$(INSTALL_SH) -m 755 $(OCTAVE_MEX) $(OCTAVEBASE)/mex
 	$(INSTALL_SH) -m 644 $(srcdir)/../../matlab/tools/*.m $(OCTAVEBASE)/tools
 # TODO: docs
 else

--- a/build/linux/Makefile.in
+++ b/build/linux/Makefile.in
@@ -309,14 +309,10 @@ endif
 ifeq ($(python),yes)
 py: libastra.la
 	$(MKDIR) python/build
-	$(MKDIR) python/finalbuild
 	# Note: setting CC to CXX is intentional. Python uses CC for compilation even if input is C++.
-	cd $(srcdir)/../../python; CXX="${CXX}" CC="${CXX}" CPPFLAGS="${PYCPPFLAGS}" LDFLAGS="${PYLDFLAGS}" $(PYTHON) builder.py build --build-base=$(abs_top_builddir)/python/build install \
-	--install-base=$(abs_top_builddir)/python/finalbuild --install-headers=$(abs_top_builddir)/python/finalbuild --install-purelib=$(abs_top_builddir)/python/finalbuild \
-	--install-platlib=$(abs_top_builddir)/python/finalbuild --install-scripts=$(abs_top_builddir)/python/finalbuild --install-data=$(abs_top_builddir)/python/finalbuild
+	cd $(srcdir)/../../python; CXX="${CXX}" CC="${CXX}" CPPFLAGS="${PYCPPFLAGS}" LDFLAGS="${PYLDFLAGS}" $(PYTHON) builder.py build --build-base=$(abs_top_builddir)/python/build
 
-python-root-install: libastra.la
-	$(MKDIR) python/build
+python-root-install: py
 	# Note: setting CC to CXX is intentional. Python uses CC for compilation even if input is C++.
 	cd $(srcdir)/../../python; CXX="${CXX}" CC="${CXX}" CPPFLAGS="${PYCPPFLAGS}" LDFLAGS="${PYLDFLAGS}" $(PYTHON) builder.py build --build-base=$(abs_top_builddir)/python/build install
 
@@ -433,6 +429,11 @@ endif
 ifeq ($(python),yes)
 # TODO: This install location doesn't work well for /usr or /usr/local
 install-python: py
+	$(MKDIR) python/finalbuild
+	# Note: setting CC to CXX is intentional. Python uses CC for compilation even if input is C++.
+	cd $(srcdir)/../../python; CXX="${CXX}" CC="${CXX}" CPPFLAGS="${PYCPPFLAGS}" LDFLAGS="${PYLDFLAGS}" $(PYTHON) builder.py build --build-base=$(abs_top_builddir)/python/build install \
+	--install-base=$(abs_top_builddir)/python/finalbuild --install-headers=$(abs_top_builddir)/python/finalbuild --install-purelib=$(abs_top_builddir)/python/finalbuild \
+	--install-platlib=$(abs_top_builddir)/python/finalbuild --install-scripts=$(abs_top_builddir)/python/finalbuild --install-data=$(abs_top_builddir)/python/finalbuild
 	$(INSTALL_SH) -m 755 -d @prefix@/python
 	$(INSTALL_SH) -m 755 -d @prefix@/python/astra
 	$(INSTALL_SH) -m 755 -d @prefix@/python/astra/plugins

--- a/build/linux/Makefile.in
+++ b/build/linux/Makefile.in
@@ -421,7 +421,7 @@ install-libraries: libastra.la
 
 ifeq ($(install_type),prefix)
 # libraries into @libdir@, python into site-packages, mex into @datadir@
-install: install-libraries install-matlab python-root-install install-octave
+install: install-libraries install-matlab install-python-site-packages install-octave
 
 PYPKGDATA=
 MATLABBASE=@datadir@/astra/matlab
@@ -442,7 +442,7 @@ ifeq ($(install_type),module)
 # python into site-packages, mex into @datadir@
 # library copied into python/mex directories
 # modules built with rpath=$ORIGIN
-install: install-matlab python-root-install install-octave
+install: install-matlab install-python-site-packages install-octave
 
 PYPKGDATA=$(SONAME)
 MATLABBASE=@prefix@/matlab
@@ -478,11 +478,11 @@ install-python: py
 	$(INSTALL_SH) -m 644 python/finalbuild/*.egg-info @prefix@/python/
 # TODO: docs
 
-python-root-install: py
+install-python-site-packages: py
 # Note: setting CC to CXX is intentional. Python uses CC for compilation even if input is C++.
 	cd $(srcdir)/../../python; ASTRA_INSTALL_LIBRARY_AS_DATA=$(PYPKGDATA) CXX="${CXX}" CC="${CXX}" CPPFLAGS="${PYCPPFLAGS}" LDFLAGS="${PYLDFLAGS}" $(PYTHON) builder.py build --build-base=$(abs_top_builddir)/python/build install
 else
-python-root-install:
+install-python-site-packages:
 install-python:
 endif
 
@@ -523,7 +523,7 @@ $(srcdir)/configure: $(srcdir)/configure.ac
 	@echo "configure.ac has been changed. Regenerating configure script"
 	cd $(srcdir) && $(SHELL) ./autogen.sh
 
-.PHONY: all mex test clean distclean install install-libraries py python-root-install install-python install-octave install-matlab-so install-octave-so
+.PHONY: all mex test clean distclean install install-libraries py install-python-site-packages install-python install-octave install-matlab-so install-octave-so
 
 # don't remove intermediate files:
 .SECONDARY:

--- a/build/linux/configure.ac
+++ b/build/linux/configure.ac
@@ -141,6 +141,8 @@ if test x"$HAVECUDA" = xyes; then
   AC_MSG_RESULT([$NVCCARCHS])
 fi
 
+AC_ARG_VAR(NVCCFLAGS, [CUDA nvcc flags])
+
 
 AC_SUBST(HAVECUDA)
 AC_SUBST(LDFLAGS_CUDA)

--- a/build/linux/configure.ac
+++ b/build/linux/configure.ac
@@ -24,7 +24,7 @@ dnl
 dnl -----------------------------------------------------------------------
 dnl $Id$
 
-AC_INIT(astra_toolbox, 1.7.1)
+AC_INIT(astra, 1.7.1)
 AC_CONFIG_SRCDIR([Makefile.in])
 LT_INIT([disable-static])
 
@@ -274,6 +274,15 @@ AC_SUBST(CPPFLAGS_OS)
 VPATH_SRCDIR="$srcdir"
 AC_SUBST(VPATH_SRCDIR)
 
+
+# Installation type
+AC_ARG_WITH(install-type, [[  --with-install-type=prefix|module|dir  type of installation (default prefix)]],,with_install_type=prefix)
+
+INSTALL_TYPE=$with_install_type
+AC_SUBST(INSTALL_TYPE)
+
+
+
 # TODO:
 
 # Detection of tools:
@@ -299,4 +308,5 @@ echo "  Octave : $HAVEOCTAVE"
 echo "  Python : $HAVEPYTHON"
 echo
 echo "  prefix : $prefix"
+echo "  install: $with_install_type"
 echo

--- a/build/linux/configure.ac
+++ b/build/linux/configure.ac
@@ -179,8 +179,8 @@ AC_SUBST(HAVEMATLAB)
 
 # octave
 
-AC_ARG_ENABLE(octave, [[  --disable-octave      disable Octave support]])
-if test x"$enable_octave" != xno; then
+AC_ARG_ENABLE(octave, [[  --enable-octave         enable Octave support]])
+if test x"$enable_octave" = xyes; then
   AC_PATH_PROG([HAVEOCTAVE], [octave-config], [no], [$PATH])
   AC_MSG_CHECKING([for octave])
   if test x"HAVEOCTAVE" != xno -a $HAVEMATLAB = yes; then

--- a/build/linux/configure.ac
+++ b/build/linux/configure.ac
@@ -302,11 +302,46 @@ AC_OUTPUT
 
 echo
 echo "Summary of ASTRA Toolbox build options:"
-echo "  CUDA   : $HAVECUDA"
-echo "  Matlab : $HAVEMATLAB"
-echo "  Octave : $HAVEOCTAVE"
-echo "  Python : $HAVEPYTHON"
+echo "  CUDA  : $HAVECUDA"
+echo "  Matlab: $HAVEMATLAB"
+echo "  Octave: $HAVEOCTAVE"
+echo "  Python: $HAVEPYTHON"
 echo
-echo "  prefix : $prefix"
-echo "  install: $with_install_type"
-echo
+echo "Installation type: $with_install_type"
+case $with_install_type in
+  prefix)
+    echo   "  Library     : "$(eval echo `eval echo $libdir`)
+    if test $HAVEMATLAB = yes; then
+      echo "  Matlab files: "$(eval echo `eval echo $datadir`)"/astra/matlab"
+    fi
+    if test $HAVEOCTAVE = yes; then
+      echo "  Octave files: "$(eval echo `eval echo $datadir`)"/astra/octave"
+    fi
+    if test $HAVEPYTHON = yes; then
+      echo "  Python files to site-packages"
+    fi
+    ;;
+  dir)
+    echo   "  Library     : "$(eval echo `eval echo $libdir`)
+    if test $HAVEMATLAB = yes; then
+      echo "  Matlab files: $prefix/matlab"
+    fi
+    if test $HAVEOCTAVE = yes; then
+      echo "  Octave files: $prefix/octave"
+    fi
+    if test $HAVEPYTHON = yes; then
+      echo "  Python files: $prefix/python"
+    fi
+    ;;
+  module)
+    echo   "  Library into Matlab/Octave/Python module directories"
+    if test $HAVEMATLAB = yes; then
+      echo "  Matlab files: $prefix/matlab"
+    fi
+    if test $HAVEOCTAVE = yes; then
+      echo "  Octave files: $prefix/octave"
+    fi
+    if test $HAVEPYTHON = yes; then
+      echo "  Python files to site-packages"
+    fi
+esac

--- a/build/linux/configure.ac
+++ b/build/linux/configure.ac
@@ -133,9 +133,9 @@ fi
 AC_ARG_WITH(cuda_compute, [[  --with-cuda-compute=archs  comma separated list of CUDA compute models (optional)]],,)
 if test x"$HAVECUDA" = xyes; then
   AC_MSG_CHECKING([for nvcc archs])
-  dnl 10 11 12 13 20 30 32 35 37 50
+  dnl 10 11 12 13 20 21 30 32 35 37 50 52 53 60 61
   if test x"$with_cuda_compute" = x; then
-    with_cuda_compute="10,12,20,30,35,50"
+    with_cuda_compute="20,30,35,50,60"
   fi
   ASTRA_FIND_NVCC_ARCHS([$with_cuda_compute],NVCCFLAGS_EXTRA,NVCCARCHS)
   AC_MSG_RESULT([$NVCCARCHS])

--- a/python/builder.py
+++ b/python/builder.py
@@ -74,7 +74,7 @@ for m in ext_modules:
   if m.name == 'astra.plugin_c':
     m.sources.append('astra/src/PythonPluginAlgorithm.cpp')
 
-setup (name = 'PyASTRAToolbox',
+setup (name = 'astra-toolbox',
        version = '1.7.1',
        description = 'Python interface to the ASTRA-Toolbox',
        author='D.M. Pelt',

--- a/python/builder.py
+++ b/python/builder.py
@@ -64,6 +64,14 @@ if cfgHasToBeUpdated:
     cfg.write(cfgToWrite)
     cfg.close()
 
+
+pkgdata = { }
+try:
+    if os.environ['ASTRA_INSTALL_LIBRARY_AS_DATA']:
+        pkgdata['astra'] = [os.environ['ASTRA_INSTALL_LIBRARY_AS_DATA']]
+except KeyError:
+    pass
+
 cmdclass = { }
 ext_modules = [ ]
 
@@ -88,5 +96,6 @@ setup (name = 'astra-toolbox',
        cmdclass = cmdclass,
        #ext_modules = [Extension("astra","astra/astra.pyx")],
        packages=['astra', 'astra.plugins'],
+       package_data=pkgdata,
        requires=["numpy"],
 	)

--- a/python/conda/build.sh
+++ b/python/conda/build.sh
@@ -5,4 +5,4 @@ if [ $MAKEOPTS == '<UNDEFINED>' ]
   then
     MAKEOPTS=""
 fi
-make $MAKEOPTS python-root-install
+make $MAKEOPTS install


### PR DESCRIPTION
There are now three ways of installing from configure/make:
    
./configure --with-install-type=prefix (default)
    
libraries go into \@prefix@/lib (or lib64)
matlab tools/mex go into \@prefix@/share/astra/matlab
octave tools/mex go into \@prefix@/share/astra/octave
python module goes into site-packages
    
./configure --with-install-type=dir
    
libraries go into \@prefix@/lib
matlab tools/mex go into \@prefix@/matlab
octave tools/mex go into \@prefix@/octave
python module goes into \@prefix@/python
    
./configure --with-install-type=module
    
matlab tools/mex go into \@prefix@/matlab
octave tools/mex go into \@prefix@/octave
python module goes into site-packages
library is installed along with the matlab/octave/python module(s), with rpath