### PR TITLE
Use specific numpy version in conda package

### DIFF
--- a/python/conda/linux_release/builder/Dockerfile
+++ b/python/conda/linux_release/builder/Dockerfile
@@ -1,8 +1,13 @@
 FROM astra-build-env
 ARG BUILD_NUMBER=
 WORKDIR /root
-RUN git clone -b master https://github.com/astra-toolbox/astra-toolbox
-RUN [ -z $BUILD_NUMBER ] || perl -pi -e "s/^(\s*number:\s*)[0-9]+$/\${1}$BUILD_NUMBER/" astra-toolbox/python/conda/libastra/meta.yaml astra-toolbox/python/conda//meta.yaml
+RUN git clone --depth 1 https://github.com/astra-toolbox/astra-toolbox
+RUN [ -z $BUILD_NUMBER ] || perl -pi -e "s/^(\s*number:\s*)[0-9]+$/\${1}$BUILD_NUMBER/" astra-toolbox/python/conda/libastra/meta.yaml astra-toolbox/python/conda/meta.yaml
 RUN conda-build --python=3.5 astra-toolbox/python/conda/libastra
-RUN conda-build --python=3.5 astra-toolbox/python/conda
-RUN conda-build --python=2.7 astra-toolbox/python/conda
+RUN conda-build --python 2.7 --numpy 1.8 astra-toolbox/python/conda
+RUN conda-build --python 2.7 --numpy 1.9 astra-toolbox/python/conda
+RUN conda-build --python 2.7 --numpy 1.10 astra-toolbox/python/conda
+RUN conda-build --python 2.7 --numpy 1.11 astra-toolbox/python/conda
+RUN conda-build --python 3.5 --numpy 1.9 astra-toolbox/python/conda
+RUN conda-build --python 3.5 --numpy 1.10 astra-toolbox/python/conda
+RUN conda-build --python 3.5 --numpy 1.11 astra-toolbox/python/conda

--- a/python/conda/linux_release/release.sh
+++ b/python/conda/linux_release/release.sh
@@ -6,6 +6,7 @@ D=`mktemp -d`
 [ -f buildenv/Miniconda3-4.2.12-Linux-x86_64.sh ] || (cd buildenv; wget https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh )
 
 docker build -t astra-build-env buildenv
+#docker build --no-cache --build-arg=BUILD_NUMBER=0 -t astra-builder builder
 docker build --no-cache -t astra-builder builder
 
 docker run --name astra-build-cnt -v $D:/out:z astra-builder /bin/bash -c "cp /root/miniconda3/conda-bld/linux-64/*astra* /out"

--- a/python/conda/meta.yaml
+++ b/python/conda/meta.yaml
@@ -33,7 +33,7 @@ requirements:
 
   run:
     - python
-    - numpy
+    - numpy x.x
     - scipy
     - six
     - libastra ==1.8


### PR DESCRIPTION
Current conda packages of ASTRA do not specify the numpy version that they were built with. Since we link to specific versions of numpy, the current packages will probably not work when using a different numpy version than the one it was compiled with.

This PR fixes this problem by using `numpy x.x` in the `meta.yaml` file (see [here](http://conda.pydata.org/docs/building/meta-yaml.html)). This requires the `conda-build` call to supply the numpy version to build with on the command line (e.g., `--numpy 1.11`).