### PR TITLE
Use recent version of conda during linux conda-build

### DIFF
--- a/python/conda/linux_release/buildenv/Dockerfile
+++ b/python/conda/linux_release/buildenv/Dockerfile
@@ -48,4 +48,11 @@ ENV PATH /root/miniconda3/bin:$PATH
 COPY Miniconda3-4.5.4-Linux-x86_64.sh /root/
 RUN /bin/bash /root/Miniconda3-4.5.4-Linux-x86_64.sh -b && \
 	rm -f /root/Miniconda3*
-RUN conda install -y conda-build conda-verify conda=4.6.14
+
+RUN conda install -y conda-build conda-verify
+
+# cudatoolkit < 9.0 is not easily available anymore from recent versions of conda.
+# We have to enable the free channel (globally) to reenable old versions of cudatookit..
+# See: https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/free-channel.html#troubleshooting
+# TODO: Remove when support for cudatoolkit 8.0 is dropped.
+RUN conda config --set restore_free_channel true


### PR DESCRIPTION
This fixes the issue where cudatoolkit=8.0 would not install any more
with recent versions of conda. Also, no corruption appears to take
place while downloading packages.

I have run the build process in a docker container. I get 19 outputs, a lot of warnings, but there appear to be no error messages. 