### PR TITLE
Fix cuda2d fan bp memleak

### DIFF
--- a/cuda/2d/fan_bp.cu
+++ b/cuda/2d/fan_bp.cu
@@ -290,6 +290,8 @@ bool transferConstants(const SFanProjection* angles, unsigned int iProjAngles, b
 	// TODO: Check for errors
 	cudaMemcpyToSymbol(gC_C, p, iProjAngles*sizeof(DevFanParams), 0, cudaMemcpyHostToDevice);
 
+    delete [] p;
+
 	return true;
 }
 

--- a/cuda/2d/fan_bp.cu
+++ b/cuda/2d/fan_bp.cu
@@ -290,7 +290,7 @@ bool transferConstants(const SFanProjection* angles, unsigned int iProjAngles, b
 	// TODO: Check for errors
 	cudaMemcpyToSymbol(gC_C, p, iProjAngles*sizeof(DevFanParams), 0, cudaMemcpyHostToDevice);
 
-    delete [] p;
+        delete [] p;
 
 	return true;
 }


### PR DESCRIPTION
This is a fix for issue #271. As noted in the issue, it is similar to issue #255 with fix #256. Inside the function transferConstants, an array p was dynamically allocated but it was not deallocated. Now it is deallocated after its contents have been copied into the GPU memory.