### PR TITLE
Line causing astra_mex_projector items to pile up

### DIFF
--- a/matlab/tools/opTomo.m
+++ b/matlab/tools/opTomo.m
@@ -76,9 +76,7 @@ classdef opTomo < opSpot
             gpuEnabled = strcmpi(type, 'cuda');
             
             if is2D
-                % create a projector
-                proj_id = astra_create_projector(type, proj_geom, vol_geom);
-                
+      
                 % create a function handle
                 op.funHandle = @opTomo_intrnl2D;
                 


### PR DESCRIPTION
In the 2D case code first makes a projector, then checks if it's a gpu algorithm and recreates a projector on the same identifier or deletes the identifier. However at no point does the original projector get deleted, and the destructor no longer knows it exists.

Effect: every time an opTomo 2D object is created, an extra astra_mex_projector gets created which the user doesn't see unless he asks for all projector info. 

Change to code: deleted the line that caused the effect, no adverse side-effects should come from it.