### PR TITLE
Optional optomo load

### DIFF
--- a/python/astra/__init__.py
+++ b/python/astra/__init__.py
@@ -38,7 +38,6 @@ from . import matrix
 from . import plugin
 from . import plugins
 from . import log
-from .optomo import OpTomo
 from .tests import test, test_noCUDA, test_CUDA
 
 __version__ = '1.9.0dev'
@@ -48,3 +47,6 @@ import os
 if 'ASTRA_GPU_INDEX' in os.environ:
     L = [ int(x) for x in os.environ['ASTRA_GPU_INDEX'].split(',') ]
     set_gpu_index(L)
+
+if 'ASTRA_LOAD_OPTOMO' in os.environ:
+    from .optomo import OpTomo

--- a/python/astra/__init__.py
+++ b/python/astra/__init__.py
@@ -48,5 +48,8 @@ if 'ASTRA_GPU_INDEX' in os.environ:
     L = [ int(x) for x in os.environ['ASTRA_GPU_INDEX'].split(',') ]
     set_gpu_index(L)
 
-if 'ASTRA_LOAD_OPTOMO' in os.environ:
-    from .optomo import OpTomo
+try:
+    if os.environ['ASTRA_LOAD_OPTOMO'] in ['y','yes','Y','YES']:
+        from .optomo import OpTomo
+except KeyError:
+    pass


### PR DESCRIPTION
See #140 .

On my machine the difference is not extremely large: it takes the import time from 115 ms to 85 ms, so I guess it depends a bit on each specific setup.

By setting `ASTRA_LOAD_OPTOMO=y` (or `Y`, `yes`, `YES`) as an environmental variable, OpTomo is automatically imported, to make things backwards compatible with existing scripts.