### PR TITLE
Fix log printing of size_t variables

### DIFF
--- a/cuda/3d/mem3d.cu
+++ b/cuda/3d/mem3d.cu
@@ -133,7 +133,11 @@ bool freeGPUMemory(MemHandle3D handle)
 	cudaError_t err = cudaFree(handle.d->ptr.ptr);
 	size_t free2 = availableGPUMemory();
 
+#if defined(_MSC_VER) && _MSC_VER < 1800
+	ASTRA_DEBUG("Freeing memory. (Pre: %Iu, post: %Iu)", free, free2);
+#else
 	ASTRA_DEBUG("Freeing memory. (Pre: %zu, post: %zu)", free, free2);
+#endif
 
 	return err == cudaSuccess;
 }

--- a/cuda/3d/mem3d.cu
+++ b/cuda/3d/mem3d.cu
@@ -99,9 +99,11 @@ MemHandle3D allocateGPUMemory(unsigned int x, unsigned int y, unsigned int z, Me
 
 	size_t free2 = availableGPUMemory();
 
+#if defined(_MSC_VER) && _MSC_VER < 1800
+	ASTRA_DEBUG("Allocated %d x %d x %d on GPU. (Pre: %Iu, post: %Iu)", x, y, z, free, free2);
+#else
 	ASTRA_DEBUG("Allocated %d x %d x %d on GPU. (Pre: %zu, post: %zu)", x, y, z, free, free2);
-
-
+#endif
 
 	if (zero == INIT_ZERO) {
 		err = cudaMemset3D(hnd.ptr, 0, make_cudaExtent(sizeof(float)*x, y, z));

--- a/cuda/3d/mem3d.cu
+++ b/cuda/3d/mem3d.cu
@@ -99,7 +99,7 @@ MemHandle3D allocateGPUMemory(unsigned int x, unsigned int y, unsigned int z, Me
 
 	size_t free2 = availableGPUMemory();
 
-	ASTRA_DEBUG("Allocated %d x %d x %d on GPU. (Pre: %lu, post: %lu)", x, y, z, free, free2);
+	ASTRA_DEBUG("Allocated %d x %d x %d on GPU. (Pre: %zu, post: %zu)", x, y, z, free, free2);
 
 
 
@@ -131,7 +131,7 @@ bool freeGPUMemory(MemHandle3D handle)
 	cudaError_t err = cudaFree(handle.d->ptr.ptr);
 	size_t free2 = availableGPUMemory();
 
-	ASTRA_DEBUG("Freeing memory. (Pre: %lu, post: %lu)", free, free2);
+	ASTRA_DEBUG("Freeing memory. (Pre: %zu, post: %zu)", free, free2);
 
 	return err == cudaSuccess;
 }

--- a/src/CompositeGeometryManager.cpp
+++ b/src/CompositeGeometryManager.cpp
@@ -1655,10 +1655,18 @@ bool CCompositeGeometryManager::doJobs(TJobList &jobs)
 			ASTRA_WARN("Unable to get available GPU memory. Defaulting to 1GB.");
 			maxSize = 1024 * 1024 * 1024;
 		} else {
+#if defined(_MSC_VER) && _MSC_VER < 1800
+			ASTRA_DEBUG("Detected %Iu bytes of GPU memory", maxSize);
+#else
 			ASTRA_DEBUG("Detected %zu bytes of GPU memory", maxSize);
+#endif
 		}
 	} else {
+#if defined(_MSC_VER) && _MSC_VER < 1800
+		ASTRA_DEBUG("Set to %Iu bytes of GPU memory", maxSize);
+#else
 		ASTRA_DEBUG("Set to %zu bytes of GPU memory", maxSize);
+#endif
 	}
 	maxSize = (maxSize * 9) / 10;
 

--- a/src/CompositeGeometryManager.cpp
+++ b/src/CompositeGeometryManager.cpp
@@ -1655,10 +1655,10 @@ bool CCompositeGeometryManager::doJobs(TJobList &jobs)
 			ASTRA_WARN("Unable to get available GPU memory. Defaulting to 1GB.");
 			maxSize = 1024 * 1024 * 1024;
 		} else {
-			ASTRA_DEBUG("Detected %lu bytes of GPU memory", maxSize);
+			ASTRA_DEBUG("Detected %zu bytes of GPU memory", maxSize);
 		}
 	} else {
-		ASTRA_DEBUG("Set to %lu bytes of GPU memory", maxSize);
+		ASTRA_DEBUG("Set to %zu bytes of GPU memory", maxSize);
 	}
 	maxSize = (maxSize * 9) / 10;
 


### PR DESCRIPTION
When the GPU has more than 4GB of memory, the debug messages about the available memory are wrong. "%zu" is the proper placeholder to use for size_t types, see e.g. here: https://stackoverflow.com/questions/2524611/how-can-one-print-a-size-t-variable-portably-using-the-printf-family