### PR TITLE
Added Matlab API version check

### DIFF
--- a/matlab/mex/mexDataManagerHelpFunctions.cpp
+++ b/matlab/mex/mexDataManagerHelpFunctions.cpp
@@ -39,11 +39,7 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 #ifdef USE_MATLAB_UNDOCUMENTED
 extern "C" {
 mxArray *mxCreateSharedDataCopy(const mxArray *pr);
-#if (defined(MX_API_VER)) && (MX_API_VER >= 0x08000000)
-	int mxUnshareArray(mxArray *pr, int noDeepCopy);	// Should work fine with >= R2018a
-#else
-	bool mxUnshareArray(mxArray *pr, bool noDeepCopy);	// Left here for older versions
-#endif
+int mxUnshareArray(mxArray *pr, int noDeepCopy);
 mxArray *mxUnreference(mxArray *pr);
 #if 0
 // Unsupported in Matlab R2014b and later

--- a/matlab/mex/mexDataManagerHelpFunctions.cpp
+++ b/matlab/mex/mexDataManagerHelpFunctions.cpp
@@ -39,7 +39,11 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 #ifdef USE_MATLAB_UNDOCUMENTED
 extern "C" {
 mxArray *mxCreateSharedDataCopy(const mxArray *pr);
-bool mxUnshareArray(mxArray *pr, bool noDeepCopy);
+#if (defined(MX_API_VER)) && (MX_API_VER >= 0x08000000)
+	int mxUnshareArray(mxArray *pr, int noDeepCopy);	// Should work fine with >= R2018a
+#else
+	bool mxUnshareArray(mxArray *pr, bool noDeepCopy);	// Left here for older versions
+#endif
 mxArray *mxUnreference(mxArray *pr);
 #if 0
 // Unsupported in Matlab R2014b and later


### PR DESCRIPTION
Addressing issue #149 : it appears that mxUnshareArray signature and return value changed since R2018a. Thus building for R2018a only with -DMATLAB_MEXCMD_RELEASE=700 leads to a compilation error. This work-around takes into account Matlab API version, and changes signature of mxUnshareArray to the consistent one with the current Matlab version.

Tested (build and launched ASTRA Toolbox) on Linux, g++ 7.3 with:
- Matlab R2017a. Build doesn't require -DMATLAB_MEXCMD_RELEASE=700 in CXXFLAGS
- Matlab R2018a. Build requires -DMATLAB_MEXCMD_RELEASE=700 in CXXFLAGS