### PR TITLE
Expose the density weighting option of cone_bp

### DIFF
--- a/cuda/3d/mem3d.cu
+++ b/cuda/3d/mem3d.cu
@@ -249,7 +249,7 @@ bool FP(const astra::CProjectionGeometry3D* pProjGeom, MemHandle3D projData, con
 	return ok;
 }
 
-bool BP(const astra::CProjectionGeometry3D* pProjGeom, MemHandle3D projData, const astra::CVolumeGeometry3D* pVolGeom, MemHandle3D volData, int iVoxelSuperSampling)
+bool BP(const astra::CProjectionGeometry3D* pProjGeom, MemHandle3D projData, const astra::CVolumeGeometry3D* pVolGeom, MemHandle3D volData, int iVoxelSuperSampling, bool bFDKWeighting)
 {
 	SDimensions3D dims;
 	SProjectorParams3D params;
@@ -268,6 +268,8 @@ bool BP(const astra::CProjectionGeometry3D* pProjGeom, MemHandle3D projData, con
 	ok = convertAstraGeometry(pVolGeom, pProjGeom,
 	                          pParProjs, pConeProjs,
 	                          params);
+
+	params.bFDKWeighting = bFDKWeighting;
 
 	if (pParProjs)
 		ok &= Par3DBP(volData.d->ptr, projData.d->ptr, dims, pParProjs, params);

--- a/cuda/3d/mem3d.h
+++ b/cuda/3d/mem3d.h
@@ -93,7 +93,7 @@ bool setGPUIndex(int index);
 
 bool FP(const astra::CProjectionGeometry3D* pProjGeom, MemHandle3D projData, const astra::CVolumeGeometry3D* pVolGeom, MemHandle3D volData, int iDetectorSuperSampling, astra::Cuda3DProjectionKernel projKernel);
 
-bool BP(const astra::CProjectionGeometry3D* pProjGeom, MemHandle3D projData, const astra::CVolumeGeometry3D* pVolGeom, MemHandle3D volData, int iVoxelSuperSampling);
+bool BP(const astra::CProjectionGeometry3D* pProjGeom, MemHandle3D projData, const astra::CVolumeGeometry3D* pVolGeom, MemHandle3D volData, int iVoxelSuperSampling, bool bFDKWeighting);
 
 bool FDK(const astra::CProjectionGeometry3D* pProjGeom, MemHandle3D projData, const astra::CVolumeGeometry3D* pVolGeom, MemHandle3D volData, bool bShortScan, const float *pfFilter = 0);
 

--- a/include/astra/CudaProjector3D.h
+++ b/include/astra/CudaProjector3D.h
@@ -117,6 +117,7 @@ public:
 	int getVoxelSuperSampling() const { return m_iVoxelSuperSampling; }
 	int getDetectorSuperSampling() const { return m_iDetectorSuperSampling; }
 	int getGPUIndex() const { return m_iGPUIndex; }
+	bool getDensityWeighting() const { return m_bDensityWeighting; }
 
 protected:
 
@@ -124,6 +125,7 @@ protected:
 	int m_iVoxelSuperSampling;
 	int m_iDetectorSuperSampling;
 	int m_iGPUIndex;
+	bool m_bDensityWeighting;
 
 };
 

--- a/src/CompositeGeometryManager.cpp
+++ b/src/CompositeGeometryManager.cpp
@@ -1228,10 +1228,12 @@ static bool doJob(const CCompositeGeometryManager::TJobSet::const_iterator& iter
 		Cuda3DProjectionKernel projKernel = ker3d_default;
 		int detectorSuperSampling = 1;
 		int voxelSuperSampling = 1;
+		bool densityWeighting = false;
 		if (projector) {
 			projKernel = projector->getProjectionKernel();
 			detectorSuperSampling = projector->getDetectorSuperSampling();
 			voxelSuperSampling = projector->getVoxelSuperSampling();
+			densityWeighting = projector->getDensityWeighting();
 		}
 
 		size_t inx, iny, inz;
@@ -1274,7 +1276,7 @@ static bool doJob(const CCompositeGeometryManager::TJobSet::const_iterator& iter
 
 			ASTRA_DEBUG("CCompositeGeometryManager::doJobs: doing BP");
 
-			ok = astraCUDA3d::BP(((CCompositeGeometryManager::CProjectionPart*)j.pInput.get())->pGeom, inputMem, ((CCompositeGeometryManager::CVolumePart*)j.pOutput.get())->pGeom, outputMem, voxelSuperSampling);
+			ok = astraCUDA3d::BP(((CCompositeGeometryManager::CProjectionPart*)j.pInput.get())->pGeom, inputMem, ((CCompositeGeometryManager::CVolumePart*)j.pOutput.get())->pGeom, outputMem, voxelSuperSampling, densityWeighting);
 			if (!ok) ASTRA_ERROR("Error performing sub-BP");
 			ASTRA_DEBUG("CCompositeGeometryManager::doJobs: BP done");
 		}

--- a/src/CudaProjector3D.cpp
+++ b/src/CudaProjector3D.cpp
@@ -30,6 +30,9 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 #include "astra/VolumeGeometry3D.h"
 #include "astra/ProjectionGeometry3D.h"
 
+#include "astra/ConeProjectionGeometry3D.h"
+#include "astra/ConeVecProjectionGeometry3D.h"
+
 
 namespace astra
 {
@@ -64,6 +67,7 @@ void CCudaProjector3D::_clear()
 	m_iVoxelSuperSampling = 1;
 	m_iDetectorSuperSampling = 1;
 	m_iGPUIndex = -1;
+	m_bDensityWeighting = false;
 }
 
 //----------------------------------------------------------------------------------------
@@ -127,6 +131,13 @@ bool CCudaProjector3D::initialize(const Config& _cfg)
  
 	m_iDetectorSuperSampling = (int)_cfg.self.getOptionNumerical("DetectorSuperSampling", 1);
 	CC.markOptionParsed("DetectorSuperSampling");
+
+	if (dynamic_cast<CConeProjectionGeometry3D*>(m_pProjectionGeometry) ||
+	    dynamic_cast<CConeVecProjectionGeometry3D*>(m_pProjectionGeometry))
+	{
+		m_bDensityWeighting = _cfg.self.getOptionBool("DensityWeighting", false);
+		CC.markOptionParsed("DensityWeighting");
+	}
 
 	m_iGPUIndex = (int)_cfg.self.getOptionNumerical("GPUindex", -1);
 	m_iGPUIndex = (int)_cfg.self.getOptionNumerical("GPUIndex", m_iGPUIndex);


### PR DESCRIPTION
It is now exposed via the new DensityWeighting option of CudaProjector3D. This is a bit ugly, and will probably disappear in astra-2.0 in favour of a cleaner alternative, but this lets you use the 1/r^2 factor in cone_bp, as long as the source-origin distance is constant.

Quick'n'dirty way to get it in ODL:

In `astra_setup.astra_projector` add this option to `proj_cfg`:

        if proj_type == 'cone' or proj_type == 'cone_vec':
        astra_ver_num = astra.astra.version()
        astra_version = '.'.join([str(astra_ver_num // 100),
                                  str(astra_ver_num % 100)])
        if parse_version(astra_version) >= parse_version('1.8'):
            proj_cfg['options'] = { 'DensityWeighting': True }

In `astra_cuda.astra_cuda_back_projector` add an extra scaling factor in cone/helical (relative to branch issue-724__astra_scaling_fixed):

    scaling_factor *= (src_radius ** 2) * (geometry.det_partition.cell_volume ** 2) / (reco_space.cell_volume ** 2) 

