### PR TITLE
Reorder setuptools import

### DIFF
--- a/python/builder.py
+++ b/python/builder.py
@@ -29,10 +29,10 @@ import numpy as np
 from distutils.core import setup
 from pkg_resources import parse_version
 
+from setuptools import Command
+
 from Cython.Distutils import build_ext
 from Cython.Build import cythonize
-
-from setuptools import Command
 
 import argparse
 import sys


### PR DESCRIPTION
Fixes build error: each element of 'ext_modules' option must be an Extension instance or 2-tuple

See also: https://stackoverflow.com/questions/21594925

`make` fails for me without this change.