### PR TITLE
Limit cuda runtime to avoid Windows display watchdog timeouts

### DIFF
--- a/cuda/3d/cone_bp.cu
+++ b/cuda/3d/cone_bp.cu
@@ -78,7 +78,7 @@ bool bindProjDataTexture(const cudaArray* array)
 //__launch_bounds__(32*16, 4)
 template<bool FDKWEIGHT>
 __global__ void dev_cone_BP(void* D_volData, unsigned int volPitch, int startAngle,
-                            int angleOffset, const astraCUDA3d::SDimensions3D dims,
+                            int angleOffset, int startZ, const astraCUDA3d::SDimensions3D dims,
                             float fOutputScale)
 {
 	float* volData = (float*)D_volData;
@@ -103,7 +103,10 @@ __global__ void dev_cone_BP(void* D_volData, unsigned int volPitch, int startAng
 	if (Y >= dims.iVolY)
 		return;
 
-	const int startZ = blockIdx.y * g_volBlockZ;
+	startZ += blockIdx.y * g_volBlockZ;
+	if (startZ >= dims.iVolZ)
+		return;
+
 	const float fX = X - 0.5f*dims.iVolX + 0.5f;
 	const float fY = Y - 0.5f*dims.iVolY + 0.5f;
 	const float fZ = startZ - 0.5f*dims.iVolZ + 0.5f;
@@ -147,8 +150,8 @@ __global__ void dev_cone_BP(void* D_volData, unsigned int volPitch, int startAng
 	}
 
 	int endZ = ZSIZE;
-	if (endZ > dims.iVolZ - startZ)
-		endZ = dims.iVolZ - startZ;
+	if (endZ > (int)dims.iVolZ - startZ)
+		endZ = (int)dims.iVolZ - startZ;
 
 	for(int i=0; i < endZ; i++)
 		volData[((startZ+i)*dims.iVolY+Y)*volPitch+X] += Z[i] * fOutputScale;
@@ -157,7 +160,7 @@ __global__ void dev_cone_BP(void* D_volData, unsigned int volPitch, int startAng
 
 
 // supersampling version
-__global__ void dev_cone_BP_SS(void* D_volData, unsigned int volPitch, int startAngle, int angleOffset, const SDimensions3D dims, int iRaysPerVoxelDim, float fOutputScale)
+__global__ void dev_cone_BP_SS(void* D_volData, unsigned int volPitch, int startAngle, int angleOffset, int startZ, const SDimensions3D dims, int iRaysPerVoxelDim, float fOutputScale)
 {
 	float* volData = (float*)D_volData;
 
@@ -183,7 +186,10 @@ __global__ void dev_cone_BP_SS(void* D_volData, unsigned int volPitch, int start
 	if (Y >= dims.iVolY)
 		return;
 
-	const int startZ = blockIdx.y * g_volBlockZ;
+	startZ += blockIdx.y * g_volBlockZ;
+	if (startZ >= dims.iVolZ)
+		return;
+
 	int endZ = startZ + g_volBlockZ;
 	if (endZ > dims.iVolZ)
 		endZ = dims.iVolZ;
@@ -293,19 +299,22 @@ bool ConeBP_Array(cudaPitchedPtr D_volumeData,
 
 		dim3 dimBlock(g_volBlockX, g_volBlockY);
 
-		dim3 dimGrid(((dims.iVolX/1+g_volBlockX-1)/(g_volBlockX))*((dims.iVolY/1+1*g_volBlockY-1)/(1*g_volBlockY)), (dims.iVolZ+g_volBlockZ-1)/g_volBlockZ);
+		dim3 dimGrid(((dims.iVolX/1+g_volBlockX-1)/(g_volBlockX))*((dims.iVolY/1+1*g_volBlockY-1)/(1*g_volBlockY)), 8);
 
 		// timeval t;
 		// tic(t);
 
 		for (unsigned int i = 0; i < angleCount; i += g_anglesPerBlock) {
+		for (unsigned int startZ = 0; startZ < dims.iVolZ; startZ += 8*g_volBlockZ) {
+
 		// printf("Calling BP: %d, %dx%d, %dx%d to %p\n", i, dimBlock.x, dimBlock.y, dimGrid.x, dimGrid.y, (void*)D_volumeData.ptr); 
 			if (params.bFDKWeighting)
-				dev_cone_BP<true><<<dimGrid, dimBlock>>>(D_volumeData.ptr, D_volumeData.pitch/sizeof(float), i, th, dims, fOutputScale);
+				dev_cone_BP<true><<<dimGrid, dimBlock>>>(D_volumeData.ptr, D_volumeData.pitch/sizeof(float), i, th, startZ, dims, fOutputScale);
 			else if (params.iRaysPerVoxelDim == 1)
-				dev_cone_BP<false><<<dimGrid, dimBlock>>>(D_volumeData.ptr, D_volumeData.pitch/sizeof(float), i, th, dims, fOutputScale);
+				dev_cone_BP<false><<<dimGrid, dimBlock>>>(D_volumeData.ptr, D_volumeData.pitch/sizeof(float), i, th, startZ, dims, fOutputScale);
 			else
-				dev_cone_BP_SS<<<dimGrid, dimBlock>>>(D_volumeData.ptr, D_volumeData.pitch/sizeof(float), i, th, dims, params.iRaysPerVoxelDim, fOutputScale);
+				dev_cone_BP_SS<<<dimGrid, dimBlock>>>(D_volumeData.ptr, D_volumeData.pitch/sizeof(float), i, th, startZ, dims, params.iRaysPerVoxelDim, fOutputScale);
+		}
 		}
 
 		cudaTextForceKernelsCompletion();

--- a/cuda/3d/cone_fp.cu
+++ b/cuda/3d/cone_fp.cu
@@ -67,6 +67,11 @@ __constant__ float gC_DetVY[g_MaxAngles];
 __constant__ float gC_DetVZ[g_MaxAngles];
 
 
+// startAngle, endAngle, startDetectorV
+__constant__ int gC_params[3];
+
+
+
 bool bindVolumeDataTexture(const cudaArray* array)
 {
 	cudaChannelFormatDesc channelDesc = cudaCreateChannelDesc<float>();
@@ -149,14 +154,13 @@ struct SCALE_NONCUBE {
 template<class COORD, class SCALE>
 __global__ void cone_FP_t(float* D_projData, unsigned int projPitch,
                           unsigned int startSlice,
-                          unsigned int startAngle, unsigned int endAngle,
                           const SDimensions3D dims,
                           SCALE sc)
 {
 	COORD c;
 
-	int angle = startAngle + blockIdx.y * g_anglesPerBlock + threadIdx.y;
-	if (angle >= endAngle)
+	int angle = gC_params[0] + blockIdx.y * g_anglesPerBlock + threadIdx.y;
+	if (angle >= gC_params[1])
 		return;
 
 	const float fSrcX = gC_SrcX[angle];
@@ -172,8 +176,8 @@ __global__ void cone_FP_t(float* D_projData, unsigned int projPitch,
 	const float fDetSY = gC_DetSY[angle] + 0.5f * fDetUY + 0.5f * fDetVY;
 	const float fDetSZ = gC_DetSZ[angle] + 0.5f * fDetUZ + 0.5f * fDetVZ;
 
-	const int detectorU = (blockIdx.x%((dims.iProjU+g_detBlockU-1)/g_detBlockU)) * g_detBlockU + threadIdx.x;
-	const int startDetectorV = (blockIdx.x/((dims.iProjU+g_detBlockU-1)/g_detBlockU)) * g_detBlockV;
+	const int detectorU = blockIdx.x * g_detBlockU + threadIdx.x;
+	const int startDetectorV = gC_params[2];
 	int endDetectorV = startDetectorV + g_detBlockV;
 	if (endDetectorV > dims.iProjV)
 		endDetectorV = dims.iProjV;
@@ -225,14 +229,13 @@ __global__ void cone_FP_t(float* D_projData, unsigned int projPitch,
 template<class COORD>
 __global__ void cone_FP_SS_t(float* D_projData, unsigned int projPitch,
                              unsigned int startSlice,
-                             unsigned int startAngle, unsigned int endAngle,
                              const SDimensions3D dims, int iRaysPerDetDim,
                              SCALE_NONCUBE sc)
 {
 	COORD c;
 
-	int angle = startAngle + blockIdx.y * g_anglesPerBlock + threadIdx.y;
-	if (angle >= endAngle)
+	int angle = gC_params[0] + blockIdx.y * g_anglesPerBlock + threadIdx.y;
+	if (angle >= gC_params[1])
 		return;
 
 	const float fSrcX = gC_SrcX[angle];
@@ -248,8 +251,8 @@ __global__ void cone_FP_SS_t(float* D_projData, unsigned int projPitch,
 	const float fDetSY = gC_DetSY[angle] + 0.5f * fDetUY + 0.5f * fDetVY;
 	const float fDetSZ = gC_DetSZ[angle] + 0.5f * fDetUZ + 0.5f * fDetVZ;
 
-	const int detectorU = (blockIdx.x%((dims.iProjU+g_detBlockU-1)/g_detBlockU)) * g_detBlockU + threadIdx.x;
-	const int startDetectorV = (blockIdx.x/((dims.iProjU+g_detBlockU-1)/g_detBlockU)) * g_detBlockV;
+	const int detectorU = blockIdx.x * g_detBlockU + threadIdx.x;
+	const int startDetectorV = gC_params[2];
 	int endDetectorV = startDetectorV + g_detBlockV;
 	if (endDetectorV > dims.iProjV)
 		endDetectorV = dims.iProjV;
@@ -404,7 +407,7 @@ bool ConeFP_Array_internal(cudaPitchedPtr D_projData,
 			if (blockStart != blockEnd) {
 
 				dim3 dimGrid(
-				             ((dims.iProjU+g_detBlockU-1)/g_detBlockU)*((dims.iProjV+g_detBlockV-1)/g_detBlockV),
+				             ((dims.iProjU+g_detBlockU-1)/g_detBlockU),
 (blockEnd-blockStart+g_anglesPerBlock-1)/g_anglesPerBlock);
 				// TODO: check if we can't immediately
 				//       destroy the stream after use
@@ -414,35 +417,38 @@ bool ConeFP_Array_internal(cudaPitchedPtr D_projData,
 
 				// printf("angle block: %d to %d, %d (%dx%d, %dx%d)\n", blockStart, blockEnd, blockDirection, dimGrid.x, dimGrid.y, dimBlock.x, dimBlock.y);
 
-				if (blockDirection == 0) {
-					for (unsigned int i = 0; i < dims.iVolX; i += g_blockSlices)
-						if (params.iRaysPerDetDim == 1)
-							if (cube)
-								cone_FP_t<DIR_X><<<dimGrid, dimBlock, 0, stream>>>((float*)D_projData.ptr, D_projData.pitch/sizeof(float), i, blockStart, blockEnd, dims, scube);
+				for (unsigned int startDetectorV = 0; startDetectorV < dims.iProjV; startDetectorV += g_detBlockV) {
+					int p[3] = { (int)blockStart, (int)blockEnd, (int)startDetectorV };
+					cudaMemcpyToSymbol(gC_params, p, 3*sizeof(int), 0, cudaMemcpyHostToDevice);
+					if (blockDirection == 0) {
+						for (unsigned int i = 0; i < dims.iVolX; i += g_blockSlices)
+							if (params.iRaysPerDetDim == 1)
+								if (cube)
+									cone_FP_t<DIR_X><<<dimGrid, dimBlock, 0, stream>>>((float*)D_projData.ptr, D_projData.pitch/sizeof(float), i, dims, scube);
+								else
+									cone_FP_t<DIR_X><<<dimGrid, dimBlock, 0, stream>>>((float*)D_projData.ptr, D_projData.pitch/sizeof(float), i, dims, snoncubeX);
 							else
-								cone_FP_t<DIR_X><<<dimGrid, dimBlock, 0, stream>>>((float*)D_projData.ptr, D_projData.pitch/sizeof(float), i, blockStart, blockEnd, dims, snoncubeX);
-						else
-							cone_FP_SS_t<DIR_X><<<dimGrid, dimBlock, 0, stream>>>((float*)D_projData.ptr, D_projData.pitch/sizeof(float), i, blockStart, blockEnd, dims, params.iRaysPerDetDim, snoncubeX);
-				} else if (blockDirection == 1) {
-					for (unsigned int i = 0; i < dims.iVolY; i += g_blockSlices)
-						if (params.iRaysPerDetDim == 1)
-							if (cube)
-								cone_FP_t<DIR_Y><<<dimGrid, dimBlock, 0, stream>>>((float*)D_projData.ptr, D_projData.pitch/sizeof(float), i, blockStart, blockEnd, dims, scube);
+								cone_FP_SS_t<DIR_X><<<dimGrid, dimBlock, 0, stream>>>((float*)D_projData.ptr, D_projData.pitch/sizeof(float), i, dims, params.iRaysPerDetDim, snoncubeX);
+					} else if (blockDirection == 1) {
+						for (unsigned int i = 0; i < dims.iVolY; i += g_blockSlices)
+							if (params.iRaysPerDetDim == 1)
+								if (cube)
+									cone_FP_t<DIR_Y><<<dimGrid, dimBlock, 0, stream>>>((float*)D_projData.ptr, D_projData.pitch/sizeof(float), i, dims, scube);
+								else
+									cone_FP_t<DIR_Y><<<dimGrid, dimBlock, 0, stream>>>((float*)D_projData.ptr, D_projData.pitch/sizeof(float), i, dims, snoncubeY);
 							else
-								cone_FP_t<DIR_Y><<<dimGrid, dimBlock, 0, stream>>>((float*)D_projData.ptr, D_projData.pitch/sizeof(float), i, blockStart, blockEnd, dims, snoncubeY);
-						else
-							cone_FP_SS_t<DIR_Y><<<dimGrid, dimBlock, 0, stream>>>((float*)D_projData.ptr, D_projData.pitch/sizeof(float), i, blockStart, blockEnd, dims, params.iRaysPerDetDim, snoncubeY);
-				} else if (blockDirection == 2) {
-					for (unsigned int i = 0; i < dims.iVolZ; i += g_blockSlices)
-						if (params.iRaysPerDetDim == 1)
-							if (cube)
-								cone_FP_t<DIR_Z><<<dimGrid, dimBlock, 0, stream>>>((float*)D_projData.ptr, D_projData.pitch/sizeof(float), i, blockStart, blockEnd, dims, scube);
+								cone_FP_SS_t<DIR_Y><<<dimGrid, dimBlock, 0, stream>>>((float*)D_projData.ptr, D_projData.pitch/sizeof(float), i, dims, params.iRaysPerDetDim, snoncubeY);
+					} else if (blockDirection == 2) {
+						for (unsigned int i = 0; i < dims.iVolZ; i += g_blockSlices)
+							if (params.iRaysPerDetDim == 1)
+								if (cube)
+									cone_FP_t<DIR_Z><<<dimGrid, dimBlock, 0, stream>>>((float*)D_projData.ptr, D_projData.pitch/sizeof(float), i, dims, scube);
+								else
+									cone_FP_t<DIR_Z><<<dimGrid, dimBlock, 0, stream>>>((float*)D_projData.ptr, D_projData.pitch/sizeof(float), i, dims, snoncubeZ);
 							else
-								cone_FP_t<DIR_Z><<<dimGrid, dimBlock, 0, stream>>>((float*)D_projData.ptr, D_projData.pitch/sizeof(float), i, blockStart, blockEnd, dims, snoncubeZ);
-						else
-							cone_FP_SS_t<DIR_Z><<<dimGrid, dimBlock, 0, stream>>>((float*)D_projData.ptr, D_projData.pitch/sizeof(float), i, blockStart, blockEnd, dims, params.iRaysPerDetDim, snoncubeZ);
+								cone_FP_SS_t<DIR_Z><<<dimGrid, dimBlock, 0, stream>>>((float*)D_projData.ptr, D_projData.pitch/sizeof(float), i, dims, params.iRaysPerDetDim, snoncubeZ);
+					}
 				}
-
 			}
 
 			blockDirection = dir;

--- a/cuda/3d/par3d_bp.cu
+++ b/cuda/3d/par3d_bp.cu
@@ -76,7 +76,7 @@ static bool bindProjDataTexture(const cudaArray* array)
 }
 
 
-__global__ void dev_par3D_BP(void* D_volData, unsigned int volPitch, int startAngle, int angleOffset, const SDimensions3D dims, float fOutputScale)
+__global__ void dev_par3D_BP(void* D_volData, unsigned int volPitch, int startAngle, int angleOffset, int startZ, const SDimensions3D dims, float fOutputScale)
 {
 	float* volData = (float*)D_volData;
 
@@ -99,7 +99,9 @@ __global__ void dev_par3D_BP(void* D_volData, unsigned int volPitch, int startAn
 	if (Y >= dims.iVolY)
 		return;
 
-	const int startZ = blockIdx.y * g_volBlockZ;
+	startZ += blockIdx.y * ZSIZE;
+	if (startZ >= dims.iVolZ)
+		return;
 
 	float fX = X - 0.5f*dims.iVolX + 0.5f;
 	float fY = Y - 0.5f*dims.iVolY + 0.5f;
@@ -134,15 +136,15 @@ __global__ void dev_par3D_BP(void* D_volData, unsigned int volPitch, int startAn
 	}
 
 	int endZ = ZSIZE;
-	if (endZ > dims.iVolZ - startZ)
-		endZ = dims.iVolZ - startZ;
+	if (endZ > (int)dims.iVolZ - startZ)
+		endZ = (int)dims.iVolZ - startZ;
 
 	for(int i=0; i < endZ; i++)
 		volData[((startZ+i)*dims.iVolY+Y)*volPitch+X] += Z[i] * fOutputScale;
 }
 
 // supersampling version
-__global__ void dev_par3D_BP_SS(void* D_volData, unsigned int volPitch, int startAngle, int angleOffset, const SDimensions3D dims, int iRaysPerVoxelDim, float fOutputScale)
+__global__ void dev_par3D_BP_SS(void* D_volData, unsigned int volPitch, int startAngle, int angleOffset, int startZ, const SDimensions3D dims, int iRaysPerVoxelDim, float fOutputScale)
 {
 	float* volData = (float*)D_volData;
 
@@ -168,7 +170,10 @@ __global__ void dev_par3D_BP_SS(void* D_volData, unsigned int volPitch, int star
 	if (Y >= dims.iVolY)
 		return;
 
-	const int startZ = blockIdx.y * g_volBlockZ;
+	startZ += blockIdx.y * g_volBlockZ;
+	if (startZ >= dims.iVolZ)
+		return;	
+
 	int endZ = startZ + g_volBlockZ;
 	if (endZ > dims.iVolZ)
 		endZ = dims.iVolZ;
@@ -268,17 +273,19 @@ bool Par3DBP_Array(cudaPitchedPtr D_volumeData,
 
 		dim3 dimBlock(g_volBlockX, g_volBlockY);
 
-		dim3 dimGrid(((dims.iVolX+g_volBlockX-1)/g_volBlockX)*((dims.iVolY+g_volBlockY-1)/g_volBlockY), (dims.iVolZ+g_volBlockZ-1)/g_volBlockZ);
+		dim3 dimGrid(((dims.iVolX+g_volBlockX-1)/g_volBlockX)*((dims.iVolY+g_volBlockY-1)/g_volBlockY), 8);
 
 		// timeval t;
 		// tic(t);
 
 		for (unsigned int i = 0; i < angleCount; i += g_anglesPerBlock) {
-			// printf("Calling BP: %d, %dx%d, %dx%d to %p\n", i, dimBlock.x, dimBlock.y, dimGrid.x, dimGrid.y, (void*)D_volumeData.ptr); 
-			if (params.iRaysPerVoxelDim == 1)
-				dev_par3D_BP<<<dimGrid, dimBlock>>>(D_volumeData.ptr, D_volumeData.pitch/sizeof(float), i, th, dims, fOutputScale);
-			else
-				dev_par3D_BP_SS<<<dimGrid, dimBlock>>>(D_volumeData.ptr, D_volumeData.pitch/sizeof(float), i, th, dims, params.iRaysPerVoxelDim, fOutputScale);
+			for (unsigned int startZ = 0; startZ < dims.iVolZ; startZ += 8*g_volBlockZ) {
+				// printf("Calling BP: %d, %dx%d, %dx%d to %p\n", i, dimBlock.x, dimBlock.y, dimGrid.x, dimGrid.y, (void*)D_volumeData.ptr); 
+				if (params.iRaysPerVoxelDim == 1)
+					dev_par3D_BP<<<dimGrid, dimBlock>>>(D_volumeData.ptr, D_volumeData.pitch/sizeof(float), i, th, startZ, dims, fOutputScale);
+				else
+					dev_par3D_BP_SS<<<dimGrid, dimBlock>>>(D_volumeData.ptr, D_volumeData.pitch/sizeof(float), i, th, startZ, dims, params.iRaysPerVoxelDim, fOutputScale);
+			}
 		}
 
 		cudaTextForceKernelsCompletion();


### PR DESCRIPTION
Performance impact on BP is limited. Performance on FP is barely slower in the X/Y directions, and is even improved in the Z direction.