### PR TITLE
Reduce cuda 3d job sizes

### DIFF
--- a/cuda/3d/cone_bp.cu
+++ b/cuda/3d/cone_bp.cu
@@ -49,7 +49,7 @@ namespace astraCUDA3d {
 #define ZSIZE 6
 static const unsigned int g_volBlockZ = ZSIZE;
 
-static const unsigned int g_anglesPerBlock = 32;
+static const unsigned int g_anglesPerBlock = 4;
 static const unsigned int g_volBlockX = 16;
 static const unsigned int g_volBlockY = 32;
 

--- a/cuda/3d/cone_fp.cu
+++ b/cuda/3d/cone_fp.cu
@@ -48,7 +48,7 @@ namespace astraCUDA3d {
 static const unsigned int g_anglesPerBlock = 4;
 
 // thickness of the slices we're splitting the volume up into
-static const unsigned int g_blockSlices = 32;
+static const unsigned int g_blockSlices = 8;
 static const unsigned int g_detBlockU = 32;
 static const unsigned int g_detBlockV = 32;
 

--- a/cuda/3d/par3d_bp.cu
+++ b/cuda/3d/par3d_bp.cu
@@ -49,7 +49,7 @@ namespace astraCUDA3d {
 #define ZSIZE 6
 static const unsigned int g_volBlockZ = ZSIZE;
 
-static const unsigned int g_anglesPerBlock = 32;
+static const unsigned int g_anglesPerBlock = 4;
 static const unsigned int g_volBlockX = 16;
 static const unsigned int g_volBlockY = 32;
 

--- a/cuda/3d/par3d_fp.cu
+++ b/cuda/3d/par3d_fp.cu
@@ -48,7 +48,7 @@ namespace astraCUDA3d {
 static const unsigned int g_anglesPerBlock = 4;
 
 // thickness of the slices we're splitting the volume up into
-static const unsigned int g_blockSlices = 32;
+static const unsigned int g_blockSlices = 8;
 static const unsigned int g_detBlockU = 32;
 static const unsigned int g_detBlockV = 32;
 


### PR DESCRIPTION
This is to accomodate the Windows graphics watchdog timer. There
doesn't seem to be any significant performance reduction from this.