### PR TITLE
Fix FDK reconstruction with ShortScan option

### DIFF
--- a/cuda/3d/fdk.cu
+++ b/cuda/3d/fdk.cu
@@ -136,13 +136,13 @@ __global__ void devFDK_ParkerWeight(void* D_projData, unsigned int projPitch, un
 
 	if (fBeta <= 0.0f) {
 		fWeight = 0.0f;
-	} else if (fBeta <= 2.0f*(fCentralFanAngle + fGamma)) {
-		fWeight = sinf((M_PI / 4.0f) * fBeta / (fCentralFanAngle + fGamma));
+	} else if (fBeta <= 2.0f*(fCentralFanAngle - fGamma)) {
+		fWeight = sinf((M_PI / 4.0f) * fBeta / (fCentralFanAngle - fGamma));
 		fWeight *= fWeight;
-	} else if (fBeta <= M_PI + 2*fGamma) {
+	} else if (fBeta <= M_PI - 2.0f*fGamma) {
 		fWeight = 1.0f;
-	} else if (fBeta <= M_PI + 2*fCentralFanAngle) {
-		fWeight = sinf((M_PI / 4.0f) * (M_PI + 2.0f*fCentralFanAngle - fBeta) / (fCentralFanAngle - fGamma));
+	} else if (fBeta <= M_PI + 2.0f*fCentralFanAngle) {
+		fWeight = sinf((M_PI / 4.0f) * (M_PI + 2.0f*fCentralFanAngle - fBeta) / (fCentralFanAngle + fGamma));
 		fWeight *= fWeight;
 	} else {
 		fWeight = 0.0f;


### PR DESCRIPTION
This PR fix issues with FDK reconstruction with ShortScan option. 

Without this changes our reconstruction of asymmetric objects in fanflat and cone geometry using FBP_CUDA and FDK_CUDA algorithms was terrible

![old](https://cloud.githubusercontent.com/assets/954295/21779308/21a10246-d6b8-11e6-8728-537732d8966b.png)

and after this patch quality is significantly improved

![new](https://cloud.githubusercontent.com/assets/954295/21779334/3d54b118-d6b8-11e6-8171-4fe8b15de8b5.png)
