### PR TITLE
Correct beta coefficient

### DIFF
--- a/cuda/2d/fan_fp.cu
+++ b/cuda/2d/fan_fp.cu
@@ -190,7 +190,7 @@ __global__ void FanFPvertical(float* D_projData, unsigned int projPitch, unsigne
 
 		// ray: x = alpha * y + beta
 		const float alpha = (fSrcX - fDetX) / (fSrcY - fDetY);
-		const float beta = fSrcX - alpha * fSrcY;
+		const float beta = - fSrcX + alpha * fSrcY;
 	
 		const float fDistCorr = sqrt(alpha*alpha+1) * outputScale / dims.iRaysPerDet;
 


### PR DESCRIPTION
This seems to fix the weird sinogram flip that happens when angles switch between `FanFPvertical` and `FanFPhorizontal`, but I didn't test it thoroughly.

See also: https://github.com/odlgroup/odl/blob/3dd1439892de92883df29f3329db38066cc3d7c0/odl/tomo/backends/astra_setup.py#L234