### PR TITLE
Add correct shebangs to autogen.sh, add python check for setuptools

### DIFF
--- a/build/linux/autogen.sh
+++ b/build/linux/autogen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 aclocal
 if test $? -ne 0; then

--- a/build/linux/configure.ac
+++ b/build/linux/configure.ac
@@ -249,6 +249,15 @@ if test x"$with_python" != x -a x"$with_python" != xno; then
     AC_MSG_ERROR(You need the numpy module to use the ASTRA toolbox in Python)
   fi
   AC_MSG_RESULT(yes)
+  AC_MSG_CHECKING(for setuptools module)
+  ASTRA_TRY_PYTHON([
+from pkg_resources import parse_version
+],,HAVEPYTHON=no)
+  if test x$HAVEPYTHON = xno; then
+    AC_MSG_RESULT(no)
+    AC_MSG_ERROR(You need the setuptools module use the ASTRA toolbox in Python)
+  fi
+  AC_MSG_RESULT(yes)
   AC_MSG_CHECKING(for Cython module)
   ASTRA_TRY_PYTHON([
 import Cython


### PR DESCRIPTION
Adapted the shebang in autoconf.sh
also since 
```
import Cython
from pkg_resources import parse_version
assert(parse_version(Cython.__version__) >= parse_version("0.13"))
```
uses parse_version which is part of the setuptools python package, I added a check to make sure its actually installed