### PR TITLE
Implemented _adjoint of OpTomo by equating it to _transpose

### DIFF
--- a/python/astra/optomo.py
+++ b/python/astra/optomo.py
@@ -95,6 +95,9 @@ class OpTomo(scipy.sparse.linalg.LinearOperator):
     def _transpose(self):
         return self.transposeOpTomo
 
+    # real operator
+    _adjoint = _transpose
+
     def __checkArray(self, arr, shp):
         if len(arr.shape)==1:
             arr = arr.reshape(shp)
@@ -248,6 +251,9 @@ class OpTomoTranspose(scipy.sparse.linalg.LinearOperator):
 
     def _transpose(self):
         return self.parent
+
+    # real operator
+    _adjoint = _transpose
 
     def __mul__(self,s):
         # Catch the case of a backprojection of 2D/3D data


### PR DESCRIPTION
A minor modification to `optomo.py` to solve [this issue](https://github.com/astra-toolbox/astra-toolbox/issues/240).



This PR enables the use of OpTomo in algorithms that internally need the Hermitian adjoint. If you define `W = astra.OpTomo(proj_id)` then you can now do `W.H @ x` or `W.adjoint() @ x`, with the same effect as `W.T @ x` and `W.transpose() @ x`. The adjoint is equal to the transpose because the operator is real.

Before this PR, `W.H` did return an operator, but it throws an error if you multiply it with a vector.