### PR TITLE
Add scripts for building conda packages using Docker

### DIFF
--- a/python/conda/bld.bat
+++ b/python/conda/bld.bat
@@ -1,0 +1,35 @@
+@echo off
+
+set R=%SRC_DIR%%
+
+set B_VC=C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64
+call "%B_VC%\vcvars64.bat"
+
+cd /D %R%
+
+set B_BV=1_61
+
+mkdir "%R%\lib\x64"
+mkdir "%R%\bin\x64\Release_CUDA"
+
+cd /D %CONDA_PREFIX%\Library\lib
+
+
+copy boost_unit_test_framework-vc140-mt-%B_BV%.lib %R%\lib\x64
+copy libboost_chrono-vc140-mt-%B_BV%.lib %R%\lib\x64
+copy libboost_date_time-vc140-mt-%B_BV%.lib %R%\lib\x64
+copy libboost_system-vc140-mt-%B_BV%.lib %R%\lib\x64
+copy libboost_thread-vc140-mt-%B_BV%.lib %R%\lib\x64
+
+cd /D %CONDA_PREFIX%\Library\include
+
+xcopy /i /e /q boost "%R%\lib\include\boost"
+
+cd /D %R%
+
+cd python
+
+set VS90COMNTOOLS=%VS140COMNTOOLS%
+set CL=/DASTRA_CUDA /DASTRA_PYTHON "/I%R%\include" "/I%R%\lib\include" "/I%CUDA_PATH%\include"
+copy %CONDA_PREFIX%\Library\lib\AstraCuda64.lib astra.lib
+python builder.py build_ext --compiler=msvc install

--- a/python/conda/libastra/bld.bat
+++ b/python/conda/libastra/bld.bat
@@ -1,0 +1,33 @@
+@echo off
+
+set B_VC=C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64
+
+call "%B_VC%\vcvars64.bat"
+
+set R=%SRC_DIR%
+set B_BV=1_61
+
+mkdir "%R%\lib\x64"
+mkdir "%R%\bin\x64\Release_CUDA"
+
+cd /D %CONDA_PREFIX%\Library\lib
+
+
+copy boost_unit_test_framework-vc140-mt-%B_BV%.lib %R%\lib\x64
+copy libboost_chrono-vc140-mt-%B_BV%.lib %R%\lib\x64
+copy libboost_date_time-vc140-mt-%B_BV%.lib %R%\lib\x64
+copy libboost_system-vc140-mt-%B_BV%.lib %R%\lib\x64
+copy libboost_thread-vc140-mt-%B_BV%.lib %R%\lib\x64
+
+cd /D %CONDA_PREFIX%\Library\include
+
+xcopy /i /e /q boost "%R%\lib\include\boost"
+
+cd /D %R%
+
+msbuild astra_vc14.sln /p:Configuration=Release_CUDA /p:Platform=x64 /t:astra_vc14
+
+copy bin\x64\Release_CUDA\AstraCuda64.dll "%CONDA_PREFIX%\Library\bin"
+copy bin\x64\Release_CUDA\AstraCuda64.lib "%CONDA_PREFIX%\Library\lib"
+copy "%CUDA_PATH%\bin\cudart64_80.dll" "%CONDA_PREFIX%\Library\bin"
+copy "%CUDA_PATH%\bin\cufft64_80.dll" "%CONDA_PREFIX%\Library\bin"

--- a/python/conda/libastra/meta.yaml
+++ b/python/conda/libastra/meta.yaml
@@ -10,13 +10,17 @@ source:
 build:
   number: 0
   script_env:
-    - CC
-    - CXX
-    - CUDA_ROOT
+    - CC # [not win]
+    - CXX # [not win]
+    - CUDA_ROOT # [not win]
 
 requirements:
   build:
-    - boost
+    - boost ==1.61 # [win]
+    - vs2015_runtime # [win]
+
+  run:
+    - vs2015_runtime # [win]
 
 about:
   home: http://www.astra-toolbox.com

--- a/python/conda/linux_release/README.txt
+++ b/python/conda/linux_release/README.txt
@@ -1,0 +1,2 @@
+This directory contains a Docker container based environment for building linux release packages for conda.
+

--- a/python/conda/linux_release/buildenv/Dockerfile
+++ b/python/conda/linux_release/buildenv/Dockerfile
@@ -1,0 +1,15 @@
+FROM debian:7
+ENV PATH /root/miniconda3/bin:$PATH
+ENV DEBIAN_FRONTEND noninteractive
+# http://developer.download.nvidia.com/compute/cuda/5_5/rel/installers/cuda_5.5.22_linux_64.run
+ADD cuda_5.5.22_linux_64.run /root/
+# https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh
+ADD Miniconda3-4.2.12-Linux-x86_64.sh /root/
+RUN apt-get update
+RUN apt-get install -y perl-modules build-essential autoconf libtool automake libboost-dev git
+RUN /bin/bash /root/Miniconda3-4.2.12-Linux-x86_64.sh -b
+RUN /bin/bash /root/cuda_5.5.22_linux_64.run -toolkit -silent
+RUN conda install -y conda-build
+ENV CUDA_ROOT /usr/local/cuda
+ENV CC gcc
+ENV CXX g++

--- a/python/conda/linux_release/builder/Dockerfile
+++ b/python/conda/linux_release/builder/Dockerfile
@@ -1,0 +1,8 @@
+FROM astra-build-env
+ARG BUILD_NUMBER=
+WORKDIR /root
+RUN git clone -b conda_release https://github.com/astra-toolbox/astra-toolbox
+RUN [ -z $BUILD_NUMBER ] || perl -pi -e "s/^(\s*number:\s*)[0-9]+$/\${1}$BUILD_NUMBER/" astra-toolbox/python/conda/libastra/meta.yaml astra-toolbox/python/conda//meta.yaml
+RUN conda-build --python=3.5 astra-toolbox/python/conda/libastra
+RUN conda-build --python=3.5 astra-toolbox/python/conda
+RUN conda-build --python=2.7 astra-toolbox/python/conda

--- a/python/conda/linux_release/release.sh
+++ b/python/conda/linux_release/release.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+D=`mktemp -d`
+
+[ -f buildenv/cuda_5.5.22_linux_64.run ] || (cd buildenv; wget http://developer.download.nvidia.com/compute/cuda/5_5/rel/installers/cuda_5.5.22_linux_64.run )
+[ -f buildenv/Miniconda3-4.2.12-Linux-x86_64.sh ] || (cd buildenv; wget https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh )
+
+docker build -t astra-build-env buildenv
+docker build --no-cache -t astra-builder builder
+
+docker run --name astra-build-cnt -v $D:/out:z astra-builder /bin/bash -c "cp /root/miniconda3/conda-bld/linux-64/*astra* /out"
+
+mkdir -p pkgs
+mv $D/* pkgs
+rmdir $D
+
+docker rm astra-build-cnt
+docker rmi astra-builder
+

--- a/python/conda/meta.yaml
+++ b/python/conda/meta.yaml
@@ -10,8 +10,8 @@ source:
 build:
   number: 0
   script_env:
-    - CC
-    - CUDA_ROOT
+    - CC # [not win]
+    - CUDA_ROOT # [not win]
 
 test:
   imports:
@@ -24,6 +24,7 @@ test:
 requirements:
   build:
     - python
+    - boost ==1.61 # [win]
     - cython >=0.13
     - nomkl # [not win]
     - numpy


### PR DESCRIPTION
This is a build environment based on Debian 7 + CUDA 5.5 that produces conda packages for libastra and astra-toolbox.

On the conda side, the only difference with the files in the `python/conda` directory is a run-time dependency on the cudatoolkit=5.5.1 conda package to avoid shipping the libraries ourselves.

Also included is a win-64 / py35 conda build recipe.