### PR TITLE
Tv

### DIFF
--- a/cuda/2d/sirt.cu
+++ b/cuda/2d/sirt.cu
@@ -92,9 +92,6 @@ void SIRT::reset()
 
 bool SIRT::init()
 {
-
-	// TODO allocate primal and dual variables, declare them in header (and their pitch)
-
 	allocateVolumeData(D_pixelWeight, pixelPitch, dims);
 	zeroVolumeData(D_pixelWeight, pixelPitch, dims);
 

--- a/cuda/2d/sirt.cu
+++ b/cuda/2d/sirt.cu
@@ -92,6 +92,9 @@ void SIRT::reset()
 
 bool SIRT::init()
 {
+
+	// TODO allocate primal and dual variables, declare them in header (and their pitch)
+
 	allocateVolumeData(D_pixelWeight, pixelPitch, dims);
 	zeroVolumeData(D_pixelWeight, pixelPitch, dims);
 
@@ -100,7 +103,7 @@ bool SIRT::init()
 
 	allocateProjectionData(D_projData, projPitch, dims);
 	zeroProjectionData(D_projData, projPitch, dims);
-	
+
 	allocateProjectionData(D_lineWeight, linePitch, dims);
 	zeroProjectionData(D_lineWeight, linePitch, dims);
 
@@ -360,7 +363,7 @@ int main()
 	allocateVolume(D_sinoData, dims.iProjDets, dims.iProjAngles, sinoPitch);
 	zeroVolume(D_sinoData, sinoPitch, dims.iProjDets, dims.iProjAngles);
 	printf("pitch: %u\n", sinoPitch);
-	
+
 	unsigned int y, x;
 	float* sino = loadImage("sino.png", y, x);
 

--- a/cuda/2d/tv.cu
+++ b/cuda/2d/tv.cu
@@ -49,18 +49,18 @@ static int iDivUp(int a, int b){
 }
 
 
-
-
 TV::TV() : ReconAlgo()
 {
 	D_projData = 0;
-	D_x = 0;
+	//~ D_x = 0;
 	D_xTilde = 0;
 	D_xold = 0;
 	D_sliceTmp = 0;
 	D_dualp = 0;
 	D_dualq = 0;
 	D_sinoTmp = 0;
+	D_gradTmp = 0; //
+	D_gradTmp2 = 0; //
 
 	D_minMaskData = 0;
 	D_maxMaskData = 0;
@@ -79,13 +79,15 @@ TV::~TV()
 void TV::reset()
 {
 	cudaFree(D_projData);
-	cudaFree(D_x);
+	//~ cudaFree(D_x);
 	cudaFree(D_xTilde);
 	cudaFree(D_xold);
 	cudaFree(D_sliceTmp);
 	cudaFree(D_dualp);
 	cudaFree(D_dualq);
 	cudaFree(D_sinoTmp);
+	cudaFree(D_gradTmp); //
+	cudaFree(D_gradTmp2); //
 
 	if (freeMinMaxMasks) {
 		cudaFree(D_minMaskData);
@@ -93,7 +95,7 @@ void TV::reset()
 	}
 
 	D_projData = 0;
-	D_x = 0;
+	//~ D_x = 0;
 	D_xTilde = 0;
 	D_xold = 0;
 	D_sliceTmp = 0;
@@ -102,6 +104,9 @@ void TV::reset()
 	D_sinoTmp = 0;
 	D_minMaskData = 0;
 	D_maxMaskData = 0;
+	D_gradTmp = 0; //
+	D_gradTmp2 = 0; //
+
 
 	freeMinMaxMasks = false;
 	useVolumeMask = false;
@@ -129,20 +134,25 @@ bool TV::init()
     allocateVolumeData(D_xTilde, xtildePitch, dims);
 	zeroVolumeData(D_xTilde, xtildePitch, dims);
 
-    int nels = dims.iVolWidth * dims.iVolHeight;
-    cudaMalloc(&D_dualp, 2*nels*sizeof(float));
-    cudaMemset(D_dualp, 0, 2*nels*sizeof(float));
-
 	allocateProjectionData(D_sinoTmp, sinoTmpPitch, dims);
 	zeroProjectionData(D_sinoTmp, sinoTmpPitch, dims);
 
 	allocateProjectionData(D_dualq, dualqPitch, dims);
 	zeroProjectionData(D_dualq, dualqPitch, dims);
 
+	// if float2 cannot be used, we use a buffer with height*2
+    SDimensions dimsGrad = dims;
+    dimsGrad.iVolHeight *= 2;
+    allocateVolumeData(D_dualp, dualpPitch, dimsGrad);
+	zeroVolumeData(D_dualp, dualpPitch, dimsGrad);
+   	// if not cublas
+   	allocateVolumeData(D_gradTmp, gradTmpPitch, dimsGrad);
+	zeroVolumeData(D_gradTmp, gradTmpPitch, dimsGrad);
+	allocateVolumeData(D_gradTmp2, gradTmp2Pitch, dimsGrad);
+	zeroVolumeData(D_gradTmp2, gradTmp2Pitch, dimsGrad);
 
     nIterComputeNorm = 20;
     normFactor = 1.2f;
-
 
 	// TODO: check if allocations succeeded
 	return true;
@@ -191,97 +201,126 @@ bool TV::uploadMinMaxMasks(const float* pfMinMaskData, const float* pfMaxMaskDat
 
 
 
-
-
-__global__ void projLinfKernel(float* dst, float* src, const SDimensions dims, float radius) {
-	int gidx = threadIdx.x + blockIdx.x*blockDim.x;
-	int gidy = threadIdx.y + blockIdx.y*blockDim.y;
-    int sizeX = dims.iVolWidth, sizeY = dims.iVolHeight;
+__global__ void projLinfKernel(float* dst, float* src, const SDimensions dims, unsigned int pitch, float radius) {
+	unsigned int gidx = threadIdx.x + blockIdx.x*blockDim.x;
+	unsigned int gidy = threadIdx.y + blockIdx.y*blockDim.y;
+    unsigned int sizeX = dims.iVolWidth, sizeY = dims.iVolHeight;
 
 	if (gidx < sizeX && gidy < sizeY) {
-		int idx = gidy*sizeX+gidx;
+		unsigned int idx = gidy*pitch+gidx;
 		float val_x = src[idx];
-		float val_y = src[sizeX*sizeY + idx];
+		float val_y = src[pitch*sizeY + idx];
 
 		dst[idx] = copysignf(min(fabsf(val_x), radius), val_x);
-		dst[sizeX*sizeY + idx] = copysignf(min(fabsf(val_y), radius), val_y);
+		dst[pitch*sizeY + idx] = copysignf(min(fabsf(val_y), radius), val_y);
 	}
 }
 
-bool TV::projLinf(float* D_gradData, float* D_data, float radius) {
+bool TV::projLinf(float* D_gradData, float* D_data, unsigned int pitch, float radius) {
 	dim3 nBlocks, nThreadsPerBlock;
 	nThreadsPerBlock = dim3(threadsPerBlock, threadsPerBlock, 1);
 	nBlocks = dim3(iDivUp(dims.iVolWidth, threadsPerBlock), iDivUp(dims.iVolHeight, threadsPerBlock), 1);
 
-	projLinfKernel<<<nBlocks, nThreadsPerBlock>>>(D_data, D_gradData, dims, radius);
+	projLinfKernel<<<nBlocks, nThreadsPerBlock>>>(D_data, D_gradData, dims, pitch, radius);
 	return true;
 }
 
 
 
-__global__ void gradientKernel2D(float* dst, float* src, const SDimensions dims, float alpha, int doUpdate) {
-    int gidx = threadIdx.x + blockIdx.x*blockDim.x;
-    int gidy = threadIdx.y + blockIdx.y*blockDim.y;
-    int sizeX = dims.iVolWidth, sizeY = dims.iVolHeight;
+__global__ void gradientKernel2D(float* dst, float* src, const SDimensions dims, unsigned int pitch, float alpha, int doUpdate) {
+    unsigned int gidx = threadIdx.x + blockIdx.x*blockDim.x;
+    unsigned int gidy = threadIdx.y + blockIdx.y*blockDim.y;
+    unsigned int sizeX = dims.iVolWidth, sizeY = dims.iVolHeight;
     float val_x = 0, val_y = 0;
 
     if (gidx < sizeX && gidy < sizeY) {
         if (gidx == sizeX-1) val_y = 0;
-        else val_y = src[(gidy)*sizeX+gidx+1] - src[gidy*sizeX+gidx];
+        else val_y = src[(gidy)*pitch+gidx+1] - src[gidy*pitch+gidx];
         if (gidy == sizeY-1) val_x = 0;
-        else val_x = src[(gidy+1)*sizeX+gidx] - src[gidy*sizeX+gidx];
+        else val_x = src[(gidy+1)*pitch+gidx] - src[gidy*pitch+gidx];
 
         if (doUpdate) {
-            val_x = alpha*val_x + dst[gidy*sizeX+gidx];
-            val_y = alpha*val_y + dst[sizeX*sizeY + gidy*sizeX+gidx];
+            val_x = alpha*val_x + dst[gidy*pitch+gidx];
+            val_y = alpha*val_y + dst[pitch*sizeY + gidy*pitch+gidx];
         }
 
-        dst[(gidy)*sizeX+gidx] = val_x;
-        dst[sizeX*sizeY + (gidy)*sizeX+gidx] = val_y;
+        dst[(gidy)*pitch+gidx] = val_x;
+        dst[pitch*sizeY + (gidy)*pitch+gidx] = val_y;
     }
 }
 
 
 // gradientOperator(dst, src, alpha, 0)  computes  dst = gradient(src)
 // gradientOperator(dst, src, alpha, 1)  computes  dst = dst + alpha*gradient(src)
-bool TV::gradientOperator(float* D_gradData, float* D_data, float alpha, int doUpdate) {
+bool TV::gradientOperator(float* D_gradData, float* D_data, unsigned int pitch, float alpha, int doUpdate) {
     dim3 nBlocks, nThreadsPerBlock;
     nThreadsPerBlock = dim3(threadsPerBlock, threadsPerBlock, 1);
     nBlocks = dim3(iDivUp(dims.iVolWidth, threadsPerBlock), iDivUp(dims.iVolHeight, threadsPerBlock), 1);
 
-    gradientKernel2D<<<nBlocks, nThreadsPerBlock>>>(D_gradData, D_data, dims, alpha, doUpdate);
+    gradientKernel2D<<<nBlocks, nThreadsPerBlock>>>(D_gradData, D_data, dims, pitch, alpha, doUpdate);
     return true;
 }
 
 
-__global__ void divergenceKernel2D(float* dst, float* src, const SDimensions dims, float alpha, int doUpdate) {
-    int gidx = threadIdx.x + blockIdx.x*blockDim.x;
-    int gidy = threadIdx.y + blockIdx.y*blockDim.y;
-    int sizeX = dims.iVolWidth, sizeY = dims.iVolHeight;
+__global__ void divergenceKernel2D(float* dst, float* src, const SDimensions dims, unsigned int pitch, float alpha, int doUpdate) {
+    unsigned int gidx = threadIdx.x + blockIdx.x*blockDim.x;
+    unsigned int gidy = threadIdx.y + blockIdx.y*blockDim.y;
+    unsigned int sizeX = dims.iVolWidth, sizeY = dims.iVolHeight;
     float val_x = 0, val_y = 0;
 
     if (gidx < sizeX && gidy < sizeY) {
-        if (gidx == 0) val_y = src[(gidy)*sizeX+gidx];
-        else val_y = src[sizeX*sizeY + (gidy)*sizeX+gidx] - src[sizeX*sizeY +  (gidy)*sizeX+gidx-1];
-        if (gidy == 0) val_x = src[(gidy)*sizeX+gidx];
-        else val_x = src[(gidy)*sizeX+gidx] - src[(gidy-1)*sizeX+gidx];
+        if (gidx == 0) val_y = src[(gidy)*pitch+gidx];
+        else val_y = src[pitch*sizeY + (gidy)*pitch+gidx] - src[pitch*sizeY +  (gidy)*pitch+gidx-1];
+        if (gidy == 0) val_x = src[(gidy)*pitch+gidx];
+        else val_x = src[(gidy)*pitch+gidx] - src[(gidy-1)*pitch+gidx];
 
-        if (doUpdate) dst[(gidy)*sizeX+gidx] += alpha*(val_x + val_y);
-        else dst[(gidy)*sizeX+gidx] = val_x + val_y;
+        if (doUpdate) dst[(gidy)*pitch+gidx] += alpha*(val_x + val_y);
+        else dst[(gidy)*pitch+gidx] = val_x + val_y;
     }
 }
 
 
 // divergenceOperator(dst, src, alpha, 0)  computes  dst = div(src)
 // divergenceOperator(dst, src, alpha, 1)  computes  dst = dst + alpha*div(src)
-bool TV::divergenceOperator(float* D_data, float* D_gradData, float alpha, int doUpdate) {
+bool TV::divergenceOperator(float* D_data, float* D_gradData, unsigned int pitch, float alpha, int doUpdate) {
     dim3 nBlocks, nThreadsPerBlock;
     nThreadsPerBlock = dim3(threadsPerBlock, threadsPerBlock, 1);
     nBlocks = dim3(iDivUp(dims.iVolWidth, threadsPerBlock), iDivUp(dims.iVolHeight, threadsPerBlock), 1);
 
-    divergenceKernel2D<<<nBlocks, nThreadsPerBlock>>>(D_data, D_gradData, dims, alpha, doUpdate);
+    divergenceKernel2D<<<nBlocks, nThreadsPerBlock>>>(D_data, D_gradData, dims, pitch, alpha, doUpdate);
     return true;
 }
+
+
+__global__ void signKernel2D(float* dst, float* src, const SDimensions dims, unsigned int pitch, int nz) {
+    unsigned int gidx = threadIdx.x + blockIdx.x*blockDim.x;
+    unsigned int gidy = threadIdx.y + blockIdx.y*blockDim.y;
+    unsigned int sizeX = dims.iVolWidth, sizeY = dims.iVolHeight;
+    unsigned int idx = gidy*pitch + gidx;
+    if (gidx < sizeX && gidy < sizeY) {
+		dst[idx] = copysignf(1, src[idx]);
+		if (nz > 1) for (int i = 1; i < nz; i++) {
+			dst[i*pitch*sizeY + idx] = copysignf(1, src[i*pitch*sizeY + idx]);
+		}
+	}
+}
+
+// signOperator(dst, src, 1) computes dst = sign(src).
+// If the last parameter is greater than 1, it means that there are several buffers
+bool TV::signOperator(float* D_dst, float* D_src, unsigned int pitch, int nz) {
+    dim3 nBlocks, nThreadsPerBlock;
+    nThreadsPerBlock = dim3(threadsPerBlock, threadsPerBlock, 1);
+    nBlocks = dim3(iDivUp(dims.iVolWidth, threadsPerBlock), iDivUp(dims.iVolHeight, threadsPerBlock), 1);
+
+    signKernel2D<<<nBlocks, nThreadsPerBlock>>>(D_dst, D_src, dims, pitch, nz);
+    return true;
+}
+
+
+
+
+
+
 
 
 
@@ -300,8 +339,8 @@ float TV::computeOperatorNorm() {
         callFP(D_sliceTmp, tmpPitch, D_sinoTmp, sinoTmpPitch, 1.0f);
         zeroVolumeData(D_sliceTmp, tmpPitch, dims);
         callBP(D_sliceTmp, tmpPitch, D_sinoTmp, sinoTmpPitch, 1.0f);
-        gradientOperator(D_dualp, D_sliceTmp, 1.0, 0);
-        divergenceOperator(D_sliceTmp, D_dualp, -1.0f, 1); // TODO: what is computed is div or -div ? In the latter case: put alpha=+1
+        gradientOperator(D_dualp, D_sliceTmp, tmpPitch, 1.0, 0);
+        divergenceOperator(D_sliceTmp, D_dualp, tmpPitch, -1.0f, 1); // TODO: what is computed is div or -div ? In the latter case: put alpha=+1
 
         // Compute norm and scale x
         norm = dotProduct2D(D_sliceTmp, tmpPitch, dims.iVolWidth, dims.iVolHeight); // TODO: check
@@ -309,7 +348,7 @@ float TV::computeOperatorNorm() {
         processVol<opMul>(D_sliceTmp, 1.0f/norm, tmpPitch, dims);
     }
     //
-    cudaMemset(D_dualp, 0, 2*dims.iVolHeight*dims.iVolWidth*sizeof(float));
+    cudaMemset(D_dualp, 0, 2*dims.iVolHeight*tmpPitch*sizeof(float));
     //
     if (norm < 0) return -1.0f;     // something went wrong
     else return sqrt(norm);
@@ -338,6 +377,7 @@ void write_device_array(float* data, int nels, char* fname) {
 
 // TODO: implement volume mask
 // TODO: implement either use_fbp in iterations, or preconditioned CP
+// TODO: use less buffers (for eg use D_x = D_volumeData ?)
 bool TV::iterate(unsigned int iterations)
 {
     // Compute the primal and dual steps, for non-preconditionned CP
@@ -347,6 +387,8 @@ bool TV::iterate(unsigned int iterations)
     float theta = 1.;				  // C-P relaxation parameter
 
 	printf("L = %f, sigma = %f\n", L, sigma);
+	fRegularization = 10.0; /// DEBUG
+	printf("Lambda = %f\n", fRegularization);
 
 	// iteration
 	for (unsigned int iter = 0; iter < iterations; ++iter) {
@@ -357,16 +399,12 @@ bool TV::iterate(unsigned int iterations)
 		// ----------------------
 		// p = proj_linf(p + sigma*gradient(x_tilde), Lambda)
 		/// DEBUG
-		// dims.iVolWidth = 1024; dims.iVolHeight = 1024; dims.iProjAngles = 512; dims.iProjDets = 1536;
-		//~ cudaMemset(D_dualp, 0, sizeof(float)*dims.iVolHeight*dims.iVolWidth);
-
-		write_device_array(D_dualp, dims.iVolHeight*dims.iVolWidth, "p0.dat"); /// DEBUG
-		write_device_array(D_dualp, dims.iVolHeight*dims.iVolWidth, "p1.dat"); /// DEBUG
+		/// write_device_array(D_dualp, dims.iVolHeight*dims.iVolWidth, "p0.dat"); /// DEBUG
+		/// write_device_array(D_dualp, dims.iVolHeight*dims.iVolWidth, "p1.dat"); /// DEBUG
 		/// -----
-		gradientOperator(D_dualp, D_xTilde, sigma, 1);
+		gradientOperator(D_dualp, D_xTilde, dualpPitch, sigma, 1);
 
-
-		projLinf(D_dualp, D_dualp, fRegularization); // *sigma
+		projLinf(D_dualp, D_dualp, dualpPitch, fRegularization); // *sigma
 
 
 		// q = (q + sigma*P(x_tilde) - sigma*data)/(1.0 + sigma)
@@ -375,8 +413,7 @@ bool TV::iterate(unsigned int iterations)
 								 dualqPitch, dims);
         processSino<opMul>(D_dualq, 1.0f/(1.0f+sigma), dualqPitch, dims);   // q /= 1+sigma
         /// DEBUG
-		// dims.iVolWidth = 1024; dims.iVolHeight = 1024; dims.iProjAngles = 512; dims.iProjDets = 1536;
-		write_device_array(D_dualq, dims.iProjDets*dims.iProjAngles, "sino_a.dat"); /// DEBUG
+		/// write_device_array(D_dualq, dims.iProjDets*dims.iProjAngles, "sino_a.dat"); /// DEBUG
 		/// -----
 
 
@@ -384,7 +421,7 @@ bool TV::iterate(unsigned int iterations)
 		// ------------------------
 		duplicateVolumeData(D_xold, D_x, volumePitch, dims);
 		// x = x + tau*div(p) - tau*P^T(q)
-		divergenceOperator(D_x, D_dualp, tau, 1);							// x = x + tau*div(p)
+		divergenceOperator(D_x, D_dualp, xPitch, tau, 1);					// x = x + tau*div(p)
 		callBP(D_x, xPitch, D_dualq, dualqPitch, -tau);		  				// x += (-tau)*P^T(q)
 
         // Extra constraints (if any)
@@ -408,9 +445,12 @@ bool TV::iterate(unsigned int iterations)
 
 	}
 
+	 duplicateVolumeData(D_volumeData, D_x, volumePitch, dims);
+
 	return true;
 }
 
+/// Compute  0.5 * ||P(x) - data||_2^2  + Lambda*TV(x)
 float TV::computeDiffNorm()
 {
 	// copy sinogram to projection data
@@ -420,9 +460,17 @@ float TV::computeDiffNorm()
 	callFP(D_volumeData, volumePitch, D_projData, projPitch, -1.0f);
 
 	// compute norm of D_projData
-	float s = dotProduct2D(D_projData, projPitch, dims.iProjDets, dims.iProjAngles);
+	float l2 = dotProduct2D(D_projData, projPitch, dims.iProjDets, dims.iProjAngles);
+	l2 *= 0.5;
 
-	return sqrt(s);
+	// cublasSasum() would be ideal. If it cannot be used,
+	// the only solution is to use a dot product between grad(x) and sign(grad(x)),
+	// but it entails two extra gradient buffers
+	gradientOperator(D_gradTmp, D_volumeData, gradTmpPitch, 0, 0);
+	signOperator(D_gradTmp2, D_gradTmp, gradTmpPitch, 2);
+	float l1 = dotProduct2D(D_gradTmp, gradTmpPitch, dims.iVolWidth, dims.iVolHeight);
+
+	return l2 + fRegularization*l1;
 }
 
 

--- a/cuda/2d/tv.cu
+++ b/cuda/2d/tv.cu
@@ -1,0 +1,308 @@
+/*
+-----------------------------------------------------------------------
+Copyright: 2010-2015, iMinds-Vision Lab, University of Antwerp
+           2014-2015, CWI, Amsterdam
+
+Contact: astra@uantwerpen.be
+Website: http://sf.net/projects/astra-toolbox
+
+This file is part of the ASTRA Toolbox.
+
+
+The ASTRA Toolbox is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The ASTRA Toolbox is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
+
+-----------------------------------------------------------------------
+$Id$
+*/
+
+#include <cstdio>
+#include <cassert>
+
+#include "tv.h"
+#include "util.h"
+#include "arith.h"
+
+#ifdef STANDALONE
+#include "testutil.h"
+#endif
+
+namespace astraCUDA {
+
+TV::TV() : ReconAlgo()
+{
+	D_projData = 0;
+	D_tmpData = 0;
+
+	D_lineWeight = 0;
+	D_pixelWeight = 0;
+
+	D_minMaskData = 0;
+	D_maxMaskData = 0;
+
+	fRelaxation = 1.0f;
+
+	freeMinMaxMasks = false;
+}
+
+
+TV::~TV()
+{
+	reset();
+}
+
+void TV::reset()
+{
+	cudaFree(D_projData);
+	cudaFree(D_tmpData);
+	cudaFree(D_lineWeight);
+	cudaFree(D_pixelWeight);
+	if (freeMinMaxMasks) {
+		cudaFree(D_minMaskData);
+		cudaFree(D_maxMaskData);
+	}
+
+	D_projData = 0;
+	D_tmpData = 0;
+
+	D_lineWeight = 0;
+	D_pixelWeight = 0;
+
+	freeMinMaxMasks = false;
+	D_minMaskData = 0;
+	D_maxMaskData = 0;
+
+	useVolumeMask = false;
+	useSinogramMask = false;
+
+	fRelaxation = 1.0f;
+
+	ReconAlgo::reset();
+}
+
+bool TV::init()
+{
+	allocateVolumeData(D_pixelWeight, pixelPitch, dims);
+	zeroVolumeData(D_pixelWeight, pixelPitch, dims);
+
+	allocateVolumeData(D_tmpData, tmpPitch, dims);
+	zeroVolumeData(D_tmpData, tmpPitch, dims);
+
+	allocateProjectionData(D_projData, projPitch, dims);
+	zeroProjectionData(D_projData, projPitch, dims);
+
+	allocateProjectionData(D_lineWeight, linePitch, dims);
+	zeroProjectionData(D_lineWeight, linePitch, dims);
+
+	// TODO: check if allocations succeeded
+	return true;
+}
+
+/*
+bool TV::setMinMaxMasks(float* D_minMaskData_, float* D_maxMaskData_,
+	                      unsigned int iPitch)
+{
+	D_minMaskData = D_minMaskData_;
+	D_maxMaskData = D_maxMaskData_;
+	minMaskPitch = iPitch;
+	maxMaskPitch = iPitch;
+
+	freeMinMaxMasks = false;
+	return true;
+}
+
+bool TV::uploadMinMaxMasks(const float* pfMinMaskData, const float* pfMaxMaskData,
+	                         unsigned int iPitch)
+{
+	freeMinMaxMasks = true;
+	bool ok = true;
+	if (pfMinMaskData) {
+		allocateVolumeData(D_minMaskData, minMaskPitch, dims);
+		ok = copyVolumeToDevice(pfMinMaskData, iPitch,
+		                        dims,
+		                        D_minMaskData, minMaskPitch);
+	}
+	if (!ok)
+		return false;
+
+	if (pfMaxMaskData) {
+		allocateVolumeData(D_maxMaskData, maxMaskPitch, dims);
+		ok = copyVolumeToDevice(pfMaxMaskData, iPitch,
+		                        dims,
+		                        D_maxMaskData, maxMaskPitch);
+	}
+	if (!ok)
+		return false;
+
+	return true;
+}
+*/
+
+bool TV::iterate(unsigned int iterations)
+{
+	shouldAbort = false;
+
+	// iteration
+	for (unsigned int iter = 0; iter < iterations && !shouldAbort; ++iter) {
+
+		// copy sinogram to projection data
+		duplicateProjectionData(D_projData, D_sinoData, projPitch, dims);
+
+		// do FP, subtracting projection from sinogram
+		if (useVolumeMask) {
+				duplicateVolumeData(D_tmpData, D_volumeData, volumePitch, dims);
+				processVol<opMul>(D_tmpData, D_maskData, tmpPitch, dims);
+				callFP(D_tmpData, tmpPitch, D_projData, projPitch, -1.0f);
+		} else {
+				callFP(D_volumeData, volumePitch, D_projData, projPitch, -1.0f);
+		}
+
+		processSino<opMul>(D_projData, D_lineWeight, projPitch, dims);
+
+		zeroVolumeData(D_tmpData, tmpPitch, dims);
+
+		callBP(D_tmpData, tmpPitch, D_projData, projPitch, 1.0f);
+
+		// pixel weights also contain the volume mask and relaxation factor
+		processVol<opAddMul>(D_volumeData, D_pixelWeight, D_tmpData, volumePitch, dims);
+
+		if (useMinConstraint)
+			processVol<opClampMin>(D_volumeData, fMinConstraint, volumePitch, dims);
+		if (useMaxConstraint)
+			processVol<opClampMax>(D_volumeData, fMaxConstraint, volumePitch, dims);
+		if (D_minMaskData)
+			processVol<opClampMinMask>(D_volumeData, D_minMaskData, volumePitch, dims);
+		if (D_maxMaskData)
+			processVol<opClampMaxMask>(D_volumeData, D_maxMaskData, volumePitch, dims);
+	}
+
+	return true;
+}
+
+float TV::computeDiffNorm()
+{
+	// copy sinogram to projection data
+	duplicateProjectionData(D_projData, D_sinoData, projPitch, dims);
+
+	// do FP, subtracting projection from sinogram
+	if (useVolumeMask) {
+			duplicateVolumeData(D_tmpData, D_volumeData, volumePitch, dims);
+			processVol<opMul>(D_tmpData, D_maskData, tmpPitch, dims);
+			callFP(D_tmpData, tmpPitch, D_projData, projPitch, -1.0f);
+	} else {
+			callFP(D_volumeData, volumePitch, D_projData, projPitch, -1.0f);
+	}
+
+
+	// compute norm of D_projData
+
+	float s = dotProduct2D(D_projData, projPitch, dims.iProjDets, dims.iProjAngles);
+
+	return sqrt(s);
+}
+
+
+bool doTV(float* D_volumeData, unsigned int volumePitch,
+            float* D_sinoData, unsigned int sinoPitch,
+            float* D_maskData, unsigned int maskPitch,
+            const SDimensions& dims, const float* angles,
+            const float* TOffsets, unsigned int iterations)
+{
+	TV tv;
+	bool ok = true;
+
+	ok &= tv.setGeometry(dims, angles);
+	if (D_maskData)
+		ok &= tv.enableVolumeMask();
+	if (TOffsets)
+		ok &= tv.setTOffsets(TOffsets);
+
+	if (!ok)
+		return false;
+
+	ok = tv.init();
+	if (!ok)
+		return false;
+
+	if (D_maskData)
+		ok &= tv.setVolumeMask(D_maskData, maskPitch);
+
+	ok &= tv.setBuffers(D_volumeData, volumePitch, D_sinoData, sinoPitch);
+	if (!ok)
+		return false;
+
+	ok = tv.iterate(iterations);
+
+	return ok;
+}
+
+}
+
+#ifdef STANDALONE
+
+using namespace astraCUDA;
+
+int main()
+{
+	float* D_volumeData;
+	float* D_sinoData;
+
+	SDimensions dims;
+	dims.iVolWidth = 1024;
+	dims.iVolHeight = 1024;
+	dims.iProjAngles = 512;
+	dims.iProjDets = 1536;
+	dims.fDetScale = 1.0f;
+	dims.iRaysPerDet = 1;
+	unsigned int volumePitch, sinoPitch;
+
+	allocateVolume(D_volumeData, dims.iVolWidth, dims.iVolHeight, volumePitch);
+	zeroVolume(D_volumeData, volumePitch, dims.iVolWidth, dims.iVolHeight);
+	printf("pitch: %u\n", volumePitch);
+
+	allocateVolume(D_sinoData, dims.iProjDets, dims.iProjAngles, sinoPitch);
+	zeroVolume(D_sinoData, sinoPitch, dims.iProjDets, dims.iProjAngles);
+	printf("pitch: %u\n", sinoPitch);
+
+	unsigned int y, x;
+	float* sino = loadImage("sino.png", y, x);
+
+	float* img = new float[dims.iVolWidth*dims.iVolHeight];
+
+	copySinogramToDevice(sino, dims.iProjDets, dims.iProjDets, dims.iProjAngles, D_sinoData, sinoPitch);
+
+	float* angle = new float[dims.iProjAngles];
+
+	for (unsigned int i = 0; i < dims.iProjAngles; ++i)
+		angle[i] = i*(M_PI/dims.iProjAngles);
+
+	TV tv;
+
+	tv.setGeometry(dims, angle);
+	tv.init();
+
+	tv.setBuffers(D_volumeData, volumePitch, D_sinoData, sinoPitch);
+
+	tv.iterate(25);
+
+
+	delete[] angle;
+
+	copyVolumeFromDevice(img, dims.iVolWidth, dims, D_volumeData, volumePitch);
+
+	saveImage("vol.png",dims.iVolHeight,dims.iVolWidth,img);
+
+	return 0;
+}
+#endif
+

--- a/cuda/2d/tv.h
+++ b/cuda/2d/tv.h
@@ -53,24 +53,32 @@ public:
 
 	virtual bool iterate(unsigned int iterations);
 
+	// TODO: declare additional methods here
+
 	virtual float computeDiffNorm();
 
 protected:
 	void reset();
 
- 	// Temporary buffers
-	float* D_projData;
-	unsigned int projPitch;
-
-	float* D_tmpData;
+	// Slice-like buffers
+	float* D_x;
+	float* D_xTilde;
+	float* D_xold;
+	float* D_sliceTmp;
+	unsigned int xPitch;
+	unsigned int xtildePitch;
+	unsigned int xoldPitch;
 	unsigned int tmpPitch;
 
-	// Geometry-specific precomputed data
-	float* D_lineWeight;
-	unsigned int linePitch;
+	// Slice gradient-like buffers
+	float2* D_dualp;
+	unsigned int dualpPitch;
 
-	float* D_pixelWeight;
-	unsigned int pixelPitch;
+	// Sinogram-like buffers
+	float* D_dualq;
+	float* D_sinoTmp;
+	unsigned int dualqPitch;
+	unsigned int sinoTmpPitch;
 
 	// Masks
 	bool freeMinMaxMasks;
@@ -79,7 +87,12 @@ protected:
 	float* D_maxMaskData;
 	unsigned int maxMaskPitch;
 
-	float fRelaxation;
+	float fLambda; // fRelaxation in sirt
+
+	// Algorithm-related parameters
+	int nIterComputeNorm;
+	float normFactor;
+
 };
 
 bool doTV(float* D_volumeData, unsigned int volumePitch,

--- a/cuda/2d/tv.h
+++ b/cuda/2d/tv.h
@@ -52,10 +52,9 @@ public:
 
 	void setRegularization(float r) { fRegularization = r; }
 
-	virtual bool iterate(unsigned int iterations); // preconditioned
-	bool iterate_old(unsigned int iterations); // not preconditioned
-
-	// TODO: declare additional methods here
+	bool chambollepock(unsigned int iterations);
+	bool chambollepock_preconditioned(unsigned int iterations);
+	virtual bool iterate(unsigned int iterations);
 
 	virtual float computeDiffNorm();
 	bool projLinf(float* D_gradData, float* D_data, unsigned int pitch, float radius);

--- a/cuda/2d/tv.h
+++ b/cuda/2d/tv.h
@@ -52,7 +52,8 @@ public:
 
 	void setRegularization(float r) { fRegularization = r; }
 
-	virtual bool iterate(unsigned int iterations);
+	virtual bool iterate(unsigned int iterations); // preconditioned
+	bool iterate_old(unsigned int iterations); // not preconditioned
 
 	// TODO: declare additional methods here
 
@@ -60,6 +61,9 @@ public:
 	bool projLinf(float* D_gradData, float* D_data, unsigned int pitch, float radius);
 	bool gradientOperator(float* D_gradData, float* D_data, unsigned int pitch, float alpha, int doUpdate);
 	bool divergenceOperator(float* D_data, float* D_gradData, unsigned int pitch, float alpha, int doUpdate);
+	bool callUpdateDualq1(float* D_out, unsigned int outPitch, float* D_in1, unsigned int in1Pitch, float* D_in2, unsigned int in2Pitch);
+	bool callUpdateDualq2(float* D_out, unsigned int outPitch, float* D_in, unsigned int inPitch);
+	bool computeDiagonalPreconditioners();
 	bool signOperator(float* D_dst, float* D_src, unsigned int pitch, int nz);
 	float computeOperatorNorm();
 
@@ -67,30 +71,30 @@ protected:
 	void reset();
 
 	// Slice-like buffers
-	float* D_projData;
 	float* D_x;
 	float* D_xTilde;
 	float* D_xold;
-	float* D_sliceTmp;
-	float* D_gradTmp; //
-	float* D_gradTmp2; //
-	unsigned int projPitch;
+	float* D_tau;
+	float* D_sigma;
 	unsigned int xPitch;
 	unsigned int xtildePitch;
 	unsigned int xoldPitch;
-	unsigned int tmpPitch;
-	unsigned int gradTmpPitch;
-	unsigned int gradTmp2Pitch;
+	unsigned int tauPitch;
+	unsigned int sigmaPitch;
 
 	// Slice gradient-like buffers
 	float* D_dualp;
 	unsigned int dualpPitch;
+	float* D_gradTmp; //
+	float* D_gradTmp2; //
+	unsigned int gradTmpPitch;
+	unsigned int gradTmp2Pitch;
 
 	// Sinogram-like buffers
+	float* D_projData;
 	float* D_dualq;
-	float* D_sinoTmp;
+	unsigned int projPitch;
 	unsigned int dualqPitch;
-	unsigned int sinoTmpPitch;
 
 	// Masks
 	bool freeMinMaxMasks;
@@ -103,6 +107,9 @@ protected:
 	// Algorithm-related parameters
 	int nIterComputeNorm;
 	float normFactor;
+
+	// Misc.
+	SDimensions dimsGrad;
 };
 
 bool doTV(float* D_volumeData, unsigned int volumePitch,

--- a/cuda/2d/tv.h
+++ b/cuda/2d/tv.h
@@ -1,0 +1,93 @@
+/*
+-----------------------------------------------------------------------
+Copyright: 2010-2015, iMinds-Vision Lab, University of Antwerp
+           2014-2015, CWI, Amsterdam
+
+Contact: astra@uantwerpen.be
+Website: http://sf.net/projects/astra-toolbox
+
+This file is part of the ASTRA Toolbox.
+
+
+The ASTRA Toolbox is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The ASTRA Toolbox is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
+
+-----------------------------------------------------------------------
+$Id$
+*/
+
+#ifndef _CUDA_TV_H
+#define _CUDA_TV_H
+
+#include "util.h"
+#include "algo.h"
+
+namespace astraCUDA {
+
+class _AstraExport TV : public ReconAlgo {
+public:
+	TV();
+	~TV();
+
+	virtual bool init();
+
+	/*
+	// Set min/max masks to existing GPU memory buffers
+	bool setMinMaxMasks(float* D_minMaskData, float* D_maxMaskData,
+	                    unsigned int pitch);
+
+	// Set min/max masks from RAM buffers
+	bool uploadMinMaxMasks(const float* minMaskData, const float* maxMaskData,
+	                       unsigned int pitch);
+	*/
+
+	virtual bool iterate(unsigned int iterations);
+
+	virtual float computeDiffNorm();
+
+protected:
+	void reset();
+
+ 	// Temporary buffers
+	float* D_projData;
+	unsigned int projPitch;
+
+	float* D_tmpData;
+	unsigned int tmpPitch;
+
+	// Geometry-specific precomputed data
+	float* D_lineWeight;
+	unsigned int linePitch;
+
+	float* D_pixelWeight;
+	unsigned int pixelPitch;
+
+	// Masks
+	bool freeMinMaxMasks;
+	float* D_minMaskData;
+	unsigned int minMaskPitch;
+	float* D_maxMaskData;
+	unsigned int maxMaskPitch;
+
+	float fRelaxation;
+};
+
+bool doTV(float* D_volumeData, unsigned int volumePitch,
+            float* D_projData, unsigned int projPitch,
+            float* D_maskData, unsigned int maskPitch,
+            const SDimensions& dims, const float* angles,
+            const float* TOffsets, unsigned int iterations);
+
+}
+
+#endif

--- a/cuda/2d/tv.h
+++ b/cuda/2d/tv.h
@@ -57,9 +57,10 @@ public:
 	// TODO: declare additional methods here
 
 	virtual float computeDiffNorm();
-	bool projLinf(float* D_gradData, float* D_data, float radius);
-	bool gradientOperator(float* D_gradData, float* D_data, float alpha, int doUpdate);
-	bool divergenceOperator(float* D_data, float* D_gradData, float alpha, int doUpdate);
+	bool projLinf(float* D_gradData, float* D_data, unsigned int pitch, float radius);
+	bool gradientOperator(float* D_gradData, float* D_data, unsigned int pitch, float alpha, int doUpdate);
+	bool divergenceOperator(float* D_data, float* D_gradData, unsigned int pitch, float alpha, int doUpdate);
+	bool signOperator(float* D_dst, float* D_src, unsigned int pitch, int nz);
 	float computeOperatorNorm();
 
 protected:
@@ -71,11 +72,15 @@ protected:
 	float* D_xTilde;
 	float* D_xold;
 	float* D_sliceTmp;
+	float* D_gradTmp; //
+	float* D_gradTmp2; //
 	unsigned int projPitch;
 	unsigned int xPitch;
 	unsigned int xtildePitch;
 	unsigned int xoldPitch;
 	unsigned int tmpPitch;
+	unsigned int gradTmpPitch;
+	unsigned int gradTmp2Pitch;
 
 	// Slice gradient-like buffers
 	float* D_dualp;

--- a/include/astra/AlgorithmTypelist.h
+++ b/include/astra/AlgorithmTypelist.h
@@ -56,6 +56,7 @@ $Id$
 #include "CudaDartSmoothingAlgorithm3D.h"
 #include "CudaDataOperationAlgorithm.h"
 #include "CudaRoiSelectAlgorithm.h"
+#include "CudaTVAlgorithm.h"
 
 using namespace astra;
 
@@ -63,7 +64,7 @@ using namespace astra;
 
 #include "CudaFilteredBackProjectionAlgorithm.h"
 
-typedef TYPELIST_25(
+typedef TYPELIST_26(
 			CArtAlgorithm,
 			CSartAlgorithm,
 			CSirtAlgorithm,
@@ -88,7 +89,8 @@ typedef TYPELIST_25(
 			CCudaFDKAlgorithm3D,
 			CCudaSirtAlgorithm3D,
 			CCudaForwardProjectionAlgorithm3D,
-			CCudaBackProjectionAlgorithm3D
+			CCudaBackProjectionAlgorithm3D,
+			CCudaTVAlgorithm
 			)
 	AlgorithmTypeList;
 #else


### PR DESCRIPTION
This PR implements an iterative reconstruction with Total Variation regularization, using a preconditioned version of the Chambolle-Pock optimization algorithm.
It is implemented for the 2D case, only in CUDA.

I included this as a built-in reconstruction algorithm, so it can be used from Python and Matlab. For example, the sample script `s003_gpu_reconstruction.py` reconstructing the Shepp-Logan photom can be modified with
```python
cfg = astra.astra_dict('TV_CUDA')
cfg['option'] = {}
cfg['option']['Regularization'] = 0.03
```
The current version falls back to a non-preconditioned version of the CP algorithm if `iProjDets > iVolWidth`. This might be corrected if there is a way to determine the center of rotation inside TV.cu.