### PR TITLE
Fix memory leak in CUDA 2D par_fp

### DIFF
--- a/cuda/2d/par_fp.cu
+++ b/cuda/2d/par_fp.cu
@@ -251,6 +251,10 @@ static void convertAndUploadAngles(const SParProjection *projs, unsigned int nth
 	cudaMemcpyToSymbol(gC_angle, angles, nth*sizeof(float), 0, cudaMemcpyHostToDevice); 
 	cudaMemcpyToSymbol(gC_angle_offset, offsets, nth*sizeof(float), 0, cudaMemcpyHostToDevice);
 	cudaMemcpyToSymbol(gC_angle_detsize, detsizes, nth*sizeof(float), 0, cudaMemcpyHostToDevice); 
+	
+	delete [] angles;
+	delete [] offsets;
+	delete [] detsizes;
 }
 
 


### PR DESCRIPTION
Arrays were dynamically allocated in the function convertAndUploadAngles, but were not deallocated, resulting in a memory leak. At the end of this function I now delete [] these arrays, fixing the memory leak.