### PR TITLE
Link cuda runtime and cufft statically

### DIFF
--- a/build/linux/Makefile.in
+++ b/build/linux/Makefile.in
@@ -61,7 +61,7 @@ ifeq ($(cuda),yes)
 CPPFLAGS  += @CPPFLAGS_CUDA@ -DASTRA_CUDA
 NVCCFLAGS += @NVCCFLAGS_EXTRA@ @CPPFLAGS_CUDA@ -I$(srcdir)/../../include -DASTRA_CUDA
 LDFLAGS   += @LDFLAGS_CUDA@
-LIBS      += -lcudart -lcufft
+LIBS      += -Wl,-Bstatic,-lcudart_static,-lcufft_static_nocallback,-lculibos,-Bdynamic
 NVCC       = @NVCC@
 endif
 

--- a/build/linux/Makefile.in
+++ b/build/linux/Makefile.in
@@ -61,7 +61,7 @@ ifeq ($(cuda),yes)
 CPPFLAGS  += @CPPFLAGS_CUDA@ -DASTRA_CUDA
 NVCCFLAGS += @NVCCFLAGS_EXTRA@ @CPPFLAGS_CUDA@ -I$(srcdir)/../../include -DASTRA_CUDA
 LDFLAGS   += @LDFLAGS_CUDA@
-LIBS      += -Wl,-Bstatic,-lcudart_static,-lcufft_static_nocallback,-lculibos,-Bdynamic
+LIBS      += -Wl,-Bstatic,-lcudart_static,-lcufft_static_nocallback,-lculibos,-Bdynamic,-ldl
 NVCC       = @NVCC@
 endif
 
@@ -406,8 +406,8 @@ endif
 endif
 
 ifeq ($(boostutf),yes)
-test.bin: $(ALL_OBJECTS) $(TEST_OBJECTS)
-	./libtool --mode=link $(LD) -o $@ $(LDFLAGS) $+ $(LIBS) $(BOOSTUTF_LIBS)
+test.bin: $(TEST_OBJECTS) libastra.la
+	$(LD) -o $@ $(LDFLAGS) -L$(abs_top_builddir)/.libs -Wl,-rpath=$(abs_top_builddir)/.libs $(BOOSTUTF_LIBS) $(LIBS) -lastra $(TEST_OBJECTS)
 
 test: test.bin
 	./test.bin

--- a/build/linux/Makefile.in
+++ b/build/linux/Makefile.in
@@ -314,7 +314,7 @@ ifeq ($(matlab),yes)
 mex: $(MATLAB_MEX)
 
 %.$(MEXSUFFIX): %.o $(MATLAB_CXX_OBJECTS) libastra.la
-	$(MEX) LDFLAGS="$(MEXLDFLAGS)" $(MEXFLAGS) $(LIBS) $(MEXLIBS) -lastra -output $* $*.o $(MATLAB_CXX_OBJECTS)
+	$(MEX) LDFLAGS="$(MEXLDFLAGS)" $(MEXFLAGS) $(MEXLIBS) -lastra -output $* $*.o $(MATLAB_CXX_OBJECTS)
 ifeq ($(install_type),module)
 ifeq ($(macos),yes)
 	@# tell macOS dynamic loader to look in mex directory for libastra.0.dylib
@@ -326,7 +326,7 @@ endif
 
 ifeq ($(python),yes)
 matlab/mex/astra_mex_plugin_c.$(MEXSUFFIX): matlab/mex/astra_mex_plugin_c.o $(MATLAB_CXX_OBJECTS) libastra.la
-	$(MEX) LDFLAGS="$(MEXLDFLAGS)" $(MEXFLAGS) $(LIBS) $(MEXLIBS) $(MODPYLIBS) -lastra -output matlab/mex/astra_mex_plugin_c $< $(MATLAB_CXX_OBJECTS)
+	$(MEX) LDFLAGS="$(MEXLDFLAGS)" $(MEXFLAGS) $(MEXLIBS) $(MODPYLIBS) -lastra -output matlab/mex/astra_mex_plugin_c $< $(MATLAB_CXX_OBJECTS)
 endif
 endif
 
@@ -346,11 +346,11 @@ ifeq ($(octave),yes)
 oct: $(OCTAVE_MEX)
 
 %.mex: %.o $(MATLAB_CXX_OBJECTS) $(OCTAVE_CXX_OBJECTS) libastra.la
-	mkoctfile --mex $(OCTFLAGS) $(OCTLDFLAGS) $(LIBS) -lastra --output $* $*.o $(MATLAB_CXX_OBJECTS) $(OCTAVE_CXX_OBJECTS)
+	mkoctfile --mex $(OCTFLAGS) $(OCTLDFLAGS) -lastra --output $* $*.o $(MATLAB_CXX_OBJECTS) $(OCTAVE_CXX_OBJECTS)
 
 ifeq ($(python),yes)
 matlab/mex/astra_mex_plugin_c.mex: matlab/mex/astra_mex_plugin_c.o $(MATLAB_CXX_OBJECTS) $(OCTAVE_CXX_OBJECTS) libastra.la
-	mkoctfile --mex $(OCTFLAGS) $(OCTLDFLAGS) $(LIBS) $(MODPYLIBS) -lastra --output matlab/mex/astra_mex_plugin_c $< $(MATLAB_CXX_OBJECTS) $(OCTAVE_CXX_OBJECTS)
+	mkoctfile --mex $(OCTFLAGS) $(OCTLDFLAGS) $(MODPYLIBS) -lastra --output matlab/mex/astra_mex_plugin_c $< $(MATLAB_CXX_OBJECTS) $(OCTAVE_CXX_OBJECTS)
 endif
 endif
 


### PR DESCRIPTION
Create a portable shared library that does not depend on specific cuda runtime version.
(this is the recommended way to distribute a cuda application [1]).

Clean up dynamic dependencies of mex files.

fixes #246 

Tested on linux with Matlab2020a on 4 different systems running CUDA 10.2 and 11.0 (the library built with CUDA 10.2 also runs on 11.0).
Not tested on MacOS.

[1] https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/index.html#distributing-cuda-runtime-and-libraries