### PR TITLE
Fix some compiler warnings and cuda deprecations

### DIFF
--- a/cuda/2d/fan_bp.cu
+++ b/cuda/2d/fan_bp.cu
@@ -320,7 +320,7 @@ bool FanBP_internal(float* D_volumeData, unsigned int volumePitch,
 		else
 			devFanBP<false><<<dimGrid, dimBlock, 0, stream>>>(D_volumeData, volumePitch, i, dims, fOutputScale);
 	}
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaTextForceKernelsCompletion();
 
@@ -352,7 +352,7 @@ bool FanBP_FBPWeighted_internal(float* D_volumeData, unsigned int volumePitch,
 	for (unsigned int i = 0; i < dims.iProjAngles; i += g_anglesPerBlock) {
 		devFanBP<true><<<dimGrid, dimBlock, 0, stream>>>(D_volumeData, volumePitch, i, dims, fOutputScale);
 	}
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaTextForceKernelsCompletion();
 
@@ -380,7 +380,7 @@ bool FanBP_SART(float* D_volumeData, unsigned int volumePitch,
 	             (dims.iVolHeight+g_blockSliceSize-1)/g_blockSliceSize);
 
 	devFanBP_SART<<<dimGrid, dimBlock>>>(D_volumeData, volumePitch, dims, fOutputScale);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaTextForceKernelsCompletion();
 

--- a/cuda/2d/fan_fp.cu
+++ b/cuda/2d/fan_fp.cu
@@ -271,7 +271,7 @@ bool FanFP_internal(float* D_volumeData, unsigned int volumePitch,
 	cudaStreamDestroy(stream1);
 	cudaStreamDestroy(stream2);
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaTextForceKernelsCompletion();
 

--- a/cuda/2d/fft.cu
+++ b/cuda/2d/fft.cu
@@ -43,7 +43,7 @@ using namespace astra;
 // TODO: evaluate what we want to do in these situations:
 
 #define CHECK_ERROR(errorMessage) do {                                     \
-  cudaError_t err = cudaThreadSynchronize();                               \
+  cudaError_t err = cudaDeviceSynchronize();                               \
   if( cudaSuccess != err) {                                                \
       ASTRA_ERROR("Cuda error %s : %s",                                    \
               errorMessage,cudaGetErrorString( err));                      \
@@ -57,7 +57,7 @@ using namespace astra;
               cudaGetErrorString( err));                                   \
       exit(EXIT_FAILURE);                                                  \
   }                                                                        \
-  err = cudaThreadSynchronize();                                           \
+  err = cudaDeviceSynchronize();                                           \
   if( cudaSuccess != err) {                                                \
       ASTRA_ERROR("Cuda error: %s : ",                                     \
               cudaGetErrorString( err));                                   \

--- a/cuda/2d/par_bp.cu
+++ b/cuda/2d/par_bp.cu
@@ -231,7 +231,7 @@ bool BP_internal(float* D_volumeData, unsigned int volumePitch,
 		else
 			devBP<<<dimGrid, dimBlock, 0, stream>>>(D_volumeData, volumePitch, i, dims, fOutputScale);
 	}
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaTextForceKernelsCompletion();
 
@@ -284,7 +284,7 @@ bool BP_SART(float* D_volumeData, unsigned int volumePitch,
 	             (dims.iVolHeight+g_blockSliceSize-1)/g_blockSliceSize);
 
 	devBP_SART<<<dimGrid, dimBlock>>>(D_volumeData, volumePitch, angle_offset, angle_scaled_sin, angle_scaled_cos, dims, fOutputScale);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaTextForceKernelsCompletion();
 

--- a/cuda/2d/par_fp.cu
+++ b/cuda/2d/par_fp.cu
@@ -324,7 +324,7 @@ bool FP_simple_internal(float* D_volumeData, unsigned int volumePitch,
 
 	streams.clear();
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaTextForceKernelsCompletion();
 

--- a/cuda/2d/util.cu
+++ b/cuda/2d/util.cu
@@ -258,7 +258,7 @@ float dotProduct2D(float* D_data, unsigned int pitch,
 
 bool cudaTextForceKernelsCompletion()
 {
-	cudaError_t returnedCudaError = cudaThreadSynchronize();
+	cudaError_t returnedCudaError = cudaDeviceSynchronize();
 
 	if(returnedCudaError != cudaSuccess) {
 		ASTRA_ERROR("Failed to force completion of cuda kernels: %d: %s.", returnedCudaError, cudaGetErrorString(returnedCudaError));

--- a/cuda/3d/util3d.cu
+++ b/cuda/3d/util3d.cu
@@ -432,7 +432,7 @@ float dotProduct3D(cudaPitchedPtr data, unsigned int x, unsigned int y,
 
 bool cudaTextForceKernelsCompletion()
 {
-	cudaError_t returnedCudaError = cudaThreadSynchronize();
+	cudaError_t returnedCudaError = cudaDeviceSynchronize();
 
 	if(returnedCudaError != cudaSuccess) {
 		ASTRA_ERROR("Failed to force completion of cuda kernels: %d: %s.", returnedCudaError, cudaGetErrorString(returnedCudaError));

--- a/include/astra/Float32Data2D.h
+++ b/include/astra/Float32Data2D.h
@@ -53,7 +53,7 @@ protected:
 
 	int m_iWidth;			///< width of the data (x)
 	int m_iHeight;			///< height of the data (y)
-	int m_iSize;			///< total size of the data
+	size_t m_iSize;			///< total size of the data
 
 	/** Pointer to the data block, represented as a 1-dimensional array.
 	 * Note that the data memory is "owned" by this class, meaning that the 
@@ -359,7 +359,7 @@ public:
 	 *
 	 * @return size of the data block
 	 */
-	int getSize() const;
+	size_t getSize() const;
 
 	/** which type is this class?
 	 *
@@ -497,7 +497,7 @@ inline int CFloat32Data2D::getHeight() const
 
 //----------------------------------------------------------------------------------------
 // Get the total size (width*height*depth) of the data block.
-inline int CFloat32Data2D::getSize() const
+inline size_t CFloat32Data2D::getSize() const
 {
 	ASTRA_ASSERT(m_bInitialized);
 	return m_iSize;

--- a/include/astra/Float32Data3D.h
+++ b/include/astra/Float32Data3D.h
@@ -95,7 +95,7 @@ public:
 	 *
 	 * @return size of the data block
 	 */
-	int getSize() const;
+	size_t getSize() const;
 
 	/** Which type is this class?
 	 *
@@ -153,7 +153,7 @@ inline int CFloat32Data3D::getDepth() const
 
 //----------------------------------------------------------------------------------------
 // Get the size of the data block.
-inline int CFloat32Data3D::getSize() const
+inline size_t CFloat32Data3D::getSize() const
 {
 	ASTRA_ASSERT(m_bInitialized);
 	return m_iSize;

--- a/matlab/mex/astra_mex_data2d_c.cpp
+++ b/matlab/mex/astra_mex_data2d_c.cpp
@@ -128,7 +128,8 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 		}
 		// If data is specified, check dimensions
 		if (nrhs >= 4 && !mexIsScalar(prhs[3])) {
-			if (pGeometry->getGridColCount() != mxGetN(prhs[3]) || pGeometry->getGridRowCount() != mxGetM(prhs[3])) {
+			if (static_cast<size_t>(pGeometry->getGridColCount()) != mxGetN(prhs[3]) 
+          || static_cast<size_t>(pGeometry->getGridRowCount()) != mxGetM(prhs[3])) {
 				mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry. \n");
 				delete cfg;
 				delete pGeometry;
@@ -173,7 +174,8 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 		}
 		// If data is specified, check dimensions
 		if (nrhs >= 4 && !mexIsScalar(prhs[3])) {
-			if (pGeometry->getDetectorCount() != mxGetN(prhs[3]) || pGeometry->getProjectionAngleCount() != mxGetM(prhs[3])) {
+			if (static_cast<size_t>(pGeometry->getDetectorCount()) != mxGetN(prhs[3]) 
+          || static_cast<size_t>(pGeometry->getProjectionAngleCount()) != mxGetM(prhs[3])) {
 				mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry. \n");
 				delete pGeometry;
 				delete cfg;
@@ -199,7 +201,7 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 
 	// Store data
 	if (nrhs == 3) {
-		for (int i = 0; i < pDataObject2D->getSize(); ++i) {
+		for (size_t i = 0; i < pDataObject2D->getSize(); ++i) {
 			pDataObject2D->getData()[i] = 0.0f;
 		}
 	}
@@ -209,7 +211,7 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 		// fill with scalar value
 		if (mexIsScalar(prhs[3])) {
 			float32 fValue = (float32)mxGetScalar(prhs[3]);
-			for (int i = 0; i < pDataObject2D->getSize(); ++i) {
+			for (size_t i = 0; i < pDataObject2D->getSize(); ++i) {
 				pDataObject2D->getData()[i] = fValue;
 			}
 		}
@@ -217,7 +219,8 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 		else {
 			const mwSize* dims = mxGetDimensions(prhs[3]);
 			// Check Data dimensions
-			if (pDataObject2D->getWidth() != mxGetN(prhs[3]) || pDataObject2D->getHeight() != mxGetM(prhs[3])) {
+			if (static_cast<size_t>(pDataObject2D->getWidth()) != mxGetN(prhs[3]) 
+          || static_cast<size_t>(pDataObject2D->getHeight()) != mxGetM(prhs[3])) {
 				mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry. \n");
 				return;
 			}
@@ -226,9 +229,8 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 			if (mxIsLogical(prhs[3])) {
 				mxLogical* pbMatlabData = mxGetLogicals(prhs[3]);
 				int i = 0;
-				int col, row;
-				for (col = 0; col < dims[1]; ++col) {
-					for (row = 0; row < dims[0]; ++row) {
+				for (size_t col = 0; col < dims[1]; ++col) {
+					for (size_t row = 0; row < dims[0]; ++row) {
 						pDataObject2D->getData2D()[row][col] = (float32)pbMatlabData[i];
 						++i;
 					}
@@ -237,9 +239,8 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 			} else if (mxIsDouble(prhs[3])) {
 				double* pdMatlabData = mxGetPr(prhs[3]);
 				int i = 0;
-				int col, row;
-				for (col = 0; col < dims[1]; ++col) {
-					for (row = 0; row < dims[0]; ++row) {
+				for (size_t col = 0; col < dims[1]; ++col) {
+					for (size_t row = 0; row < dims[0]; ++row) {
 						pDataObject2D->getData2D()[row][col] = pdMatlabData[i];
 						++i;
 					}
@@ -248,9 +249,8 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 			} else if (mxIsSingle(prhs[3])) {
 				const float* pfMatlabData = (const float *)mxGetData(prhs[3]);
 				int i = 0;
-				int col, row;
-				for (col = 0; col < dims[1]; ++col) {
-					for (row = 0; row < dims[0]; ++row) {
+				for (size_t col = 0; col < dims[1]; ++col) {
+					for (size_t row = 0; row < dims[0]; ++row) {
 						pDataObject2D->getData2D()[row][col] = pfMatlabData[i];
 						++i;
 					}
@@ -311,12 +311,13 @@ void astra_mex_data2d_store(int nlhs, mxArray* plhs[], int nrhs, const mxArray* 
 	// fill with scalar value
 	if (mexIsScalar(prhs[2])) {
 		float32 fValue = (float32)mxGetScalar(prhs[2]);
-		for (int i = 0; i < pDataObject->getSize(); ++i) {
+		for (size_t i = 0; i < pDataObject->getSize(); ++i) {
 			pDataObject->getData()[i] = fValue;
 		}
 	} else {
 		// Check Data dimensions
-		if (pDataObject->getWidth() != mxGetN(prhs[2]) || pDataObject->getHeight() != mxGetM(prhs[2])) {
+		if (static_cast<size_t>(pDataObject->getWidth()) != mxGetN(prhs[2]) 
+        || static_cast<size_t>(pDataObject->getHeight()) != mxGetM(prhs[2])) {
 			mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry. \n");
 			return;
 		}
@@ -326,9 +327,8 @@ void astra_mex_data2d_store(int nlhs, mxArray* plhs[], int nrhs, const mxArray* 
 		if (mxIsLogical(prhs[2])) {
 			mxLogical* pbMatlabData = mxGetLogicals(prhs[2]);
 			int i = 0;
-			int col, row;
-			for (col = 0; col < dims[1]; ++col) {
-				for (row = 0; row < dims[0]; ++row) {
+			for (size_t col = 0; col < dims[1]; ++col) {
+				for (size_t row = 0; row < dims[0]; ++row) {
 					pDataObject->getData2D()[row][col] = (float32)pbMatlabData[i];
 					++i;
 				}
@@ -337,9 +337,8 @@ void astra_mex_data2d_store(int nlhs, mxArray* plhs[], int nrhs, const mxArray* 
 		} else if (mxIsDouble(prhs[2])) {
 			double* pdMatlabData = mxGetPr(prhs[2]);
 			int i = 0;
-			int col, row;
-			for (col = 0; col < dims[1]; ++col) {
-				for (row = 0; row < dims[0]; ++row) {
+			for (size_t col = 0; col < dims[1]; ++col) {
+				for (size_t row = 0; row < dims[0]; ++row) {
 					pDataObject->getData2D()[row][col] = pdMatlabData[i];
 					++i;
 				}
@@ -348,9 +347,8 @@ void astra_mex_data2d_store(int nlhs, mxArray* plhs[], int nrhs, const mxArray* 
 		} else if (mxIsSingle(prhs[2])) {
 			const float* pfMatlabData = (const float *)mxGetData(prhs[2]);
 			int i = 0;
-			int col, row;
-			for (col = 0; col < dims[1]; ++col) {
-				for (row = 0; row < dims[0]; ++row) {
+			for (size_t col = 0; col < dims[1]; ++col) {
+				for (size_t row = 0; row < dims[0]; ++row) {
 					pDataObject->getData2D()[row][col] = pfMatlabData[i];
 					++i;
 				}

--- a/matlab/mex/astra_mex_log_c.cpp
+++ b/matlab/mex/astra_mex_log_c.cpp
@@ -237,6 +237,7 @@ void astra_mex_log_output(int nlhs, mxArray* plhs[], int nrhs, const mxArray* pr
 		eLevel = LOG_ERROR;
 	}else{
 		mexErrMsgTxt("Specify which log level to use ('debug', 'info', 'warn', or 'error')");
+		eLevel = LOG_ERROR; // default to LOG_ERROR
 	}
 	if(sType == "file"){
 		astra::CLogger::setOutputFile(sOutput.c_str(),eLevel);
@@ -248,6 +249,7 @@ void astra_mex_log_output(int nlhs, mxArray* plhs[], int nrhs, const mxArray* pr
 			fd=2;
 		}else{
 			mexErrMsgTxt("Specify which screen to output to ('stdout' or 'stderr')");
+			fd=2; // default to stderr
 		}
 		astra::CLogger::setOutputScreen(fd,eLevel);
 	} else {

--- a/matlab/mex/mexDataManagerHelpFunctions.cpp
+++ b/matlab/mex/mexDataManagerHelpFunctions.cpp
@@ -119,9 +119,9 @@ checkDataSize(const mxArray * const mArray,
 {
 	mwSize dims[3];
 	get3DMatrixDims(mArray, dims);
-	return (geom->getDetectorColCount() == dims[0]
-			&& geom->getProjectionCount() == dims[1]
-			&& geom->getDetectorRowCount() == dims[2]);
+	return (static_cast<mwSize>(geom->getDetectorColCount()) == dims[0]
+			&& static_cast<mwSize>(geom->getProjectionCount()) == dims[1]
+			&& static_cast<mwSize>(geom->getDetectorRowCount()) == dims[2]);
 }
 
 //-----------------------------------------------------------------------------------------
@@ -131,9 +131,9 @@ checkDataSize(const mxArray * const mArray,
 {
 	mwSize dims[3];
 	get3DMatrixDims(mArray, dims);
-	return (geom->getGridColCount() == dims[0]
-			&& geom->getGridRowCount() == dims[1]
-			&& geom->getGridSliceCount() == dims[2]);
+	return (static_cast<mwSize>(geom->getGridColCount()) == dims[0]
+			&& static_cast<mwSize>(geom->getGridRowCount()) == dims[1]
+			&& static_cast<mwSize>(geom->getGridSliceCount()) == dims[2]);
 }
 
 //-----------------------------------------------------------------------------------------
@@ -144,9 +144,9 @@ checkDataSize(const mxArray * const mArray,
 {
 	mwSize dims[3];
 	get3DMatrixDims(mArray, dims);
-	return (geom->getDetectorColCount() == dims[0]
-			&& geom->getProjectionCount() == dims[1]
-			&& (zOffset + geom->getDetectorRowCount()) <= dims[2]);
+	return (static_cast<mwSize>(geom->getDetectorColCount()) == dims[0]
+			&& static_cast<mwSize>(geom->getProjectionCount()) == dims[1]
+			&& (zOffset + static_cast<mwSize>(geom->getDetectorRowCount())) <= dims[2]);
 }
 
 //-----------------------------------------------------------------------------------------
@@ -157,9 +157,9 @@ checkDataSize(const mxArray * const mArray,
 {
 	mwSize dims[3];
 	get3DMatrixDims(mArray, dims);
-	return (geom->getGridColCount() == dims[0]
-			&& geom->getGridRowCount() == dims[1]
-			&& (zOffset + geom->getGridSliceCount()) <= dims[2]);
+	return (static_cast<mwSize>(geom->getGridColCount()) == dims[0]
+			&& static_cast<mwSize>(geom->getGridRowCount()) == dims[1]
+			&& (zOffset + static_cast<mwSize>(geom->getGridSliceCount())) <= dims[2]);
 }
 
 //-----------------------------------------------------------------------------------------

--- a/src/CglsAlgorithm.cpp
+++ b/src/CglsAlgorithm.cpp
@@ -209,8 +209,6 @@ void CCglsAlgorithm::run(int _iNrIterations)
 
 
 
-	int i;
-
 	if (m_iIteration == 0) {
 		// r = b;
 		r->copyData(m_pSinogram->getData());
@@ -228,7 +226,7 @@ void CCglsAlgorithm::run(int _iNrIterations)
 
 		// gamma = dot(z,z);
 		gamma = 0.0f;
-		for (i = 0; i < z->getSize(); ++i) {
+		for (size_t i = 0; i < z->getSize(); ++i) {
 			gamma += z->getData()[i] * z->getData()[i];
 		}
 		m_iIteration++;
@@ -243,18 +241,18 @@ void CCglsAlgorithm::run(int _iNrIterations)
 	
 		// alpha = gamma/dot(w,w);
 		float32 tmp = 0;
-		for (i = 0; i < w->getSize(); ++i) {
+		for (size_t i = 0; i < w->getSize(); ++i) {
 			tmp += w->getData()[i] * w->getData()[i];
 		}
 		alpha = gamma / tmp;
 
 		// x = x + alpha*p;
-		for (i = 0; i < m_pReconstruction->getSize(); ++i) {
+		for (size_t i = 0; i < m_pReconstruction->getSize(); ++i) {
 			m_pReconstruction->getData()[i] += alpha * p->getData()[i];
 		}
 
 		// r = r - alpha*w;
-		for (i = 0; i < r->getSize(); ++i) {
+		for (size_t i = 0; i < r->getSize(); ++i) {
 			r->getData()[i] -= alpha * w->getData()[i];
 		}
 
@@ -273,7 +271,7 @@ void CCglsAlgorithm::run(int _iNrIterations)
 
 		// gamma = dot(z,z);
 		gamma = 0;
-		for (i = 0; i < z->getSize(); ++i) {
+		for (size_t i = 0; i < z->getSize(); ++i) {
 			gamma += z->getData()[i] * z->getData()[i];
 		}
 
@@ -281,7 +279,7 @@ void CCglsAlgorithm::run(int _iNrIterations)
 		beta *= gamma; 
 
 		// p = z + beta*p;
-		for (i = 0; i < z->getSize(); ++i) {
+		for (size_t i = 0; i < z->getSize(); ++i) {
 			p->getData()[i] = z->getData()[i] + beta * p->getData()[i];
 		}
 		

--- a/src/Float32Data2D.cpp
+++ b/src/Float32Data2D.cpp
@@ -286,7 +286,7 @@ void CFloat32Data2D::_allocateData()
 	ASTRA_ASSERT(!m_bInitialized);
 
 	ASTRA_ASSERT(m_iSize > 0);
-	ASTRA_ASSERT((size_t)m_iSize == (size_t)m_iWidth * m_iHeight);
+	ASTRA_ASSERT(m_iSize == (size_t)m_iWidth * m_iHeight);
 	ASTRA_ASSERT(m_pfData == NULL);
 	ASTRA_ASSERT(m_ppfData2D == NULL);
 

--- a/src/SirtAlgorithm.cpp
+++ b/src/SirtAlgorithm.cpp
@@ -246,7 +246,7 @@ void CSirtAlgorithm::run(int _iNrIterations)
 	pFirstForwardProjector->project();
 
 	float32* pfT = m_pTotalPixelWeight->getData();
-	for (int i = 0; i < m_pTotalPixelWeight->getSize(); ++i) {
+	for (size_t i = 0; i < m_pTotalPixelWeight->getSize(); ++i) {
 		float32 x = pfT[i];
 		if (x < -eps || x > eps)
 			x = 1.0f / x;
@@ -255,7 +255,7 @@ void CSirtAlgorithm::run(int _iNrIterations)
 		pfT[i] = m_fLambda * x;
 	}
 	pfT = m_pTotalRayLength->getData();
-	for (int i = 0; i < m_pTotalRayLength->getSize(); ++i) {
+	for (size_t i = 0; i < m_pTotalRayLength->getSize(); ++i) {
 		float32 x = pfT[i];
 		if (x < -eps || x > eps)
 			x = 1.0f / x;


### PR DESCRIPTION
Fix some compiler warnings

  - Deprecation of cudaThreadSynchronize
  - Signed/unsigned comparisons
  - (potentially controversial) Change return value of getSize in Float32Data2D and Float32Data3D from type int to type size_t to avoid potential overflows

Please comment.
