### PR TITLE
Fix Data3D offset indices for large datasets

### DIFF
--- a/src/Float32Data3DMemory.cpp
+++ b/src/Float32Data3DMemory.cpp
@@ -216,16 +216,16 @@ void CFloat32Data3DMemory::_allocateData()
 
 	// create array of pointers to each row of the data block
 	m_ppfDataRowInd = new float32*[m_iHeight*m_iDepth];
-	for (int iy = 0; iy < m_iHeight*m_iDepth; iy++)
+	for (size_t iy = 0; iy < static_cast<size_t>(m_iHeight)*m_iDepth; iy++)
 	{
-		m_ppfDataRowInd[iy] = &(m_pfData[iy * m_iWidth]);
+		m_ppfDataRowInd[iy] = &(m_pfData[static_cast<size_t>(iy) * m_iWidth]);
 	}
 
 	// create array of pointers to each row of the data block
 	m_pppfDataSliceInd = new float32**[m_iDepth];
 	for (int iy = 0; iy < m_iDepth; iy++)
 	{
-		m_pppfDataSliceInd[iy] = &(m_ppfDataRowInd[iy * m_iHeight]);
+		m_pppfDataSliceInd[iy] = &(m_ppfDataRowInd[static_cast<size_t>(iy) * m_iHeight]);
 	}
 }
 


### PR DESCRIPTION
When dataset sizes are large (width x height x depth > 4GB), the indexed access to 3D memory is not fully initialized due to an overflow.

This pull request adds the missing conversions to size_t to avoid the overflow.