### PR TITLE
Fix compiler warnings

### DIFF
--- a/cuda/2d/arith.cu
+++ b/cuda/2d/arith.cu
@@ -451,7 +451,7 @@ void processData(float* pfOut, unsigned int pitch, unsigned int width, unsigned 
 
 	devtoD<op, 32><<<gridSize, blockSize>>>(pfOut, pitch, width, height);
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 template<typename op>
@@ -462,7 +462,7 @@ void processData(float* pfOut, float fParam, unsigned int pitch, unsigned int wi
 
 	devFtoD<op, 32><<<gridSize, blockSize>>>(pfOut, fParam, pitch, width, height);
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 template<typename op>
@@ -473,7 +473,7 @@ void processData(float* pfOut1, float* pfOut2, float fParam1, float fParam2, uns
 
 	devFFtoDD<op, 32><<<gridSize, blockSize>>>(pfOut1, pfOut2, fParam1, fParam2, pitch, width, height);
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 
@@ -485,7 +485,7 @@ void processData(float* pfOut, const float* pfIn, unsigned int pitch, unsigned i
 
 	devDtoD<op, 32><<<gridSize, blockSize>>>(pfOut, pfIn, pitch, width, height);
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 template<typename op>
@@ -496,7 +496,7 @@ void processData(float* pfOut, const float* pfIn, float fParam, unsigned int pit
 
 	devDFtoD<op, 32><<<gridSize, blockSize>>>(pfOut, pfIn, fParam, pitch, width, height);
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 template<typename op>
@@ -507,7 +507,7 @@ void processData(float* pfOut, const float* pfIn1, const float* pfIn2, float fPa
 
 	devDDFtoD<op, 32><<<gridSize, blockSize>>>(pfOut, pfIn1, pfIn2, fParam, pitch, width, height);
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 template<typename op>
@@ -518,7 +518,7 @@ void processData(float* pfOut, const float* pfIn1, const float* pfIn2, unsigned 
 
 	devDDtoD<op, 32><<<gridSize, blockSize>>>(pfOut, pfIn1, pfIn2, pitch, width, height);
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 

--- a/cuda/2d/fan_bp.cu
+++ b/cuda/2d/fan_bp.cu
@@ -375,7 +375,7 @@ bool FanBP_SART(float* D_volumeData, unsigned int volumePitch,
 
 	devFanBP_SART<<<dimGrid, dimBlock>>>(D_volumeData, volumePitch, D_texObj, dims, fOutputScale);
 
-	ok = checkCuda(cudaThreadSynchronize(), "FanBP_SART");
+	ok = checkCuda(cudaDeviceSynchronize(), "FanBP_SART");
 
 	cudaDestroyTextureObject(D_texObj);
 

--- a/cuda/2d/fft.cu
+++ b/cuda/2d/fft.cu
@@ -101,7 +101,7 @@ static void rescaleInverseFourier(int _iProjectionCount, int _iDetectorCount,
 	                                                            _iDetectorCount,
 	                                                            _pfInFourierOutput);
 
-	checkCuda(cudaThreadSynchronize(), "rescaleInverseFourier");
+	checkCuda(cudaDeviceSynchronize(), "rescaleInverseFourier");
 }
 
 void applyFilter(int _iProjectionCount, int _iFreqBinCount,
@@ -115,7 +115,7 @@ void applyFilter(int _iProjectionCount, int _iFreqBinCount,
 	                                                  _iFreqBinCount,
 	                                                  _pSinogram, _pFilter);
 
-	checkCuda(cudaThreadSynchronize(), "applyFilter");
+	checkCuda(cudaDeviceSynchronize(), "applyFilter");
 }
 
 static bool invokeCudaFFT(int _iProjectionCount, int _iDetectorCount,

--- a/cuda/2d/par_bp.cu
+++ b/cuda/2d/par_bp.cu
@@ -269,7 +269,7 @@ bool BP_SART(float* D_volumeData, unsigned int volumePitch,
 
 	devBP_SART<<<dimGrid, dimBlock>>>(D_volumeData, volumePitch, D_texObj, angle_offset, angle_scaled_sin, angle_scaled_cos, dims, fOutputScale);
 
-	bool ok = checkCuda(cudaThreadSynchronize(), "BP_SART");
+	bool ok = checkCuda(cudaDeviceSynchronize(), "BP_SART");
 
 	cudaDestroyTextureObject(D_texObj);
 

--- a/cuda/2d/sart.cu
+++ b/cuda/2d/sart.cu
@@ -54,7 +54,7 @@ void MUL_SART(float* pfOut, const float* pfIn, unsigned int pitch, unsigned int 
 
 	devMUL_SART<<<gridSize, blockSize>>>(pfOut, pfIn, pitch, width);
 
-	checkCuda(cudaThreadSynchronize(), "MUL_SART");
+	checkCuda(cudaDeviceSynchronize(), "MUL_SART");
 }
 
 

--- a/cuda/2d/util.cu
+++ b/cuda/2d/util.cu
@@ -285,7 +285,7 @@ float dotProduct2D(float* D_data, unsigned int pitch,
 	// Step 1: reduce 2D from image to a single vector, taking sum of squares
 
 	reduce2D<<< dimGrid2, dimBlock2, shared_mem2>>>(D_data, D_buf, pitch, width, height);
-	checkCuda(cudaThreadSynchronize(), "dotProduct2D reduce2D");
+	checkCuda(cudaDeviceSynchronize(), "dotProduct2D reduce2D");
 
 	// Step 2: reduce 1D: add up elements in vector
 	if (bx * by > 512)
@@ -302,7 +302,7 @@ float dotProduct2D(float* D_data, unsigned int pitch,
 	float x;
 	cudaMemcpy(&x, D_res, 4, cudaMemcpyDeviceToHost);
 
-	checkCuda(cudaThreadSynchronize(), "dotProduct2D");
+	checkCuda(cudaDeviceSynchronize(), "dotProduct2D");
 
 	cudaFree(D_buf);
 

--- a/cuda/3d/arith3d.cu
+++ b/cuda/3d/arith3d.cu
@@ -225,7 +225,7 @@ void processVol(CUdeviceptr* out, unsigned int pitch, unsigned int width, unsign
 
 	devtoD<op, 32><<<gridSize, blockSize>>>(pfOut, pitch, width, height);
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 template<typename op>
@@ -238,7 +238,7 @@ void processVol(CUdeviceptr* out, float fParam, unsigned int pitch, unsigned int
 
 	devFtoD<op, 32><<<gridSize, blockSize>>>(pfOut, fParam, pitch, width, height);
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 template<typename op>
@@ -252,7 +252,7 @@ void processVol(CUdeviceptr* out, const CUdeviceptr* in, unsigned int pitch, uns
 
 	devDtoD<op, 32><<<gridSize, blockSize>>>(pfOut, pfIn, pitch, width, height);
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 template<typename op>
@@ -266,7 +266,7 @@ void processVol(CUdeviceptr* out, const CUdeviceptr* in, float fParam, unsigned 
 
 	devDFtoD<op, 32><<<gridSize, blockSize>>>(pfOut, pfIn, fParam, pitch, width, height);
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 template<typename op>
@@ -281,7 +281,7 @@ void processVol(CUdeviceptr* out, const CUdeviceptr* in1, const CUdeviceptr* in2
 
 	devDDFtoD<op, 32><<<gridSize, blockSize>>>(pfOut, pfIn1, pfIn2, fParam, pitch, width, height);
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 template<typename op>
@@ -296,7 +296,7 @@ void processVol(CUdeviceptr* out, const CUdeviceptr* in1, const CUdeviceptr* in2
 
 	devDDtoD<op, 32><<<gridSize, blockSize>>>(pfOut, pfIn1, pfIn2, pitch, width, height);
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 
@@ -328,7 +328,7 @@ void processVol3D(cudaPitchedPtr& out, const SDimensions3D& dims)
 		pfOut += step;
 	}
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 template<typename op>
@@ -344,7 +344,7 @@ void processVol3D(cudaPitchedPtr& out, float fParam, const SDimensions3D& dims)
 		pfOut += step;
 	}
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 template<typename op>
@@ -362,7 +362,7 @@ void processVol3D(cudaPitchedPtr& out, const cudaPitchedPtr& in, const SDimensio
 		pfIn += step;
 	}
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 template<typename op>
@@ -380,7 +380,7 @@ void processVol3D(cudaPitchedPtr& out, const cudaPitchedPtr& in, float fParam, c
 		pfIn += step;
 	}
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 template<typename op>
@@ -400,7 +400,7 @@ void processVol3D(cudaPitchedPtr& out, const cudaPitchedPtr& in1, const cudaPitc
 		pfIn2 += step;
 	}
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 template<typename op>
@@ -420,7 +420,7 @@ void processVol3D(cudaPitchedPtr& out, const cudaPitchedPtr& in1, const cudaPitc
 		pfIn2 += step;
 	}
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 
@@ -448,7 +448,7 @@ void processSino3D(cudaPitchedPtr& out, const SDimensions3D& dims)
 		pfOut += step;
 	}
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 template<typename op>
@@ -464,7 +464,7 @@ void processSino3D(cudaPitchedPtr& out, float fParam, const SDimensions3D& dims)
 		pfOut += step;
 	}
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 template<typename op>
@@ -482,7 +482,7 @@ void processSino3D(cudaPitchedPtr& out, const cudaPitchedPtr& in, const SDimensi
 		pfIn += step;
 	}
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 template<typename op>
@@ -500,7 +500,7 @@ void processSino3D(cudaPitchedPtr& out, const cudaPitchedPtr& in, float fParam, 
 		pfIn += step;
 	}
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 template<typename op>
@@ -520,7 +520,7 @@ void processSino3D(cudaPitchedPtr& out, const cudaPitchedPtr& in1, const cudaPit
 		pfIn2 += step;
 	}
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 template<typename op>
@@ -540,7 +540,7 @@ void processSino3D(cudaPitchedPtr& out, const cudaPitchedPtr& in1, const cudaPit
 		pfIn2 += step;
 	}
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	checkCuda(cudaDeviceSynchronize(), __FUNCTION__);
 }
 
 

--- a/cuda/3d/cone_bp.cu
+++ b/cuda/3d/cone_bp.cu
@@ -342,7 +342,7 @@ bool ConeBP_Array(cudaPitchedPtr D_volumeData,
 		}
 
 		// TODO: Consider not synchronizing here, if possible.
-		ok = checkCuda(cudaThreadSynchronize(), "cone_bp");
+		ok = checkCuda(cudaDeviceSynchronize(), "cone_bp");
 		if (!ok)
 			break;
 

--- a/cuda/3d/fdk.cu
+++ b/cuda/3d/fdk.cu
@@ -176,7 +176,7 @@ bool FDK_PreWeight(cudaPitchedPtr D_projData,
 
 	devFDK_preweight<<<dimGrid, dimBlock>>>(D_projData.ptr, projPitch, 0, dims.iProjAngles, fSrcOrigin, fDetOrigin, fZShift, fDetUSize, fDetVSize, dims);
 
-	if (!checkCuda(cudaThreadSynchronize(), "FDK_PreWeight"))
+	if (!checkCuda(cudaDeviceSynchronize(), "FDK_PreWeight"))
 		return false;
 
 	if (bShortScan && dims.iProjAngles > 1) {
@@ -240,7 +240,7 @@ bool FDK_PreWeight(cudaPitchedPtr D_projData,
 
 		devFDK_ParkerWeight<<<dimGrid, dimBlock>>>(D_projData.ptr, projPitch, 0, dims.iProjAngles, fSrcOrigin, fDetOrigin, fDetUSize, fCentralFanAngle, fScale, dims);
 
-		if (!checkCuda(cudaThreadSynchronize(), "FDK_PreWeight ParkerWeight"))
+		if (!checkCuda(cudaDeviceSynchronize(), "FDK_PreWeight ParkerWeight"))
 			return false;
 	}
 

--- a/cuda/3d/par3d_bp.cu
+++ b/cuda/3d/par3d_bp.cu
@@ -274,7 +274,7 @@ bool Par3DBP_Array(cudaPitchedPtr D_volumeData,
 		}
 
 		// TODO: Consider not synchronizing here, if possible.
-		ok = checkCuda(cudaThreadSynchronize(), "cone_bp");
+		ok = checkCuda(cudaDeviceSynchronize(), "cone_bp");
 		if (!ok)
 			break;
 

--- a/include/astra/Float32Data2D.h
+++ b/include/astra/Float32Data2D.h
@@ -51,9 +51,9 @@ class _AstraExport CFloat32Data2D : public CFloat32Data {
 
 protected:
 
-	int m_iWidth;			///< width of the data (x)
-	int m_iHeight;			///< height of the data (y)
-	int m_iSize;			///< total size of the data
+	size_t m_iWidth;			///< width of the data (x)
+	size_t m_iHeight;			///< height of the data (y)
+	size_t m_iSize;			///< total size of the data
 
 	/** Pointer to the data block, represented as a 1-dimensional array.
 	 * Note that the data memory is "owned" by this class, meaning that the 

--- a/python/astra/experimental.pyx
+++ b/python/astra/experimental.pyx
@@ -185,7 +185,7 @@ IF HAVE_CUDA==True:
 
     def getProjectedBBox(geometry, minx, maxx, miny, maxy, minz, maxz):
         cdef CProjectionGeometry3D * ppGeometry
-        cdef double minu, maxu, minv, maxv
+        cdef double minu = 0.0, maxu = 0.0, minv = 0.0, maxv = 0.0
         ppGeometry = createProjectionGeometry3D(geometry)
         ppGeometry.getProjectedBBox(minx, maxx, miny, maxy, minz, maxz, minu, maxu, minv, maxv)
         del ppGeometry

--- a/python/astra/src/PythonPluginAlgorithm.cpp
+++ b/python/astra/src/PythonPluginAlgorithm.cpp
@@ -62,7 +62,7 @@ void logPythonError(){
                     if(iter!=NULL){
                         PyObject *line;
                         std::string errStr = "";
-                        while(line = PyIter_Next(iter)){
+                        while((line = PyIter_Next(iter))){
                             PyObject *retb = PyObject_CallMethod(six,"b","O",line);
                             if(retb!=NULL){
                                 errStr += std::string(PyBytes_AsString(retb));

--- a/python/astra/src/PythonPluginAlgorithmFactory.cpp
+++ b/python/astra/src/PythonPluginAlgorithmFactory.cpp
@@ -46,7 +46,10 @@ void logPythonError();
 CPythonPluginAlgorithmFactory::CPythonPluginAlgorithmFactory(){
     if(!Py_IsInitialized()){
         Py_Initialize();
+// This function is no longer required as of Python 3.7 and deprecated as of Python 3.9
+#if PY_VERSION_HEX < 0x03070000
         PyEval_InitThreads();
+#endif
     }
     pluginDict = PyDict_New();
     inspect = PyImport_ImportModule("inspect");

--- a/src/AsyncAlgorithm.cpp
+++ b/src/AsyncAlgorithm.cpp
@@ -29,7 +29,7 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 #include "astra/AstraObjectFactory.h"
 
 #ifndef USE_PTHREAD
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #endif
 
 namespace astra {

--- a/src/Float32Data2D.cpp
+++ b/src/Float32Data2D.cpp
@@ -306,7 +306,7 @@ void CFloat32Data2D::_allocateData()
 
 	// create array of pointers to each row of the data block
 	m_ppfData2D = new float32*[m_iHeight];
-	for (int iy = 0; iy < m_iHeight; iy++)
+	for (size_t iy = 0; iy < m_iHeight; iy++)
 	{
 		m_ppfData2D[iy] = &(m_pfData[iy * m_iWidth]);
 	}

--- a/src/Fourier.cpp
+++ b/src/Fourier.cpp
@@ -341,8 +341,10 @@ static void cftfx41(int n, float32 *a, int nw, float32 *w);
 static void cftleaf(int n, int isplt, float32 *a, int nw, float32 *w);
 static void cftmdl1(int n, float32 *a, float32 *w);
 static void cftmdl2(int n, float32 *a, float32 *w);
+#ifdef USE_CDFT_THREADS
 static void *cftrec1_th(void *p);
 static void *cftrec2_th(void *p);
+#endif
 static void cftrec4(int n, float32 *a, int nw, float32 *w);
 static void cftx020(float32 *a);
 static void dctsub(int n, float32 *a, int nc, float32 *c);


### PR DESCRIPTION
There were a bunch of warnings emitted when I was compiling Astra, so I've fixed most of them.

I have left alone the warnings about `Using deprecated NumPy API` since as far as I can see that requires updating to Cython 3.0 which is only in beta.

I have not tried building for Matlab or Octave, only CUDA and Python.