### PR TITLE
Improve error reporting

### DIFF
--- a/cuda/3d/astra3d.cu
+++ b/cuda/3d/astra3d.cu
@@ -1304,7 +1304,7 @@ bool astraCudaBP_SIRTWeighted(float* pfVolume,
 
 }
 
-_AstraExport void uploadMultipleProjections(CFloat32ProjectionData3DGPU *proj,
+_AstraExport bool uploadMultipleProjections(CFloat32ProjectionData3DGPU *proj,
                                          const float *data,
                                          unsigned int y_min, unsigned int y_max)
 {
@@ -1317,8 +1317,10 @@ _AstraExport void uploadMultipleProjections(CFloat32ProjectionData3DGPU *proj,
 
 	cudaPitchedPtr D_proj = allocateProjectionData(dims1);
 	bool ok = copyProjectionsToDevice(data, D_proj, dims1);
-	if (!ok)
+	if (!ok) {
 		ASTRA_ERROR("Failed to upload projection to GPU");
+		return false;
+	}
 
 	astraCUDA3d::MemHandle3D hnd1 = astraCUDA3d::wrapHandle(
 			(float *)D_proj.ptr,
@@ -1338,11 +1340,13 @@ _AstraExport void uploadMultipleProjections(CFloat32ProjectionData3DGPU *proj,
 	subdims.subz = 0;
 
 	ok = astraCUDA3d::copyIntoArray(hnd, hnd1, subdims);
-	if (!ok)
+	if (!ok) {
 		ASTRA_ERROR("Failed to copy projection into 3d data");
+		return false;
+	}
 
 	cudaFree(D_proj.ptr);
-
+	return true;
 }
 
 

--- a/include/astra/Globals.h
+++ b/include/astra/Globals.h
@@ -65,10 +65,6 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #define ASTRA_ASSERT(a) assert(a)
 
-#define ASTRA_CONFIG_CHECK(value, type, msg) if (!(value)) { std::cout << "Configuration Error in " << type << ": " << msg << std::endl; return false; }
-
-#define ASTRA_CONFIG_WARNING(type, msg) { std::cout << "Warning in " << type << ": " << msg << sdt::endl; }
-
 
 #define ASTRA_DELETE(a) if (a) { delete a; a = NULL; }
 #define ASTRA_DELETE_ARRAY(a) if (a) { delete[] a; a = NULL; }

--- a/include/astra/Logging.h
+++ b/include/astra/Logging.h
@@ -54,7 +54,9 @@ class _AstraExport CLogger
   static bool m_bEnabledScreen;
   static bool m_bFileProvided;
   static bool m_bInitialized;
+  static std::string m_sLastErrMsg;
   static void _assureIsInitialized();
+  static void _setLastErrMsg(const char *sfile, int sline, const char *fmt, va_list ap);
   static void _setLevel(int id, log_level m_eLevel);
 
 public:
@@ -152,6 +154,11 @@ public:
    */
   static bool setCallbackScreen(void (*cb)(const char *msg, size_t len));
 
+  /**
+   * Get last error message received by the logger.
+   *
+   */
+  static std::string getLastErrMsg();
 };
 
 }

--- a/include/astra/Logging.h
+++ b/include/astra/Logging.h
@@ -34,6 +34,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 #define ASTRA_INFO(...) astra::CLogger::info(__FILE__,__LINE__, __VA_ARGS__)
 #define ASTRA_WARN(...) astra::CLogger::warn(__FILE__,__LINE__, __VA_ARGS__)
 #define ASTRA_ERROR(...) astra::CLogger::error(__FILE__,__LINE__, __VA_ARGS__)
+#define ASTRA_CONFIG_CHECK(value, type, msg) if (!(value)) { astra::CLogger::error(__FILE__,__LINE__,"Configuration error in " type ". " msg); return false; }
+#define ASTRA_CONFIG_WARNING(type, msg) { astra::CLogger::warn(__FILE__,__LINE__,"Warning in " type ". " msg); }
 
 namespace astra
 {

--- a/include/astra/Logging.h
+++ b/include/astra/Logging.h
@@ -35,7 +35,6 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 #define ASTRA_WARN(...) astra::CLogger::warn(__FILE__,__LINE__, __VA_ARGS__)
 #define ASTRA_ERROR(...) astra::CLogger::error(__FILE__,__LINE__, __VA_ARGS__)
 #define ASTRA_CONFIG_CHECK(value, type, msg) if (!(value)) { astra::CLogger::error(__FILE__,__LINE__,"Configuration error in " type ". " msg); return false; }
-#define ASTRA_CONFIG_WARNING(type, msg) { astra::CLogger::warn(__FILE__,__LINE__,"Warning in " type ". " msg); }
 
 namespace astra
 {

--- a/include/astra/cuda/3d/astra3d.h
+++ b/include/astra/cuda/3d/astra3d.h
@@ -301,7 +301,7 @@ _AstraExport bool astraCudaBP_SIRTWeighted(float* pfVolume, const float* pfProje
                       const CProjectionGeometry3D* pProjGeom,
                       int iGPUIndex, int iVoxelSuperSampling);
 
-_AstraExport void uploadMultipleProjections(CFloat32ProjectionData3DGPU *proj,
+_AstraExport bool uploadMultipleProjections(CFloat32ProjectionData3DGPU *proj,
                                             const float *data,
                                             unsigned int y_min,
                                             unsigned int y_max);

--- a/matlab/mex/astra_mex_algorithm_c.cpp
+++ b/matlab/mex/astra_mex_algorithm_c.cpp
@@ -89,8 +89,7 @@ void astra_mex_algorithm_create(int nlhs, mxArray* plhs[], int nrhs, const mxArr
 	if (!pAlg->initialize(*cfg)) {
 		delete cfg;
 		delete pAlg;
-		mexErrMsgTxt("Unable to initialize Algorithm. \n");
-		return;
+		mexErrMsgWithAstraLog("Unable to initialize Algorithm.");
 	}
 	delete cfg;
 

--- a/matlab/mex/astra_mex_algorithm_c.cpp
+++ b/matlab/mex/astra_mex_algorithm_c.cpp
@@ -67,12 +67,11 @@ using namespace astra;
 void astra_mex_algorithm_create(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
 { 
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 
 	if (!mxIsStruct(prhs[1])) {
-		mexErrMsgTxt("Argument 1 not a valid MATLAB struct. \n");
+		mexErrMsgTxt("Argument 1 not a valid MATLAB struct.");
 	}
 
 	// turn MATLAB struct to an XML-based Config object
@@ -81,15 +80,14 @@ void astra_mex_algorithm_create(int nlhs, mxArray* plhs[], int nrhs, const mxArr
 	CAlgorithm* pAlg = CAlgorithmFactory::getSingleton().create(cfg->self.getAttribute("type"));
 	if (!pAlg) {
 		delete cfg;
-		mexErrMsgTxt("Unknown Algorithm. \n");
-		return;
+		mexErrMsgTxt("Unknown algorithm type.");
 	}
 
 	// create algorithm
 	if (!pAlg->initialize(*cfg)) {
 		delete cfg;
 		delete pAlg;
-		mexErrMsgWithAstraLog("Unable to initialize Algorithm.");
+		mexErrMsgWithAstraLog("Unable to initialize algorithm.");
 	}
 	delete cfg;
 
@@ -120,8 +118,7 @@ void astra_mex_algorithm_run(int nlhs, mxArray* plhs[], int nrhs, const mxArray*
 { 
 	// step1: get input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	int iAid = (int)(mxGetScalar(prhs[1]));
 	int iIterations = 0;
@@ -132,12 +129,10 @@ void astra_mex_algorithm_run(int nlhs, mxArray* plhs[], int nrhs, const mxArray*
 	// step2: get algorithm object
 	CAlgorithm* pAlg = CAlgorithmManager::getSingleton().get(iAid);
 	if (!pAlg) {
-		mexErrMsgTxt("Invalid algorithm ID.\n");
-		return;
+		mexErrMsgTxt("Invalid algorithm ID.");
 	}
 	if (!pAlg->isInitialized()) {
-		mexErrMsgTxt("Algorithm not initialized. \n");
-		return;
+		mexErrMsgTxt("Algorithm not initialized.");
 	}
 
 	// step3: perform actions
@@ -158,20 +153,17 @@ void astra_mex_algorithm_get_res_norm(int nlhs, mxArray* plhs[], int nrhs, const
 { 
 	// step1: get input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	int iAid = (int)(mxGetScalar(prhs[1]));
 
 	// step2: get algorithm object
 	CAlgorithm* pAlg = CAlgorithmManager::getSingleton().get(iAid);
 	if (!pAlg) {
-		mexErrMsgTxt("Invalid algorithm ID.\n");
-		return;
+		mexErrMsgTxt("Invalid algorithm ID.");
 	}
 	if (!pAlg->isInitialized()) {
-		mexErrMsgTxt("Algorithm not initialized. \n");
-		return;
+		mexErrMsgTxt("Algorithm not initialized.");
 	}
 
 	CReconstructionAlgorithm2D* pAlg2D = dynamic_cast<CReconstructionAlgorithm2D*>(pAlg);
@@ -187,8 +179,7 @@ void astra_mex_algorithm_get_res_norm(int nlhs, mxArray* plhs[], int nrhs, const
 		ok = false;
 
 	if (!ok) {
-		mexErrMsgTxt("Operation not supported.\n");
-		return;
+		mexErrMsgTxt("Operation not supported.");
 	}
 
 	plhs[0] = mxCreateDoubleScalar(res);
@@ -204,8 +195,7 @@ void astra_mex_algorithm_delete(int nlhs, mxArray* plhs[], int nrhs, const mxArr
 {
 	// step1: get algorithm ID
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 
 	for (int i = 1; i < nrhs; i++) {

--- a/matlab/mex/astra_mex_algorithm_c.cpp
+++ b/matlab/mex/astra_mex_algorithm_c.cpp
@@ -132,7 +132,7 @@ void astra_mex_algorithm_run(int nlhs, mxArray* plhs[], int nrhs, const mxArray*
 		mexErrMsgTxt("Invalid algorithm ID.");
 	}
 	if (!pAlg->isInitialized()) {
-		mexErrMsgTxt("Algorithm not initialized.");
+		mexErrMsgTxt("Algorithm ID exists but is not initialized.");
 	}
 
 	// step3: perform actions
@@ -163,7 +163,7 @@ void astra_mex_algorithm_get_res_norm(int nlhs, mxArray* plhs[], int nrhs, const
 		mexErrMsgTxt("Invalid algorithm ID.");
 	}
 	if (!pAlg->isInitialized()) {
-		mexErrMsgTxt("Algorithm not initialized.");
+		mexErrMsgTxt("Algorithm ID exists but is not initialized.");
 	}
 
 	CReconstructionAlgorithm2D* pAlg2D = dynamic_cast<CReconstructionAlgorithm2D*>(pAlg);

--- a/matlab/mex/astra_mex_c.cpp
+++ b/matlab/mex/astra_mex_c.cpp
@@ -218,7 +218,7 @@ void astra_mex_info(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
 void astra_mex_delete(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
 {
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments. Usage: astra_mex('delete', index/indices);\n");
+		mexErrMsgTxt("Not enough arguments. Usage: astra_mex('delete', index/indices);");
 	}
 
 	for (int i = 1; i < nrhs; i++) {

--- a/matlab/mex/astra_mex_c.cpp
+++ b/matlab/mex/astra_mex_c.cpp
@@ -156,9 +156,8 @@ void astra_mex_get_gpu_info(int nlhs, mxArray* plhs[], int nrhs, const mxArray* 
  */
 void astra_mex_has_feature(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
 {
-	if (2 > nrhs) {
-		mexErrMsgTxt("Usage: astra_mex('has_feature', feature);\n");
-		return;
+	if (nrhs < 2) {
+		mexErrMsgTxt("Not enough arguments. Usage: astra_mex('has_feature', feature);");
 	}
 
 	string sMode = mexToString(prhs[0]);
@@ -200,8 +199,7 @@ void astra_mex_version(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[
 void astra_mex_info(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
 {
 	if (nrhs < 2) {
-		mexErrMsgTxt("Usage: astra_mex('info', index/indices);\n");
-		return;
+		mexErrMsgTxt("Not enough arguments. Usage: astra_mex('info', index/indices);");
 	}
 
 	for (int i = 1; i < nrhs; i++) {
@@ -220,8 +218,7 @@ void astra_mex_info(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
 void astra_mex_delete(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
 {
 	if (nrhs < 2) {
-		mexErrMsgTxt("Usage: astra_mex('delete', index/indices);\n");
-		return;
+		mexErrMsgTxt("Not enough arguments. Usage: astra_mex('delete', index/indices);\n");
 	}
 
 	for (int i = 1; i < nrhs; i++) {

--- a/matlab/mex/astra_mex_data2d_c.cpp
+++ b/matlab/mex/astra_mex_data2d_c.cpp
@@ -488,6 +488,9 @@ void astra_mex_data2d_change_geometry(int nlhs, mxArray* plhs[], int nrhs, const
 
 		return;
 	}
+
+	// Neither sinogram nor volume object
+	mexErrMsgTxt("Data object not found or not initialized properly.");
 }
 
 //-----------------------------------------------------------------------------------------

--- a/matlab/mex/astra_mex_data2d_c.cpp
+++ b/matlab/mex/astra_mex_data2d_c.cpp
@@ -101,7 +101,7 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 	CFloat32Data2D* pDataObject2D = NULL;
 
 	if (nrhs >= 4 && !(mexIsScalar(prhs[3])|| mxIsDouble(prhs[3]) || mxIsLogical(prhs[3]) || mxIsSingle(prhs[3]) )) {
-		mexErrMsgTxt("Data must be single, double or logical.");
+		mexErrMsgTxt("Data type must be single, double or logical.");
 		return;
 	}
 	if (mxIsSparse(prhs[2])) {
@@ -113,7 +113,7 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 	if (sDataType == "-vol") {
 		// Read geometry
 		if (!mxIsStruct(prhs[2])) {
-			mexErrMsgTxt("Argument 3 is not a valid MATLAB struct.\n");
+			mexErrMsgTxt("Argument 3 is not a valid MATLAB struct.");
 		}
 		
 		Config* cfg = structToConfig("VolumeGeometry", prhs[2]);
@@ -139,7 +139,7 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 	else if (sDataType == "-sino") {
 		// Read geometry
 		if (!mxIsStruct(prhs[2])) {
-			mexErrMsgTxt("Argument 3 is not a valid MATLAB struct.\n");
+			mexErrMsgTxt("Argument 3 is not a valid MATLAB struct.");
 		}
 		
 		Config* cfg = structToConfig("ProjectionGeometry", prhs[2]);
@@ -210,7 +210,7 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 			const mwSize* dims = mxGetDimensions(prhs[3]);
 			// Check Data dimensions
 			if (pDataObject2D->getWidth() != mxGetN(prhs[3]) || pDataObject2D->getHeight() != mxGetM(prhs[3])) {
-				mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry. \n");
+				mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry.");
 			}
 
 			// logical data		
@@ -281,7 +281,7 @@ void astra_mex_data2d_store(int nlhs, mxArray* plhs[], int nrhs, const mxArray* 
 	int iDataID = (int)(mxGetScalar(prhs[1]));
 
 	if (!(mexIsScalar(prhs[2]) || mxIsDouble(prhs[2]) || mxIsLogical(prhs[2]) || mxIsSingle(prhs[2]))) {
-		mexErrMsgTxt("Data must be single, double or logical.");
+		mexErrMsgTxt("Data type must be single, double or logical.");
 	}
 	if (mxIsSparse(prhs[2])) {
 		mexErrMsgTxt("Data may not be sparse.");
@@ -438,7 +438,7 @@ void astra_mex_data2d_change_geometry(int nlhs, mxArray* plhs[], int nrhs, const
 		if (!pGeometry->initialize(*cfg)) {
 			delete pGeometry;
 			delete cfg;
-			mexErrMsgWithAstraLog("Geometry class not initialized.");
+			mexErrMsgWithAstraLog("Geometry could not be initialized.");
 		}
 		// If data is specified, check dimensions
 		if (pGeometry->getDetectorCount() != pSinogram->getDetectorCount() || pGeometry->getProjectionAngleCount() != pSinogram->getAngleCount()) {
@@ -469,7 +469,7 @@ void astra_mex_data2d_change_geometry(int nlhs, mxArray* plhs[], int nrhs, const
 		if (!pGeometry->initialize(*cfg)) {
 			delete cfg;
 			delete pGeometry;
-			mexErrMsgWithAstraLog("Geometry class not initialized.");
+			mexErrMsgWithAstraLog("Geometry class could not be initialized.");
 		}
 		// If data is specified, check dimensions
 		if (pGeometry->getGridColCount() != pVolume->getWidth() || pGeometry->getGridRowCount() != pVolume->getHeight()) {

--- a/matlab/mex/astra_mex_data2d_c.cpp
+++ b/matlab/mex/astra_mex_data2d_c.cpp
@@ -157,9 +157,12 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 		} else if (type == "fanflat_vec") {
 			pGeometry = new CFanFlatVecProjectionGeometry2D();	
 		} else if (type == "parallel_vec") {
-			pGeometry = new CParallelVecProjectionGeometry2D();	
+			pGeometry = new CParallelVecProjectionGeometry2D();
+		} else if (type == "parallel") {
+			pGeometry = new CParallelProjectionGeometry2D();
 		} else {
-			pGeometry = new CParallelProjectionGeometry2D();	
+			std::string message = "'" + type + "' is not a valid 2D geometry type.";
+			mexErrMsgTxt(message.c_str());
 		}
 		if (!pGeometry->initialize(*cfg)) {
 			delete pGeometry;

--- a/matlab/mex/astra_mex_data2d_c.cpp
+++ b/matlab/mex/astra_mex_data2d_c.cpp
@@ -59,8 +59,7 @@ void astra_mex_data2d_delete(int nlhs, mxArray* plhs[], int nrhs, const mxArray*
 { 
 	// step1: read input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 
 	// step2: delete all specified data objects
@@ -95,8 +94,7 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 { 
 	// step1: get datatype
 	if (nrhs < 3) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 
 	string sDataType = mexToString(prhs[1]);	
@@ -128,10 +126,9 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 		// If data is specified, check dimensions
 		if (nrhs >= 4 && !mexIsScalar(prhs[3])) {
 			if (pGeometry->getGridColCount() != mxGetN(prhs[3]) || pGeometry->getGridRowCount() != mxGetM(prhs[3])) {
-				mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry. \n");
 				delete cfg;
 				delete pGeometry;
-				return;
+				mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry.");
 			}
 		}
 		// Initialize data object
@@ -172,10 +169,9 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 		// If data is specified, check dimensions
 		if (nrhs >= 4 && !mexIsScalar(prhs[3])) {
 			if (pGeometry->getDetectorCount() != mxGetN(prhs[3]) || pGeometry->getProjectionAngleCount() != mxGetM(prhs[3])) {
-				mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry. \n");
 				delete pGeometry;
 				delete cfg;
-				return;
+				mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry.");
 			}
 		}
 		// Initialize data object
@@ -184,8 +180,7 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 		delete cfg;
 	}
 	else {
-		mexErrMsgTxt("Invalid datatype.  Please specify '-vol' or '-sino'. \n");
-		return;
+		mexErrMsgTxt("Invalid datatype. Please specify '-vol' or '-sino'.");
 	}
 
 	// Check initialization
@@ -216,7 +211,6 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 			// Check Data dimensions
 			if (pDataObject2D->getWidth() != mxGetN(prhs[3]) || pDataObject2D->getHeight() != mxGetM(prhs[3])) {
 				mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry. \n");
-				return;
 			}
 
 			// logical data		
@@ -262,7 +256,7 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 	int iIndex = CData2DManager::getSingleton().store(pDataObject2D);
 
 	// step5: return data id
-	if (1 <= nlhs) {
+	if (nlhs >= 1) {
 		plhs[0] = mxCreateDoubleScalar(iIndex);
 	}
 
@@ -279,29 +273,24 @@ void astra_mex_data2d_store(int nlhs, mxArray* plhs[], int nrhs, const mxArray* 
 {
 	// step1: input
 	if (nrhs < 3) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	if (!mxIsDouble(prhs[1])) {
-		mexErrMsgTxt("Identifier should be a scalar value. \n");
-		return;
+		mexErrMsgTxt("Identifier should be a scalar value.");
 	}
 	int iDataID = (int)(mxGetScalar(prhs[1]));
 
 	if (!(mexIsScalar(prhs[2]) || mxIsDouble(prhs[2]) || mxIsLogical(prhs[2]) || mxIsSingle(prhs[2]))) {
 		mexErrMsgTxt("Data must be single, double or logical.");
-		return;
 	}
 	if (mxIsSparse(prhs[2])) {
 		mexErrMsgTxt("Data may not be sparse.");
-		return;
 	}
 
 	// step2: get data object
 	CFloat32Data2D* pDataObject = astra::CData2DManager::getSingleton().get(iDataID);
 	if (!pDataObject || !pDataObject->isInitialized()) {
-		mexErrMsgTxt("Data object not found or not initialized properly.\n");
-		return;
+		mexErrMsgTxt("Data object not found or not initialized properly.");
 	}
 	
 	// step3: insert data
@@ -314,8 +303,7 @@ void astra_mex_data2d_store(int nlhs, mxArray* plhs[], int nrhs, const mxArray* 
 	} else {
 		// Check Data dimensions
 		if (pDataObject->getWidth() != mxGetN(prhs[2]) || pDataObject->getHeight() != mxGetM(prhs[2])) {
-			mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry. \n");
-			return;
+			mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry.");
 		}
 		const mwSize* dims = mxGetDimensions(prhs[2]);
 
@@ -369,20 +357,17 @@ void astra_mex_data2d_get_geometry(int nlhs, mxArray* plhs[], int nrhs, const mx
 { 
 	// parse input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	if (!mxIsDouble(prhs[1])) {
-		mexErrMsgTxt("Identifier should be a scalar value. \n");
-		return;
+		mexErrMsgTxt("Identifier should be a scalar value.");
 	}
 	int iDataID = (int)(mxGetScalar(prhs[1]));
 
 	// fetch data object
 	CFloat32Data2D* pDataObject = astra::CData2DManager::getSingleton().get(iDataID);
 	if (!pDataObject || !pDataObject->isInitialized()) {
-		mexErrMsgTxt("Data object not found or not initialized properly.\n");
-		return;
+		mexErrMsgTxt("Data object not found or not initialized properly.");
 	}
 
 	// create output
@@ -409,20 +394,17 @@ void astra_mex_data2d_change_geometry(int nlhs, mxArray* plhs[], int nrhs, const
 { 
 	// step1: check input
 	if (nrhs < 3) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	if (!mxIsDouble(prhs[1])) {
-		mexErrMsgTxt("Identifier should be a scalar value. \n");
-		return;
+		mexErrMsgTxt("Identifier should be a scalar value.");
 	}
 
 	// step2: get data object
 	int iDataID = (int)(mxGetScalar(prhs[1]));
 	CFloat32Data2D* pDataObject = astra::CData2DManager::getSingleton().get(iDataID);
 	if (!pDataObject || !pDataObject->isInitialized()) {
-		mexErrMsgTxt("Data object not found or not initialized properly.\n");
-		return;
+		mexErrMsgTxt("Data object not found or not initialized properly.");
 	}
 
 	CFloat32ProjectionData2D* pSinogram = dynamic_cast<CFloat32ProjectionData2D*>(pDataObject);
@@ -432,7 +414,7 @@ void astra_mex_data2d_change_geometry(int nlhs, mxArray* plhs[], int nrhs, const
 
 		// Read geometry
 		if (!mxIsStruct(prhs[2])) {
-			mexErrMsgTxt("Argument 3 is not a valid MATLAB struct.\n");
+			mexErrMsgTxt("Argument 3 is not a valid MATLAB struct.");
 		}
 		Config* cfg = structToConfig("ProjectionGeometry2D", prhs[2]);
 		// FIXME: Change how the base class is created. (This is duplicated
@@ -460,10 +442,9 @@ void astra_mex_data2d_change_geometry(int nlhs, mxArray* plhs[], int nrhs, const
 		}
 		// If data is specified, check dimensions
 		if (pGeometry->getDetectorCount() != pSinogram->getDetectorCount() || pGeometry->getProjectionAngleCount() != pSinogram->getAngleCount()) {
-			mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry. \n");
 			delete pGeometry;
 			delete cfg;
-			return;
+			mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry.");
 		}
 
 		// If ok, change geometry
@@ -481,7 +462,7 @@ void astra_mex_data2d_change_geometry(int nlhs, mxArray* plhs[], int nrhs, const
 
 		// Read geometry
 		if (!mxIsStruct(prhs[2])) {
-			mexErrMsgTxt("Argument 3 is not a valid MATLAB struct.\n");
+			mexErrMsgTxt("Argument 3 is not a valid MATLAB struct.");
 		}
 		Config* cfg = structToConfig("VolumeGeometry2D", prhs[2]);
 		CVolumeGeometry2D* pGeometry = new CVolumeGeometry2D();
@@ -492,10 +473,9 @@ void astra_mex_data2d_change_geometry(int nlhs, mxArray* plhs[], int nrhs, const
 		}
 		// If data is specified, check dimensions
 		if (pGeometry->getGridColCount() != pVolume->getWidth() || pGeometry->getGridRowCount() != pVolume->getHeight()) {
-			mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry. \n");
 			delete cfg;
 			delete pGeometry;
-			return;
+			mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry.");
 		}
 
 		// If ok, change geometry
@@ -503,10 +483,8 @@ void astra_mex_data2d_change_geometry(int nlhs, mxArray* plhs[], int nrhs, const
 		delete cfg;
 		delete pGeometry;
 
+		return;
 	}
-
-	mexErrMsgTxt("Data object not found or not initialized properly.\n");
-	return;
 }
 
 //-----------------------------------------------------------------------------------------
@@ -520,20 +498,17 @@ void astra_mex_data2d_get(int nlhs, mxArray* plhs[], int nrhs, const mxArray* pr
 { 
 	// step1: check input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	if (!mxIsDouble(prhs[1])) {
-		mexErrMsgTxt("Identifier should be a scalar value. \n");
-		return;
+		mexErrMsgTxt("Identifier should be a scalar value.");
 	}
 
 	// step2: get data object
 	int iDataID = (int)(mxGetScalar(prhs[1]));
 	CFloat32Data2D* pDataObject = astra::CData2DManager::getSingleton().get(iDataID);
 	if (!pDataObject || !pDataObject->isInitialized()) {
-		mexErrMsgTxt("Data object not found or not initialized properly.\n");
-		return;
+		mexErrMsgTxt("Data object not found or not initialized properly.");
 	}
 
 	// create output
@@ -565,20 +540,17 @@ void astra_mex_data2d_get_single(int nlhs, mxArray* plhs[], int nrhs, const mxAr
 { 
 	// step1: check input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	if (!mxIsDouble(prhs[1])) {
-		mexErrMsgTxt("Identifier should be a scalar value. \n");
-		return;
+		mexErrMsgTxt("Identifier should be a scalar value.");
 	}
 
 	// step2: get data object
 	int iDataID = (int)(mxGetScalar(prhs[1]));
 	CFloat32Data2D* pDataObject = astra::CData2DManager::getSingleton().get(iDataID);
 	if (!pDataObject || !pDataObject->isInitialized()) {
-		mexErrMsgTxt("Data object not found or not initialized properly.\n");
-		return;
+		mexErrMsgTxt("Data object not found or not initialized properly.");
 	}
 
 	// create output

--- a/matlab/mex/astra_mex_data2d_c.cpp
+++ b/matlab/mex/astra_mex_data2d_c.cpp
@@ -121,10 +121,9 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 		Config* cfg = structToConfig("VolumeGeometry", prhs[2]);
 		CVolumeGeometry2D* pGeometry = new CVolumeGeometry2D();
 		if (!pGeometry->initialize(*cfg)) {
-			mexErrMsgTxt("Geometry class not initialized. \n");
 			delete cfg;
 			delete pGeometry;
-			return;
+			mexErrMsgWithAstraLog("Geometry class could not be initialized.");
 		}
 		// If data is specified, check dimensions
 		if (nrhs >= 4 && !mexIsScalar(prhs[3])) {
@@ -166,10 +165,9 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 			pGeometry = new CParallelProjectionGeometry2D();	
 		}
 		if (!pGeometry->initialize(*cfg)) {
-			mexErrMsgTxt("Geometry class not initialized. \n");
 			delete pGeometry;
 			delete cfg;
-			return;
+			mexErrMsgWithAstraLog("Geometry class could not be initialized.");
 		}
 		// If data is specified, check dimensions
 		if (nrhs >= 4 && !mexIsScalar(prhs[3])) {
@@ -192,9 +190,8 @@ void astra_mex_data2d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 
 	// Check initialization
 	if (!pDataObject2D->isInitialized()) {
-		mexErrMsgTxt("Couldn't initialize data object.\n");
 		delete pDataObject2D;
-		return;
+		mexErrMsgWithAstraLog("Couldn't initialize data object.");
 	}
 
 	// Store data
@@ -457,10 +454,9 @@ void astra_mex_data2d_change_geometry(int nlhs, mxArray* plhs[], int nrhs, const
 			pGeometry = new CParallelProjectionGeometry2D();	
 		}
 		if (!pGeometry->initialize(*cfg)) {
-			mexErrMsgTxt("Geometry class not initialized. \n");
 			delete pGeometry;
 			delete cfg;
-			return;
+			mexErrMsgWithAstraLog("Geometry class not initialized.");
 		}
 		// If data is specified, check dimensions
 		if (pGeometry->getDetectorCount() != pSinogram->getDetectorCount() || pGeometry->getProjectionAngleCount() != pSinogram->getAngleCount()) {
@@ -490,10 +486,9 @@ void astra_mex_data2d_change_geometry(int nlhs, mxArray* plhs[], int nrhs, const
 		Config* cfg = structToConfig("VolumeGeometry2D", prhs[2]);
 		CVolumeGeometry2D* pGeometry = new CVolumeGeometry2D();
 		if (!pGeometry->initialize(*cfg)) {
-			mexErrMsgTxt("Geometry class not initialized. \n");
 			delete cfg;
 			delete pGeometry;
-			return;
+			mexErrMsgWithAstraLog("Geometry class not initialized.");
 		}
 		// If data is specified, check dimensions
 		if (pGeometry->getGridColCount() != pVolume->getWidth() || pGeometry->getGridRowCount() != pVolume->getHeight()) {

--- a/matlab/mex/astra_mex_data3d_c.cpp
+++ b/matlab/mex/astra_mex_data3d_c.cpp
@@ -355,10 +355,9 @@ void astra_mex_data3d_change_geometry(int nlhs, mxArray* plhs[], int nrhs, const
 		}
 
 		if (!pGeometry->initialize(*cfg)) {
-			mexErrMsgTxt("Geometry class not initialized. \n");
 			delete pGeometry;
 			delete cfg;
-			return;
+			mexErrMsgWithAstraLog("Geometry class not initialized.");
 		}
 		delete cfg;
 
@@ -385,10 +384,9 @@ void astra_mex_data3d_change_geometry(int nlhs, mxArray* plhs[], int nrhs, const
 		astra::CVolumeGeometry3D* pGeometry = new astra::CVolumeGeometry3D();
 		if (!pGeometry->initialize(*cfg))
 		{
-			mexErrMsgTxt("Geometry class not initialized. \n");
 			delete pGeometry;
 			delete cfg;
-			return;
+			mexErrMsgWithAstraLog("Geometry class not initialized.");
 		}
 		delete cfg;
 

--- a/matlab/mex/astra_mex_data3d_c.cpp
+++ b/matlab/mex/astra_mex_data3d_c.cpp
@@ -75,7 +75,7 @@ void astra_mex_data3d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 	}
 
 	if (data && !checkDataType(data)) {
-		mexErrMsgTxt("Data must be single, double or logical.");
+		mexErrMsgTxt("Data type must be single, double or logical.");
 	}
 
 	const string sDataType = mexToString(prhs[1]);
@@ -210,7 +210,7 @@ void astra_mex_data3d_store(int nlhs, mxArray* plhs[], int nrhs, const mxArray* 
 	}
 
 	if (!checkDataType(prhs[2])) {
-		mexErrMsgTxt("Data must be single or double.");
+		mexErrMsgTxt("Data type must be single or double.");
 	}
 
 	// step2: get data object
@@ -233,7 +233,7 @@ void astra_mex_data3d_dimensions(int nlhs, mxArray* plhs[], int nrhs, const mxAr
 	// step2: get data object
 	CFloat32Data3D* pData;
 	if (!(pData = CData3DManager::getSingleton().get(iDid))) {
-		mexErrMsgTxt("DataObject not valid.");
+		mexErrMsgTxt("Data object not found.");
 	}
 
 	// step3: output
@@ -339,7 +339,7 @@ void astra_mex_data3d_change_geometry(int nlhs, mxArray* plhs[], int nrhs, const
 		if (!pGeometry->initialize(*cfg)) {
 			delete pGeometry;
 			delete cfg;
-			mexErrMsgWithAstraLog("Geometry class not initialized.");
+			mexErrMsgWithAstraLog("Geometry class could not be initialized.");
 		}
 		delete cfg;
 
@@ -367,7 +367,7 @@ void astra_mex_data3d_change_geometry(int nlhs, mxArray* plhs[], int nrhs, const
 		{
 			delete pGeometry;
 			delete cfg;
-			mexErrMsgWithAstraLog("Geometry class not initialized.");
+			mexErrMsgWithAstraLog("Geometry class could not be initialized.");
 		}
 		delete cfg;
 

--- a/matlab/mex/astra_mex_data3d_c.cpp
+++ b/matlab/mex/astra_mex_data3d_c.cpp
@@ -64,21 +64,18 @@ void astra_mex_data3d_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 { 
 	// step1: get datatype
 	if (nrhs < 3) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 
 	const mxArray * const geometry = prhs[2];
 	const mxArray * const data = nrhs > 3 ? prhs[3] : NULL;
 
 	if (!checkStructs(geometry)) {
-		mexErrMsgTxt("Argument 3 is not a valid MATLAB struct.\n");
-		return;
+		mexErrMsgTxt("Argument 3 is not a valid MATLAB struct.");
 	}
 
 	if (data && !checkDataType(data)) {
 		mexErrMsgTxt("Data must be single, double or logical.");
-		return;
 	}
 
 	const string sDataType = mexToString(prhs[1]);
@@ -130,8 +127,7 @@ void astra_mex_data3d_link(int& nlhs, mxArray* plhs[], int& nrhs, const mxArray*
 	// TODO: Allow empty argument to let this function create its own mxArray
 	// step1: get datatype
 	if (nrhs < 4) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 
 	const mxArray * const geometry = prhs[2];
@@ -140,13 +136,11 @@ void astra_mex_data3d_link(int& nlhs, mxArray* plhs[], int& nrhs, const mxArray*
 	const mxArray * const zIndex = nrhs > 5 ? prhs[5] : NULL;
 
 	if (!checkStructs(geometry)) {
-		mexErrMsgTxt("Argument 3 is not a valid MATLAB struct.\n");
-		return;
+		mexErrMsgTxt("Argument 3 is not a valid MATLAB struct.");
 	}
 
 	if (data && !mxIsSingle(data)) {
 		mexErrMsgTxt("Data must be single.");
-		return;
 	}
 
 	string sDataType = mexToString(prhs[1]);
@@ -212,20 +206,17 @@ void astra_mex_data3d_store(int nlhs, mxArray* plhs[], int nrhs, const mxArray* 
 { 
 	// step1: input
 	if (nrhs < 3) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 
 	if (!checkDataType(prhs[2])) {
 		mexErrMsgTxt("Data must be single or double.");
-		return;
 	}
 
 	// step2: get data object
 	CFloat32Data3DMemory* pDataObject = NULL;
 	if (!checkID(mxGetScalar(prhs[1]), pDataObject)) {
 		mexErrMsgTxt("Data object not found or not initialized properly.\n");
-		return;
 	}
 
 	copyMexToCFloat32Array(prhs[2], pDataObject->getData(), pDataObject->getSize());
@@ -235,16 +226,14 @@ void astra_mex_data3d_dimensions(int nlhs, mxArray* plhs[], int nrhs, const mxAr
 {
 	// step1: get input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	int iDid = (int)(mxGetScalar(prhs[1]));
 
 	// step2: get data object
 	CFloat32Data3D* pData;
 	if (!(pData = CData3DManager::getSingleton().get(iDid))) {
-		mexErrMsgTxt("DataObject not valid. \n");
-		return;
+		mexErrMsgTxt("DataObject not valid.");
 	}
 
 	// step3: output
@@ -270,20 +259,17 @@ void astra_mex_data3d_get_geometry(int nlhs, mxArray* plhs[], int nrhs, const mx
 { 
 	// parse input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	if (!mxIsDouble(prhs[1])) {
-		mexErrMsgTxt("Identifier should be a scalar value. \n");
-		return;
+		mexErrMsgTxt("Identifier should be a scalar value.");
 	}
 	int iDataID = (int)(mxGetScalar(prhs[1]));
 
 	// fetch data object
 	CFloat32Data3D* pDataObject = astra::CData3DManager::getSingleton().get(iDataID);
 	if (!pDataObject || !pDataObject->isInitialized()) {
-		mexErrMsgTxt("Data object not found or not initialized properly.\n");
-		return;
+		mexErrMsgTxt("Data object not found or not initialized properly.");
 	}
 
 	// create output
@@ -313,22 +299,19 @@ void astra_mex_data3d_change_geometry(int nlhs, mxArray* plhs[], int nrhs, const
 {
 	// parse input
 	if (nrhs < 3) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 
 	// get data object
 	CFloat32Data3DMemory* pDataObject = NULL;
 	if (!checkID(mxGetScalar(prhs[1]), pDataObject)) {
-		mexErrMsgTxt("Data object not found or not initialized properly.\n");
-		return;
+		mexErrMsgTxt("Data object not found or not initialized properly.");
 	}
 
 	const mxArray * const geometry = prhs[2];
 
 	if (!checkStructs(geometry)) {
-		mexErrMsgTxt("Argument 3 is not a valid MATLAB struct.\n");
-		return;
+		mexErrMsgTxt("Argument 3 is not a valid MATLAB struct.");
 	}
 
 	CFloat32ProjectionData3D* pProjData = dynamic_cast<CFloat32ProjectionData3D*>(pDataObject);
@@ -350,8 +333,7 @@ void astra_mex_data3d_change_geometry(int nlhs, mxArray* plhs[], int nrhs, const
 		} else if (type == "cone_vec") {
 			pGeometry = new astra::CConeVecProjectionGeometry3D();
 		} else {
-			mexErrMsgTxt("Invalid geometry type.\n");
-			return;
+			mexErrMsgTxt("Invalid geometry type.");
 		}
 
 		if (!pGeometry->initialize(*cfg)) {
@@ -366,9 +348,8 @@ void astra_mex_data3d_change_geometry(int nlhs, mxArray* plhs[], int nrhs, const
 		    pGeometry->getProjectionCount() != pProjData->getAngleCount() ||
 		    pGeometry->getDetectorRowCount() != pProjData->getDetectorRowCount())
 		{
-			mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry. \n");
 			delete pGeometry;
-			return;
+			mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry.");
 		}
 
 		// If ok, change geometry
@@ -395,9 +376,8 @@ void astra_mex_data3d_change_geometry(int nlhs, mxArray* plhs[], int nrhs, const
 		    pGeometry->getGridRowCount() != pVolData->getRowCount() ||
 		    pGeometry->getGridSliceCount() != pVolData->getSliceCount())
 		{
-			mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry. \n");
 			delete pGeometry;
-			return;
+			mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry.");
 		}
 
 		// If ok, change geometry
@@ -414,8 +394,7 @@ void astra_mex_data3d_delete(int nlhs, mxArray* plhs[], int nrhs, const mxArray*
 { 
 	// step1: read input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 
 	for (int i = 1; i < nrhs; i++) {

--- a/matlab/mex/astra_mex_data3d_c.cpp
+++ b/matlab/mex/astra_mex_data3d_c.cpp
@@ -333,7 +333,8 @@ void astra_mex_data3d_change_geometry(int nlhs, mxArray* plhs[], int nrhs, const
 		} else if (type == "cone_vec") {
 			pGeometry = new astra::CConeVecProjectionGeometry3D();
 		} else {
-			mexErrMsgTxt("Invalid geometry type.");
+			std::string message = "'" + type + "' is not a valid 3D geometry type.";
+			mexErrMsgTxt(message.c_str());
 		}
 
 		if (!pGeometry->initialize(*cfg)) {

--- a/matlab/mex/astra_mex_direct_c.cpp
+++ b/matlab/mex/astra_mex_direct_c.cpp
@@ -74,7 +74,6 @@ void astra_mex_direct_fp3d(int& nlhs, mxArray* plhs[], int& nrhs, const mxArray*
 
 	if (nrhs < 3) {
 		mexErrMsgTxt("Not enough arguments. Syntax: astra_mex_direct_c('FP3D', projector_id, data)");
-		return;
 	}
 
 	int iPid = (int)(mxGetScalar(prhs[1]));
@@ -82,18 +81,15 @@ void astra_mex_direct_fp3d(int& nlhs, mxArray* plhs[], int& nrhs, const mxArray*
 	pProjector = astra::CProjector3DManager::getSingleton().get(iPid);
 	if (!pProjector) {
 		mexErrMsgTxt("Projector not found.");
-		return;
 	}
 	if (!pProjector->isInitialized()) {
 		mexErrMsgTxt("Projector not initialized.");
-		return;
 	}
 	bool isCuda = false;
 	if (dynamic_cast<CCudaProjector3D*>(pProjector))
 		isCuda = true;
 	if (!isCuda) {
 		mexErrMsgTxt("Only CUDA projectors are currently supported.");
-		return;
 	}
 
 	astra::CVolumeGeometry3D* pVolGeom = pProjector->getVolumeGeometry();
@@ -102,12 +98,10 @@ void astra_mex_direct_fp3d(int& nlhs, mxArray* plhs[], int& nrhs, const mxArray*
 	const mxArray* const data = prhs[2];
 	if (!checkDataType(data)) {
 		mexErrMsgTxt("Data must be single or double.");
-		return;
 	}
 
 	if (!checkDataSize(data, pVolGeom)) {
 		mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry.");
-		return;
 	}
 
 
@@ -189,7 +183,6 @@ void astra_mex_direct_bp3d(int& nlhs, mxArray* plhs[], int& nrhs, const mxArray*
 
 	if (nrhs < 3) {
 		mexErrMsgTxt("Not enough arguments. Syntax: astra_mex_direct_c('BP3D', projector_id, data)");
-		return;
 	}
 
 	int iPid = (int)(mxGetScalar(prhs[1]));
@@ -197,18 +190,15 @@ void astra_mex_direct_bp3d(int& nlhs, mxArray* plhs[], int& nrhs, const mxArray*
 	pProjector = astra::CProjector3DManager::getSingleton().get(iPid);
 	if (!pProjector) {
 		mexErrMsgTxt("Projector not found.");
-		return;
 	}
 	if (!pProjector->isInitialized()) {
 		mexErrMsgTxt("Projector not initialized.");
-		return;
 	}
 	bool isCuda = false;
 	if (dynamic_cast<CCudaProjector3D*>(pProjector))
 		isCuda = true;
 	if (!isCuda) {
 		mexErrMsgTxt("Only CUDA projectors are currently supported.");
-		return;
 	}
 
 	astra::CVolumeGeometry3D* pVolGeom = pProjector->getVolumeGeometry();
@@ -217,12 +207,10 @@ void astra_mex_direct_bp3d(int& nlhs, mxArray* plhs[], int& nrhs, const mxArray*
 	const mxArray* const data = prhs[2];
 	if (!checkDataType(data)) {
 		mexErrMsgTxt("Data must be single or double.");
-		return;
 	}
 
 	if (!checkDataSize(data, pProjGeom)) {
 		mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry.");
-		return;
 	}
 
 
@@ -324,7 +312,6 @@ void mexFunction(int nlhs, mxArray* plhs[],
 
 #ifndef ASTRA_CUDA
 	mexErrMsgTxt("Only CUDA projectors are currently supported.");
-	return;
 #else
 
 	// 3D data

--- a/matlab/mex/astra_mex_direct_c.cpp
+++ b/matlab/mex/astra_mex_direct_c.cpp
@@ -155,12 +155,11 @@ void astra_mex_direct_fp3d(int& nlhs, mxArray* plhs[], int& nrhs, const mxArray*
 	pAlg->initialize(pProjector, pOutput, pInput);
 
 	if (!pAlg->isInitialized()) {
-		mexErrMsgTxt("Error initializing algorithm.");
 		// TODO: Delete pOutputMx?
 		delete pAlg;
 		delete pInput;
 		delete pOutput;
-		return;
+		mexErrMsgWithAstraLog("Error initializing algorithm.");
 	}
 
 	pAlg->run();
@@ -271,12 +270,11 @@ void astra_mex_direct_bp3d(int& nlhs, mxArray* plhs[], int& nrhs, const mxArray*
 	pAlg->initialize(pProjector, pInput, pOutput);
 
 	if (!pAlg->isInitialized()) {
-		mexErrMsgTxt("Error initializing algorithm.");
 		// TODO: Delete pOutputMx?
 		delete pAlg;
 		delete pInput;
 		delete pOutput;
-		return;
+		mexErrMsgWithAstraLog("Error initializing algorithm.");
 	}
 
 	pAlg->run();

--- a/matlab/mex/astra_mex_direct_c.cpp
+++ b/matlab/mex/astra_mex_direct_c.cpp
@@ -73,7 +73,7 @@ void astra_mex_direct_fp3d(int& nlhs, mxArray* plhs[], int& nrhs, const mxArray*
 	// TODO: Add an optional way of specifying extra options
 
 	if (nrhs < 3) {
-		mexErrMsgTxt("Not enough arguments. Syntax: astra_mex_direct_c('FP3D', projector_id, data)");
+		mexErrMsgTxt("Not enough arguments. Syntax: astra_mex_direct_c('FP3D', projector_id, data);");
 	}
 
 	int iPid = (int)(mxGetScalar(prhs[1]));
@@ -83,7 +83,7 @@ void astra_mex_direct_fp3d(int& nlhs, mxArray* plhs[], int& nrhs, const mxArray*
 		mexErrMsgTxt("Projector not found.");
 	}
 	if (!pProjector->isInitialized()) {
-		mexErrMsgTxt("Projector not initialized.");
+		mexErrMsgTxt("Projector exists but is not initialized.");
 	}
 	bool isCuda = false;
 	if (dynamic_cast<CCudaProjector3D*>(pProjector))
@@ -97,7 +97,7 @@ void astra_mex_direct_fp3d(int& nlhs, mxArray* plhs[], int& nrhs, const mxArray*
 
 	const mxArray* const data = prhs[2];
 	if (!checkDataType(data)) {
-		mexErrMsgTxt("Data must be single or double.");
+		mexErrMsgTxt("Data type must be single or double.");
 	}
 
 	if (!checkDataSize(data, pVolGeom)) {
@@ -182,7 +182,7 @@ void astra_mex_direct_bp3d(int& nlhs, mxArray* plhs[], int& nrhs, const mxArray*
 	// TODO: Add an optional way of specifying extra options
 
 	if (nrhs < 3) {
-		mexErrMsgTxt("Not enough arguments. Syntax: astra_mex_direct_c('BP3D', projector_id, data)");
+		mexErrMsgTxt("Not enough arguments. Syntax: astra_mex_direct_c('BP3D', projector_id, data);");
 	}
 
 	int iPid = (int)(mxGetScalar(prhs[1]));
@@ -192,7 +192,7 @@ void astra_mex_direct_bp3d(int& nlhs, mxArray* plhs[], int& nrhs, const mxArray*
 		mexErrMsgTxt("Projector not found.");
 	}
 	if (!pProjector->isInitialized()) {
-		mexErrMsgTxt("Projector not initialized.");
+		mexErrMsgTxt("Projector exists but is not initialized.");
 	}
 	bool isCuda = false;
 	if (dynamic_cast<CCudaProjector3D*>(pProjector))
@@ -206,7 +206,7 @@ void astra_mex_direct_bp3d(int& nlhs, mxArray* plhs[], int& nrhs, const mxArray*
 
 	const mxArray* const data = prhs[2];
 	if (!checkDataType(data)) {
-		mexErrMsgTxt("Data must be single or double.");
+		mexErrMsgTxt("Data type must be single or double.");
 	}
 
 	if (!checkDataSize(data, pProjGeom)) {

--- a/matlab/mex/astra_mex_log_c.cpp
+++ b/matlab/mex/astra_mex_log_c.cpp
@@ -244,7 +244,7 @@ void astra_mex_log_output(int nlhs, mxArray* plhs[], int nrhs, const mxArray* pr
 		}
 		astra::CLogger::setOutputScreen(fd,eLevel);
 	} else {
-		mexErrMsgTxt("Specify which output to set ('file' or 'screen')".);
+		mexErrMsgTxt("Specify which output to set ('file' or 'screen').");
 	}
 }
 

--- a/matlab/mex/astra_mex_log_c.cpp
+++ b/matlab/mex/astra_mex_log_c.cpp
@@ -133,7 +133,7 @@ void astra_mex_log_enable(int nlhs, mxArray* plhs[], int nrhs, const mxArray* pr
 	}else if(sType == "screen"){
 		astra::CLogger::enableScreen();
 	} else {
-		mexErrMsgTxt("Specify which output to enable ('all', 'file', or 'screen')");
+		mexErrMsgTxt("Specify which output to enable ('all', 'file', or 'screen').");
 	}
 }
 
@@ -156,7 +156,7 @@ void astra_mex_log_disable(int nlhs, mxArray* plhs[], int nrhs, const mxArray* p
 	}else if(sType == "screen"){
 		astra::CLogger::disableScreen();
 	} else {
-		mexErrMsgTxt("Specify which output to disable ('all', 'file', or 'screen')");
+		mexErrMsgTxt("Specify which output to disable ('all', 'file', or 'screen').");
 	}
 }
 
@@ -197,7 +197,7 @@ void astra_mex_log_format(int nlhs, mxArray* plhs[], int nrhs, const mxArray* pr
 	}else if(sType == "screen"){
 		astra::CLogger::setFormatScreen(sFormat.c_str());
 	} else {
-		mexErrMsgTxt("Specify which output to format ('file' or 'screen')");
+		mexErrMsgTxt("Specify which output to format ('file' or 'screen').");
 	}
 }
 
@@ -229,7 +229,7 @@ void astra_mex_log_output(int nlhs, mxArray* plhs[], int nrhs, const mxArray* pr
 	}else if(sLevel == "error"){
 		eLevel = LOG_ERROR;
 	}else{
-		mexErrMsgTxt("Specify which log level to use ('debug', 'info', 'warn', or 'error')");
+		mexErrMsgTxt("Specify which log level to use ('debug', 'info', 'warn', or 'error').");
 	}
 	if(sType == "file"){
 		astra::CLogger::setOutputFile(sOutput.c_str(),eLevel);
@@ -240,11 +240,11 @@ void astra_mex_log_output(int nlhs, mxArray* plhs[], int nrhs, const mxArray* pr
 		}else if(sOutput == "stderr"){
 			fd=2;
 		}else{
-			mexErrMsgTxt("Specify which screen to output to ('stdout' or 'stderr')");
+			mexErrMsgTxt("Specify which screen to output to ('stdout' or 'stderr').");
 		}
 		astra::CLogger::setOutputScreen(fd,eLevel);
 	} else {
-		mexErrMsgTxt("Specify which output to set ('file' or 'screen')");
+		mexErrMsgTxt("Specify which output to set ('file' or 'screen')".);
 	}
 }
 

--- a/matlab/mex/astra_mex_log_c.cpp
+++ b/matlab/mex/astra_mex_log_c.cpp
@@ -48,8 +48,7 @@ using namespace astra;
 void astra_mex_log_debug(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
 {
 	if (nrhs < 4) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	string filename = mexToString(prhs[1]);
 	int linenumber = (int)mxGetScalar(prhs[2]);
@@ -68,8 +67,7 @@ void astra_mex_log_debug(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prh
 void astra_mex_log_info(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
 {
 	if (nrhs < 4) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	string filename = mexToString(prhs[1]);
 	int linenumber = (int)mxGetScalar(prhs[2]);
@@ -88,8 +86,7 @@ void astra_mex_log_info(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs
 void astra_mex_log_warn(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
 {
 	if (nrhs < 4) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	string filename = mexToString(prhs[1]);
 	int linenumber = (int)mxGetScalar(prhs[2]);
@@ -108,7 +105,7 @@ void astra_mex_log_warn(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs
 void astra_mex_log_error(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
 {
 	if (nrhs < 4) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 		return;
 	}
 	string filename = mexToString(prhs[1]);
@@ -126,8 +123,7 @@ void astra_mex_log_error(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prh
 void astra_mex_log_enable(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
 {
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	string sType = mexToString(prhs[1]);
 	if(sType == "all"){
@@ -150,8 +146,7 @@ void astra_mex_log_enable(int nlhs, mxArray* plhs[], int nrhs, const mxArray* pr
 void astra_mex_log_disable(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
 {
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	string sType = mexToString(prhs[1]);
 	if(sType == "all"){
@@ -184,8 +179,7 @@ void astra_mex_log_disable(int nlhs, mxArray* plhs[], int nrhs, const mxArray* p
 void astra_mex_log_format(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
 {
 	if (nrhs < 3) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	string sType = mexToString(prhs[1]);
 	string sFormat = mexToString(prhs[2]);
@@ -220,8 +214,7 @@ void astra_mex_log_format(int nlhs, mxArray* plhs[], int nrhs, const mxArray* pr
 void astra_mex_log_output(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
 {
 	if (nrhs < 4) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	string sType = mexToString(prhs[1]);
 	string sOutput = mexToString(prhs[2]);

--- a/matlab/mex/astra_mex_matrix_c.cpp
+++ b/matlab/mex/astra_mex_matrix_c.cpp
@@ -54,8 +54,7 @@ void astra_mex_matrix_delete(int nlhs, mxArray* plhs[], int nrhs, const mxArray*
 { 
 	// step1: read input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 
 	// step2: delete all specified data objects
@@ -81,12 +80,10 @@ static bool matlab_to_astra(const mxArray* _rhs, CSparseMatrix* _pMatrix)
 {
 	// Check input
 	if (!mxIsSparse (_rhs)) {
-		mexErrMsgTxt("Argument is not a valid MATLAB sparse matrix.\n");
-		return false;
+		mexErrMsgTxt("Argument is not a valid MATLAB sparse matrix.");
 	}
 	if (!_pMatrix->isInitialized()) {
-		mexErrMsgTxt("Couldn't initialize data object.\n");
-		return false;
+		mexErrMsgTxt("Couldn't initialize data object.");
 	}
 
 	unsigned int iHeight = mxGetM(_rhs);
@@ -95,8 +92,7 @@ static bool matlab_to_astra(const mxArray* _rhs, CSparseMatrix* _pMatrix)
 
 	if (_pMatrix->m_lSize < lSize || _pMatrix->m_iHeight < iHeight) {
 		// TODO: support resizing?
-		mexErrMsgTxt("Matrix too large to store in this object.\n");
-		return false;
+		mexErrMsgTxt("Matrix too large to store in this object.");
 	}
 
 	// Transpose matrix, as matlab stores a matrix column-by-column
@@ -172,8 +168,7 @@ static bool matlab_to_astra(const mxArray* _rhs, CSparseMatrix* _pMatrix)
 static bool astra_to_matlab(const CSparseMatrix* _pMatrix, mxArray*& _lhs)
 {
 	if (!_pMatrix->isInitialized()) {
-		mexErrMsgTxt("Uninitialized data object.\n");
-		return false;
+		mexErrMsgTxt("Uninitialized data object.");
 	}
 
 	unsigned int iHeight = _pMatrix->m_iHeight;
@@ -182,8 +177,7 @@ static bool astra_to_matlab(const CSparseMatrix* _pMatrix, mxArray*& _lhs)
 
 	_lhs = mxCreateSparse(iHeight, iWidth, lSize, mxREAL);
 	if (!mxIsSparse (_lhs)) {
-		mexErrMsgTxt("Couldn't initialize matlab sparse matrix.\n");
-		return false;
+		mexErrMsgTxt("Couldn't initialize matlab sparse matrix.");
 	}
 	
 	mwIndex *colStarts = mxGetJc(_lhs);
@@ -237,13 +231,11 @@ void astra_mex_matrix_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 { 
 	// step1: get datatype
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 
 	if (!mxIsSparse (prhs[1])) {
-		mexErrMsgTxt("Argument is not a valid MATLAB sparse matrix.\n");
-		return;
+		mexErrMsgTxt("Argument is not a valid MATLAB sparse matrix.");
 	}
 
 	unsigned int iHeight = mxGetM(prhs[1]);
@@ -285,12 +277,10 @@ void astra_mex_matrix_store(int nlhs, mxArray* plhs[], int nrhs, const mxArray* 
 {
 	// step1: input
 	if (nrhs < 3) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	if (!mxIsDouble(prhs[1])) {
-		mexErrMsgTxt("Identifier should be a scalar value. \n");
-		return;
+		mexErrMsgTxt("Identifier should be a scalar value.");
 	}
 	int iDataID = (int)(mxGetScalar(prhs[1]));
 
@@ -318,20 +308,17 @@ void astra_mex_matrix_get_size(int nlhs, mxArray* plhs[], int nrhs, const mxArra
 { 
 	// step1: input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	if (!mxIsDouble(prhs[1])) {
-		mexErrMsgTxt("Identifier should be a scalar value. \n");
-		return;
+		mexErrMsgTxt("Identifier should be a scalar value.");
 	}
 	int iDataID = (int)(mxGetScalar(prhs[1]));
 
 	// step2: get data object
 	CSparseMatrix* pMatrix = astra::CMatrixManager::getSingleton().get(iDataID);
 	if (!pMatrix || !pMatrix->isInitialized()) {
-		mexErrMsgTxt("Data object not found or not initialized properly.\n");
-		return;
+		mexErrMsgTxt("Data object not found or not initialized properly.");
 	}
 
 	// create output
@@ -349,20 +336,17 @@ void astra_mex_matrix_get(int nlhs, mxArray* plhs[], int nrhs, const mxArray* pr
 { 
 	// step1: check input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	if (!mxIsDouble(prhs[1])) {
-		mexErrMsgTxt("Identifier should be a scalar value. \n");
-		return;
+		mexErrMsgTxt("Identifier should be a scalar value.");
 	}
 	int iDataID = (int)(mxGetScalar(prhs[1]));
 
 	// step2: get data object
 	CSparseMatrix* pMatrix = astra::CMatrixManager::getSingleton().get(iDataID);
 	if (!pMatrix || !pMatrix->isInitialized()) {
-		mexErrMsgTxt("Data object not found or not initialized properly.\n");
-		return;
+		mexErrMsgTxt("Data object not found or not initialized properly.");
 	}
 
 	// create output

--- a/matlab/mex/astra_mex_matrix_c.cpp
+++ b/matlab/mex/astra_mex_matrix_c.cpp
@@ -254,17 +254,15 @@ void astra_mex_matrix_create(int& nlhs, mxArray* plhs[], int& nrhs, const mxArra
 
 	// Check initialization
 	if (!pMatrix->isInitialized()) {
-		mexErrMsgTxt("Couldn't initialize data object.\n");
 		delete pMatrix;
-		return;
+		mexErrMsgTxt("Couldn't initialize data object.");
 	}
 
 	bool bResult = matlab_to_astra(prhs[1], pMatrix);
 
 	if (!bResult) {
-		mexErrMsgTxt("Failed to create data object.\n");
 		delete pMatrix;
-		return;
+		mexErrMsgWithAstraLog("Failed to create data object.");
 	}
 
 	// store data object
@@ -305,7 +303,7 @@ void astra_mex_matrix_store(int nlhs, mxArray* plhs[], int nrhs, const mxArray* 
 
 	bool bResult = matlab_to_astra(prhs[2], pMatrix);
 	if (!bResult) {
-		mexErrMsgTxt("Failed to store matrix.\n");
+		mexErrMsgWithAstraLog("Failed to store matrix.");
 	}
 }
 
@@ -371,7 +369,7 @@ void astra_mex_matrix_get(int nlhs, mxArray* plhs[], int nrhs, const mxArray* pr
 	if (1 <= nlhs) {
 		bool bResult = astra_to_matlab(pMatrix, plhs[0]);
 		if (!bResult) {
-			mexErrMsgTxt("Failed to get matrix.\n");
+			mexErrMsgWithAstraLog("Failed to get matrix.");
 		}
 	}
 	

--- a/matlab/mex/astra_mex_projector3d_c.cpp
+++ b/matlab/mex/astra_mex_projector3d_c.cpp
@@ -131,9 +131,9 @@ void astra_mex_projector3d_get_projection_geometry(int nlhs, mxArray* plhs[], in
 	int iPid = (int)(mxGetScalar(prhs[1]));
 
 	// step2: get projector
-	CProjector3D* pProjector;
-	if (!(pProjector = CProjector3DManager::getSingleton().get(iPid))) {
-		mexErrMsgTxt("Projector not found.");
+	CProjector3D* pProjector = CProjector3DManager::getSingleton().get(iPid);
+	if (!pProjector || !pProjector->isInitialized()) {
+		mexErrMsgTxt("Projector could not be found or is not initialized.");
 	}
 
 	// step3: get projection_geometry and turn it into a MATLAB struct
@@ -159,7 +159,7 @@ void astra_mex_projector3d_get_volume_geometry(int nlhs, mxArray* plhs[], int nr
 	// step2: get projector
 	CProjector3D* pProjector = CProjector3DManager::getSingleton().get(iPid);
 	if (!pProjector || !pProjector->isInitialized()) {
-		mexErrMsgTxt("Projector could not be found or is not found.");
+		mexErrMsgTxt("Projector could not be found or is not initialized.");
 	}
 
 	// step3: get projection_geometry and turn it into a MATLAB struct

--- a/matlab/mex/astra_mex_projector3d_c.cpp
+++ b/matlab/mex/astra_mex_projector3d_c.cpp
@@ -56,12 +56,11 @@ using namespace astra;
 void astra_mex_projector3d_create(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
 { 
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 
 	if (!mxIsStruct(prhs[1])) {
-		mexErrMsgTxt("Argument 1 not a valid MATLAB struct. \n");
+		mexErrMsgTxt("Argument 1 not a valid MATLAB struct.");
 	}
 
 	// turn MATLAB struct to an XML-based Config object
@@ -71,8 +70,7 @@ void astra_mex_projector3d_create(int nlhs, mxArray* plhs[], int nrhs, const mxA
 	CProjector3D* pProj = CProjector3DFactory::getSingleton().create(cfg->self.getAttribute("type"));
 	if (pProj == NULL) {
 		delete cfg;
-		mexErrMsgTxt("Unknown Projector3D. \n");
-		return;
+		mexErrMsgTxt("Unknown Projector3D type.");
 	}
 
 	// create algorithm
@@ -101,8 +99,7 @@ void astra_mex_projector3d_destroy(int nlhs, mxArray* plhs[], int nrhs, const mx
 {
 	// step1: read input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 
 	for (int i = 1; i < nrhs; i++) {
@@ -129,16 +126,14 @@ void astra_mex_projector3d_get_projection_geometry(int nlhs, mxArray* plhs[], in
 {
 	// step1: read input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	int iPid = (int)(mxGetScalar(prhs[1]));
 
 	// step2: get projector
 	CProjector3D* pProjector;
 	if (!(pProjector = CProjector3DManager::getSingleton().get(iPid))) {
-		mexErrMsgTxt("Projector not found.\n");
-		return;
+		mexErrMsgTxt("Projector not found.");
 	}
 
 	// step3: get projection_geometry and turn it into a MATLAB struct
@@ -157,16 +152,14 @@ void astra_mex_projector3d_get_volume_geometry(int nlhs, mxArray* plhs[], int nr
 {
 	// step1: read input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	int iPid = (int)(mxGetScalar(prhs[1]));
 
 	// step2: get projector
-	CProjector3D* pProjector;
-	if (!(pProjector = CProjector3DManager::getSingleton().get(iPid))) {
-		mexErrMsgTxt("Projector not found.\n");
-		return;
+	CProjector3D* pProjector = CProjector3DManager::getSingleton().get(iPid);
+	if (!pProjector || !pProjector->isInitialized()) {
+		mexErrMsgTxt("Projector could not be found or is not found.");
 	}
 
 	// step3: get projection_geometry and turn it into a MATLAB struct
@@ -187,16 +180,14 @@ void astra_mex_projector3d_is_cuda(int nlhs, mxArray* plhs[], int nrhs, const mx
 { 
 	// step1: get input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	int iPid = (int)(mxGetScalar(prhs[1]));
 
 	// step2: get projector
 	CProjector3D* pProjector = CProjector3DManager::getSingleton().get(iPid);
 	if (!pProjector || !pProjector->isInitialized()) {
-		mexErrMsgTxt("Projector not initialized.\n");
-		return;
+		mexErrMsgTxt("Projector could not be found or is not initialized.");
 	}
 
 #ifdef ASTRA_CUDA

--- a/matlab/mex/astra_mex_projector3d_c.cpp
+++ b/matlab/mex/astra_mex_projector3d_c.cpp
@@ -79,8 +79,7 @@ void astra_mex_projector3d_create(int nlhs, mxArray* plhs[], int nrhs, const mxA
 	if (!pProj->initialize(*cfg)) {
 		delete cfg;
 		delete pProj;
-		mexErrMsgTxt("Unable to initialize Projector3D. \n");
-		return;
+		mexErrMsgWithAstraLog("Unable to initialize Projector3D.");
 	}
 	delete cfg;
 

--- a/matlab/mex/astra_mex_projector_c.cpp
+++ b/matlab/mex/astra_mex_projector_c.cpp
@@ -88,8 +88,7 @@ void astra_mex_projector_create(int nlhs, mxArray* plhs[], int nrhs, const mxArr
 	if (!pProj->initialize(*cfg)) {
 		delete cfg;
 		delete pProj;
-		mexErrMsgTxt("Unable to initialize Projector2D. \n");
-		return;
+		mexErrMsgWithAstraLog("Unable to initialize Projector2D.");
 	}
 	delete cfg;
 
@@ -361,9 +360,8 @@ void astra_mex_projector_matrix(int nlhs, mxArray* plhs[], int nrhs, const mxArr
 
 	CSparseMatrix* pMatrix = pProjector->getMatrix();
 	if (!pMatrix || !pMatrix->isInitialized()) {
-		mexErrMsgTxt("Couldn't initialize data object.\n");
 		delete pMatrix;
-		return;
+		mexErrMsgWithAstraLog("Couldn't initialize data object.");
 	}
 
 	// store data object

--- a/matlab/mex/astra_mex_projector_c.cpp
+++ b/matlab/mex/astra_mex_projector_c.cpp
@@ -64,12 +64,11 @@ void astra_mex_projector_create(int nlhs, mxArray* plhs[], int nrhs, const mxArr
 	int iIndex = 0;
 
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 
 	if (!mxIsStruct(prhs[1])) {
-		mexErrMsgTxt("Argument 1 not a valid MATLAB struct. \n");
+		mexErrMsgTxt("Argument 1 not a valid MATLAB struct.");
 	}
 
 
@@ -80,8 +79,7 @@ void astra_mex_projector_create(int nlhs, mxArray* plhs[], int nrhs, const mxArr
 	CProjector2D* pProj = CProjector2DFactory::getSingleton().create(cfg->self.getAttribute("type"));
 	if (pProj == NULL) {
 		delete cfg;
-		mexErrMsgTxt("Unknown Projector2D. \n");
-		return;
+		mexErrMsgTxt("Unknown Projector2D type.");
 	}
 
 	// create algorithm
@@ -111,8 +109,7 @@ void astra_mex_projector_delete(int nlhs, mxArray* plhs[], int nrhs, const mxArr
 {
 	// step1: read input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 
 	for (int i = 1; i < nrhs; i++) {
@@ -152,16 +149,14 @@ void astra_mex_projector_projection_geometry(int nlhs, mxArray* plhs[], int nrhs
 {
 	// step1: read input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	int iPid = (int)(mxGetScalar(prhs[1]));
 
 	// step2: get projector
 	CProjector2D* pProjector = CProjector2DManager::getSingleton().get(iPid);
 	if (!pProjector || !pProjector->isInitialized()) {
-		mexErrMsgTxt("Projector not initialized.\n");
-		return;
+		mexErrMsgTxt("Projector could not be found or is not initialized.");
 	}
 
 	// step3: get projection_geometry and turn it into a MATLAB struct
@@ -183,16 +178,14 @@ void astra_mex_projector_volume_geometry(int nlhs, mxArray* plhs[], int nrhs, co
 {
 	// step1: read input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	int iPid = (int)(mxGetScalar(prhs[1]));
 
 	// step2: get projector
 	CProjector2D* pProjector = CProjector2DManager::getSingleton().get(iPid);
 	if (!pProjector || !pProjector->isInitialized()) {
-		mexErrMsgTxt("Projector not initialized.\n");
-		return;
+		mexErrMsgTxt("Projector could not be found or is not initialized.");
 	}
 
 	// step3: get projection_geometry and turn it into a MATLAB struct
@@ -216,8 +209,7 @@ void astra_mex_projector_weights_single_ray(int nlhs, mxArray* plhs[], int nrhs,
 { 
 	// step1: get input
 	if (nrhs < 4) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	int iPid = (int)(mxGetScalar(prhs[1]));
 	int iProjectionIndex = (int)(mxGetScalar(prhs[2]));
@@ -226,8 +218,7 @@ void astra_mex_projector_weights_single_ray(int nlhs, mxArray* plhs[], int nrhs,
 	// step2: get projector
 	CProjector2D* pProjector = CProjector2DManager::getSingleton().get(iPid);
 	if (!pProjector || !pProjector->isInitialized()) {
-		mexErrMsgTxt("Projector not initialized.\n");
-		return;
+		mexErrMsgTxt("Projector could not be found or is not initialized.");
 	}
 	
 	// step3: create output vars
@@ -273,8 +264,7 @@ void astra_mex_projector_weights_projection(int nlhs, mxArray* plhs[], int nrhs,
 { 
 	// step1: get input
 	if (nrhs < 3) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	int iPid = (int)(mxGetScalar(prhs[1]));
 	int iProjectionIndex = (int)(mxGetScalar(prhs[2]));
@@ -282,8 +272,7 @@ void astra_mex_projector_weights_projection(int nlhs, mxArray* plhs[], int nrhs,
 	// step2: get projector
 	CProjector2D* pProjector = CProjector2DManager::getSingleton().get(iPid);
 	if (!pProjector || !pProjector->isInitialized()) {
-		mexErrMsgTxt("Projector not initialized.\n");
-		return;
+		mexErrMsgTxt("Projector could not be found or is not initialized.");
 	}
 
 	// step3: create output vars
@@ -346,16 +335,14 @@ void astra_mex_projector_matrix(int nlhs, mxArray* plhs[], int nrhs, const mxArr
 { 
 	// step1: get input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	int iPid = (int)(mxGetScalar(prhs[1]));
 
 	// step2: get projector
 	CProjector2D* pProjector = CProjector2DManager::getSingleton().get(iPid);
 	if (!pProjector || !pProjector->isInitialized()) {
-		mexErrMsgTxt("Projector not initialized.\n");
-		return;
+		mexErrMsgTxt("Projector could not be found or is not initialized.");
 	}
 
 	CSparseMatrix* pMatrix = pProjector->getMatrix();
@@ -383,16 +370,14 @@ void astra_mex_projector_is_cuda(int nlhs, mxArray* plhs[], int nrhs, const mxAr
 { 
 	// step1: get input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 	int iPid = (int)(mxGetScalar(prhs[1]));
 
 	// step2: get projector
 	CProjector2D* pProjector = CProjector2DManager::getSingleton().get(iPid);
 	if (!pProjector || !pProjector->isInitialized()) {
-		mexErrMsgTxt("Projector not initialized.\n");
-		return;
+		mexErrMsgTxt("Projector could not be found or is not initialized.");
 	}
 
 #ifdef ASTRA_CUDA

--- a/matlab/mex/mexDataManagerHelpFunctions.cpp
+++ b/matlab/mex/mexDataManagerHelpFunctions.cpp
@@ -201,7 +201,7 @@ allocateDataObject(const std::string & sDataType,
 	{
 		if (!mexIsScalar(unshare))
 		{
-			mexErrMsgTxt("Argument 5 (read-only) must be scalar");
+			mexErrMsgTxt("Argument 5 (read-only) must be scalar.");
 		}
 		// unshare the array if we're not linking read-only
 		bUnshare = !(bool)mxGetScalar(unshare);
@@ -212,7 +212,7 @@ allocateDataObject(const std::string & sDataType,
 	{
 		if (!mexIsScalar(zIndex))
 		{
-			mexErrMsgTxt("Argument 6 (Z) must be scalar");
+			mexErrMsgTxt("Argument 6 (Z) must be scalar.");
 		}
 		iZ = (mwSignedIndex)mxGetScalar(zIndex);
 	}
@@ -227,7 +227,7 @@ allocateDataObject(const std::string & sDataType,
 		{
 			delete pGeometry;
 			delete cfg;
-			mexErrMsgWithAstraLog("Geometry class not initialized.");
+			mexErrMsgWithAstraLog("Geometry class could not be initialized.");
 		}
 		delete cfg;
 
@@ -239,7 +239,7 @@ allocateDataObject(const std::string & sDataType,
 					: checkDataSize(data, pGeometry)) )
 			{
 				delete pGeometry;
-				mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry. \n");
+				mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry.");
 			}
 		}
 
@@ -284,7 +284,7 @@ allocateDataObject(const std::string & sDataType,
 		if (!pGeometry->initialize(*cfg)) {
 			delete pGeometry;
 			delete cfg;
-			mexErrMsgWithAstraLog("Geometry class not initialized.");
+			mexErrMsgWithAstraLog("Geometry class could not be initialized.");
 		}
 		delete cfg;
 

--- a/matlab/mex/mexDataManagerHelpFunctions.cpp
+++ b/matlab/mex/mexDataManagerHelpFunctions.cpp
@@ -202,7 +202,6 @@ allocateDataObject(const std::string & sDataType,
 		if (!mexIsScalar(unshare))
 		{
 			mexErrMsgTxt("Argument 5 (read-only) must be scalar");
-			return NULL;
 		}
 		// unshare the array if we're not linking read-only
 		bUnshare = !(bool)mxGetScalar(unshare);
@@ -214,7 +213,6 @@ allocateDataObject(const std::string & sDataType,
 		if (!mexIsScalar(zIndex))
 		{
 			mexErrMsgTxt("Argument 6 (Z) must be scalar");
-			return NULL;
 		}
 		iZ = (mwSignedIndex)mxGetScalar(zIndex);
 	}
@@ -240,9 +238,8 @@ allocateDataObject(const std::string & sDataType,
 					? checkDataSize(data, pGeometry, iZ)
 					: checkDataSize(data, pGeometry)) )
 			{
-				mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry. \n");
 				delete pGeometry;
-				return NULL;
+				mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry. \n");
 			}
 		}
 
@@ -281,8 +278,7 @@ allocateDataObject(const std::string & sDataType,
 		} else if (type == "cone_vec") {
 			pGeometry = new astra::CConeVecProjectionGeometry3D();
 		} else {
-			mexErrMsgTxt("Invalid geometry type.\n");
-			return NULL;
+			mexErrMsgTxt("Invalid geometry type.");
 		}
 
 		if (!pGeometry->initialize(*cfg)) {
@@ -299,9 +295,8 @@ allocateDataObject(const std::string & sDataType,
 					? checkDataSize(data, pGeometry, iZ)
 					: checkDataSize(data, pGeometry)) )
 			{
-				mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry. \n");
 				delete pGeometry;
-				return NULL;
+				mexErrMsgTxt("The dimensions of the data do not match those specified in the geometry.");
 			}
 		}
 
@@ -326,16 +321,14 @@ allocateDataObject(const std::string & sDataType,
 	}
 	else
 	{
-		mexErrMsgTxt("Invalid datatype.  Please specify '-vol' or '-proj3d'. \n");
-		return NULL;
+		mexErrMsgTxt("Invalid datatype. Please specify '-vol' or '-proj3d'.");
 	}
 
 	// Check initialization
 	if (!pDataObject3D->isInitialized())
 	{
-		mexErrMsgTxt("Couldn't initialize data object.\n");
 		delete pDataObject3D;
-		return NULL;
+		mexErrMsgTxt("Couldn't initialize data object.");
 	}
 
 	return pDataObject3D;

--- a/matlab/mex/mexDataManagerHelpFunctions.cpp
+++ b/matlab/mex/mexDataManagerHelpFunctions.cpp
@@ -227,10 +227,9 @@ allocateDataObject(const std::string & sDataType,
 		astra::CVolumeGeometry3D* pGeometry = new astra::CVolumeGeometry3D();
 		if (!pGeometry->initialize(*cfg))
 		{
-			mexErrMsgTxt("Geometry class not initialized. \n");
 			delete pGeometry;
 			delete cfg;
-			return NULL;
+			mexErrMsgWithAstraLog("Geometry class not initialized.");
 		}
 		delete cfg;
 
@@ -287,10 +286,9 @@ allocateDataObject(const std::string & sDataType,
 		}
 
 		if (!pGeometry->initialize(*cfg)) {
-			mexErrMsgTxt("Geometry class not initialized. \n");
 			delete pGeometry;
 			delete cfg;
-			return NULL;
+			mexErrMsgWithAstraLog("Geometry class not initialized.");
 		}
 		delete cfg;
 

--- a/matlab/mex/mexDataManagerHelpFunctions.cpp
+++ b/matlab/mex/mexDataManagerHelpFunctions.cpp
@@ -278,7 +278,8 @@ allocateDataObject(const std::string & sDataType,
 		} else if (type == "cone_vec") {
 			pGeometry = new astra::CConeVecProjectionGeometry3D();
 		} else {
-			mexErrMsgTxt("Invalid geometry type.");
+			std::string message = "'" + type + "' is not a valid 3D geometry type.";
+			mexErrMsgTxt(message.c_str());
 		}
 
 		if (!pGeometry->initialize(*cfg)) {

--- a/matlab/mex/mexDataManagerHelpFunctions.h
+++ b/matlab/mex/mexDataManagerHelpFunctions.h
@@ -66,15 +66,13 @@ void generic_astra_mex_data3d_get(int nlhs, mxArray* plhs[], int nrhs,
 {
 	// step1: input
 	if (nrhs < 2) {
-		mexErrMsgTxt("Not enough arguments.  See the help document for a detailed argument list. \n");
-		return;
+		mexErrMsgTxt("Not enough arguments. See the help document for a detailed argument list.");
 	}
 
 	// step2: get data object/s
 	astra::CFloat32Data3DMemory* pDataObject = NULL;
 	if (!checkID(mxGetScalar(prhs[1]), pDataObject)) {
-		mexErrMsgTxt("Data object not found or not initialized properly.\n");
-		return;
+		mexErrMsgTxt("Data object not found or not initialized properly.");
 	}
 
 	// create output

--- a/matlab/mex/mexHelpFunctions.cpp
+++ b/matlab/mex/mexHelpFunctions.cpp
@@ -31,11 +31,22 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
  */
 #include "mexHelpFunctions.h"
 #include "astra/Utilities.h"
+#include "astra/Logging.h"
 
 using namespace std;
 using namespace astra;
 
 
+void mexErrMsgWithAstraLog(string message)
+{
+    string last_err_msg = CLogger::getLastErrMsg();
+	if (!last_err_msg.empty()) {
+		message.append(" ");
+		message.append(last_err_msg);
+	}
+	message.append("\n");
+	mexErrMsgTxt(message.c_str());
+}
 //-----------------------------------------------------------------------------------------
 // get string from matlab 
 string mexToString(const mxArray* pInput)

--- a/matlab/mex/mexHelpFunctions.cpp
+++ b/matlab/mex/mexHelpFunctions.cpp
@@ -44,7 +44,6 @@ void mexErrMsgWithAstraLog(string message)
 		message.append(" ");
 		message.append(last_err_msg);
 	}
-	message.append("\n");
 	mexErrMsgTxt(message.c_str());
 }
 //-----------------------------------------------------------------------------------------

--- a/matlab/mex/mexHelpFunctions.cpp
+++ b/matlab/mex/mexHelpFunctions.cpp
@@ -223,7 +223,7 @@ bool optionsToXMLNode(XMLNode node, const mxArray* pOptionStruct)
 		const mxArray* pField = mxGetFieldByNumber(pOptionStruct, 0, i);
 
 		if (node.hasOption(sFieldName)) {
-			mexErrMsgTxt("Duplicate option");
+			mexErrMsgTxt("Duplicate option.");
 		}
 	
 		// string or scalar
@@ -242,7 +242,7 @@ bool optionsToXMLNode(XMLNode node, const mxArray* pOptionStruct)
 			double* pdValues = mxGetPr(pField);
 			listbase.setContent(pdValues, mxGetN(pField), mxGetM(pField), true);
 		} else {
-			mexErrMsgTxt("Unsupported option type");
+			mexErrMsgTxt("Unsupported option type.");
 		}
 	}
 	return true;

--- a/matlab/mex/mexHelpFunctions.cpp
+++ b/matlab/mex/mexHelpFunctions.cpp
@@ -142,7 +142,6 @@ Config* structToConfig(string rootname, const mxArray* pStruct)
 {
 	if (!mxIsStruct(pStruct)) {
 		mexErrMsgTxt("Input must be a struct.");
-		return NULL;
 	}
 
 	// create the document
@@ -154,7 +153,6 @@ Config* structToConfig(string rootname, const mxArray* pStruct)
 	if (!ret) {
 		delete cfg;
 		mexErrMsgTxt("Error parsing struct.");
-		return NULL;		
 	}
 	return cfg;
 }
@@ -190,7 +188,6 @@ bool structToXMLNode(XMLNode node, const mxArray* pStruct)
 		else if (mxIsNumeric(pField) && mxGetM(pField)*mxGetN(pField) > 1) {
 			if (!mxIsDouble(pField)) {
 				mexErrMsgTxt("Numeric input must be double.");
-				return false;
 			}
 			XMLNode listbase = node.addChildNode(sFieldName);
 			double* pdValues = mxGetPr(pField);
@@ -227,7 +224,6 @@ bool optionsToXMLNode(XMLNode node, const mxArray* pOptionStruct)
 
 		if (node.hasOption(sFieldName)) {
 			mexErrMsgTxt("Duplicate option");
-			return false;
 		}
 	
 		// string or scalar
@@ -239,7 +235,6 @@ bool optionsToXMLNode(XMLNode node, const mxArray* pOptionStruct)
 		else if (mxIsNumeric(pField) && mxGetM(pField)*mxGetN(pField) > 1) {
 			if (!mxIsDouble(pField)) {
 				mexErrMsgTxt("Numeric input must be double.");
-				return false;
 			}
 
 			XMLNode listbase = node.addChildNode("Option");
@@ -248,7 +243,6 @@ bool optionsToXMLNode(XMLNode node, const mxArray* pOptionStruct)
 			listbase.setContent(pdValues, mxGetN(pField), mxGetM(pField), true);
 		} else {
 			mexErrMsgTxt("Unsupported option type");
-			return false;
 		}
 	}
 	return true;
@@ -262,7 +256,6 @@ std::map<std::string, mxArray*> parseStruct(const mxArray* pInput)
 	// check type
 	if (!mxIsStruct(pInput)) {
       mexErrMsgTxt("Input must be a struct.");
-	  return res;
 	}
 
 	// get field names

--- a/matlab/mex/mexHelpFunctions.h
+++ b/matlab/mex/mexHelpFunctions.h
@@ -48,6 +48,7 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 #include "astra/XMLNode.h"
 
 // utility functions
+void mexErrMsgWithAstraLog(std::string message);
 std::string mexToString(const mxArray* pInput);
 bool mexIsScalar(const mxArray* pInput);
 void get3DMatrixDims(const mxArray* x, mwSize *dims);

--- a/matlab/tools/astra_create_proj_geom.m
+++ b/matlab/tools/astra_create_proj_geom.m
@@ -97,7 +97,7 @@ function proj_geom = astra_create_proj_geom(type, varargin)
 
 if strcmp(type,'parallel')
 	if numel(varargin) < 3
-		error('not enough input arguments: astra_create_proj_geom(parallel, detector_spacing, det_count, angles)');
+		error('Not enough input arguments. Usage: astra_create_proj_geom(parallel, detector_spacing, det_count, angles);');
 	end
 	proj_geom = struct( ...
 		'type',					'parallel', ...
@@ -108,10 +108,10 @@ if strcmp(type,'parallel')
 
 elseif strcmp(type,'parallel_vec')
 	if numel(varargin) < 2
-		error('not enough input arguments: astra_create_proj_geom(parallel_vec, det_count, V')
+		error('Not enough input arguments. Usage: astra_create_proj_geom(parallel_vec, det_count, V);')
 	end
 	if size(varargin{2}, 2) ~= 6
-		error('V should be a Nx6 matrix, with N the number of projections')
+		error('V should be a Nx6 matrix, with N the number of projections.')
 	end
 	proj_geom = struct( ...
 		'type',					'parallel_vec',  ...
@@ -121,7 +121,7 @@ elseif strcmp(type,'parallel_vec')
 
 elseif strcmp(type,'fanflat')
 	if numel(varargin) < 5
-		error('not enough input arguments: astra_create_proj_geom(fanflat, det_width, det_count, angles, source_origin, source_det)');
+		error('Not enough input arguments. Usage: astra_create_proj_geom(fanflat, det_width, det_count, angles, source_origin, source_det);');
 	end	
 	proj_geom = struct( ...
 		'type',						'fanflat', ...
@@ -134,7 +134,7 @@ elseif strcmp(type,'fanflat')
 
 elseif strcmp(type,'fanflat_vec')
 	if numel(varargin) < 2
-		error('not enough input arguments: astra_create_proj_geom(fanflat_vec, det_count, V')
+		error('Not enough input arguments. Usage: astra_create_proj_geom(fanflat_vec, det_count, V).')
 	end
 	if size(varargin{2}, 2) ~= 6
 		error('V should be a Nx6 matrix, with N the number of projections')
@@ -147,7 +147,7 @@ elseif strcmp(type,'fanflat_vec')
 
 elseif strcmp(type,'parallel3d')
 	if numel(varargin) < 5
-		error('not enough input arguments: astra_create_proj_geom(parallel3d, detector_spacing_x, detector_spacing_y, det_row_count, det_col_count, angles)');
+		error('Not enough input arguments: astra_create_proj_geom(parallel3d, detector_spacing_x, detector_spacing_y, det_row_count, det_col_count, angles);');
 	end
 	proj_geom = struct( ...
 		'type',					'parallel3d', ...
@@ -159,7 +159,7 @@ elseif strcmp(type,'parallel3d')
 	);
 elseif strcmp(type,'cone')
 	if numel(varargin) < 7
-		error('not enough input arguments: astra_create_proj_geom(cone, detector_spacing_x, detector_spacing_y, det_row_count, det_col_count, angles, source_origin, source_det)');
+		error('Not enough input arguments. Usage: astra_create_proj_geom(cone, detector_spacing_x, detector_spacing_y, det_row_count, det_col_count, angles, source_origin, source_det);');
 	end
 	proj_geom = struct( ...
 		'type',					'cone', ...
@@ -173,7 +173,7 @@ elseif strcmp(type,'cone')
 	);
 elseif strcmp(type,'cone_vec')
 	if numel(varargin) < 3
-		error('not enough input arguments: astra_create_proj_geom(cone_vec, det_row_count, det_col_count, V')
+		error('Not enough input arguments. Usage: astra_create_proj_geom(cone_vec, det_row_count, det_col_count, V);')
 	end
 	if size(varargin{3}, 2) ~= 12
 		error('V should be a Nx12 matrix, with N the number of projections')
@@ -186,10 +186,10 @@ elseif strcmp(type,'cone_vec')
 	);
 elseif strcmp(type,'parallel3d_vec')
 	if numel(varargin) < 3
-		error('not enough input arguments: astra_create_proj_geom(parallel3d_vec, det_row_count, det_col_count, V')
+		error('Not enough input arguments. Usage: astra_create_proj_geom(parallel3d_vec, det_row_count, det_col_count, V);')
 	end
 	if size(varargin{3}, 2) ~= 12
-		error('V should be a Nx12 matrix, with N the number of projections')
+		error('V should be a Nx12 matrix, with N the number of projections.')
 	end
 	proj_geom = struct( ...
 		'type',					'parallel3d_vec',  ...
@@ -199,7 +199,7 @@ elseif strcmp(type,'parallel3d_vec')
 	);
 elseif strcmp(type,'sparse_matrix')
 	if numel(varargin) < 3
-		error('not enough input arguments: astra_create_proj_geom(sparse_matrix, det_width, det_count, angles, matrix_id)')
+		error('Not enough input arguments. Usage: astra_create_proj_geom(sparse_matrix, det_width, det_count, angles, matrix_id);')
 	end
 	proj_geom = struct( ...
 		'type',					'sparse_matrix', ...
@@ -210,7 +210,6 @@ elseif strcmp(type,'sparse_matrix')
 	);
 
 else
-	disp(['Error: unknown type ' type]);
-	proj_geom = struct();
+	error(['Unknown projection geometry type: ' type '.']);
 end
 

--- a/matlab/tools/astra_geom_2vec.m
+++ b/matlab/tools/astra_geom_2vec.m
@@ -119,7 +119,7 @@ function proj_geom_vec = astra_geom_2vec(proj_geom)
 		proj_geom_vec = astra_create_proj_geom('parallel3d_vec', proj_geom.DetectorRowCount, proj_geom.DetectorColCount, vectors);
 
 	else
-		error(['No suitable vector geometry found for type: ' proj_geom.type])
+		error(['No suitable vector geometry found for type: ' proj_geom.type '.'])
 	end
 
 end

--- a/matlab/tools/astra_geom_postalignment.m
+++ b/matlab/tools/astra_geom_postalignment.m
@@ -38,7 +38,7 @@ function proj_geom = astra_geom_postalignment(proj_geom, factor)
 		end
 
 	else
-		error('Projection geometry not suited for postalignment correction.')
+		error(['Projection geometry of type ' proj_geom.type ' is not suited for postalignment correction.'])
 	end
 
 end

--- a/matlab/tools/astra_geom_superresolution.m
+++ b/matlab/tools/astra_geom_superresolution.m
@@ -10,5 +10,5 @@ function proj_geom = astra_geom_superresolution(proj_geom, factor)
 			proj_geom.Vectors(:,5:6) = proj_geom.Vectors(:,5:6) / factor; % DetectorSize			
 			proj_geom.DetectorCount = proj_geom.DetectorCount * factor;
 	else
-		error('Projection geometry not suited for super-resolution (or not implemented).')
+		error(['Projection geometry of type ' proj_geom.type ' is not suited for super-resolution (or not implemented).'])
 	end

--- a/matlab/tools/astra_geom_visualize.m
+++ b/matlab/tools/astra_geom_visualize.m
@@ -208,8 +208,7 @@ function astra_geom_visualize(proj_geom, vol_geom)
 
 
 		else
-			error('invalid projector type')
-
+			error(['Invalid projection geometry type: ' proj_geom.type '.'])
 		end
     end
 

--- a/python/astra/algorithm_c.pyx
+++ b/python/astra/algorithm_c.pyx
@@ -41,6 +41,8 @@ from .PyXMLDocument cimport XMLDocument
 from . cimport utils
 from .utils import wrap_from_bytes
 
+from .log import AstraError
+
 cdef CAlgorithmManager * manAlg = <CAlgorithmManager * >PyAlgorithmManager.getSingletonPtr()
 
 cdef extern from *:
@@ -65,7 +67,7 @@ def create(config):
     if not alg.initialize(cfg[0]):
         del cfg
         del alg
-        raise Exception("Unable to initialize Algorithm.")
+        raise AstraError("Unable to initialize algorithm", append_log=True)
     del cfg
     return manAlg.store(alg)
 

--- a/python/astra/algorithm_c.pyx
+++ b/python/astra/algorithm_c.pyx
@@ -63,7 +63,7 @@ def create(config):
     alg = PyAlgorithmFactory.getSingletonPtr().create(cfg.self.getAttribute(six.b('type')))
     if alg == NULL:
         del cfg
-        raise Exception("Unknown Algorithm.")
+        raise AstraError("Unknown algorithm type")
     if not alg.initialize(cfg[0]):
         del cfg
         del alg
@@ -74,9 +74,9 @@ def create(config):
 cdef CAlgorithm * getAlg(i) except NULL:
     cdef CAlgorithm * alg = manAlg.get(i)
     if alg == NULL:
-        raise Exception("Unknown algorithm.")
+        raise AstraError("Unknown algorithm type")
     if not alg.isInitialized():
-        raise Exception("Algorithm not initialized.")
+        raise AstraError("Algorithm not initialized")
     return alg
 
 
@@ -96,12 +96,12 @@ def get_res_norm(i):
     pAlg3D = dynamic_cast_recAlg3D(alg)
     if pAlg2D != NULL:
         if not pAlg2D.getResidualNorm(res):
-            raise Exception("Operation not supported.")
+            raise AstraError("Operation not supported")
     elif pAlg3D != NULL:
         if not pAlg3D.getResidualNorm(res):
-            raise Exception("Operation not supported.")
+            raise AstraError("Operation not supported")
     else:
-        raise Exception("Operation not supported.")
+        raise AstraError("Operation not supported")
     return res
 
 
@@ -119,7 +119,7 @@ def get_plugin_object(algorithm_id):
     alg = getAlg(algorithm_id)
     pluginAlg = dynamic_cast_PluginAlg(alg)
     if not pluginAlg:
-        raise Exception("Not a plugin algorithm")
+        raise AstraError("Not a plugin algorithm")
     return pluginAlg.getInstance()
 
 

--- a/python/astra/astra_c.pyx
+++ b/python/astra/astra_c.pyx
@@ -29,6 +29,7 @@
 include "config.pxi"
 import six
 from .utils import wrap_from_bytes, wrap_to_bytes
+from .log import AstraError
 
 from libcpp.string cimport string
 from libcpp.vector cimport vector
@@ -90,7 +91,7 @@ IF HAVE_CUDA==True:
     if not isinstance(idx, abc.Iterable) or isinstance(idx, six.string_types + (six.text_type,six.binary_type)):
         idx = (idx,)
     if memory != 0 and memory < 1024*1024:
-        raise ValueError("Setting GPU memory lower than 1MB is not supported.")
+        raise AstraError("Setting GPU memory lower than 1MB is not supported")
     params.memory = memory
     params.GPUIndices = idx
     setGlobalGPUParams(params)
@@ -101,9 +102,9 @@ IF HAVE_CUDA==True:
     return wrap_from_bytes(getCudaDeviceString(idx))
 ELSE:
   def set_gpu_index(idx, memory=0):
-    raise NotImplementedError("CUDA support is not enabled in ASTRA")
+    raise AstraError("CUDA support is not enabled in ASTRA")
   def get_gpu_info(idx=-1):
-    raise NotImplementedError("CUDA support is not enabled in ASTRA")
+    raise AstraError("CUDA support is not enabled in ASTRA")
 
 def delete(ids):
     try:

--- a/python/astra/creators.py
+++ b/python/astra/creators.py
@@ -31,6 +31,7 @@ from . import data3d
 from . import projector
 from . import projector3d
 from . import algorithm
+from .log import AstraError
 
 def astra_dict(intype):
     """Creates a dict to use with the ASTRA Toolbox.
@@ -238,52 +239,52 @@ This method can be called in a number of ways:
 """
     if intype == 'parallel':
         if len(args) < 3:
-            raise Exception(
-                'not enough variables: astra_create_proj_geom(parallel, detector_spacing, det_count, angles)')
+            raise AstraError(
+                'Not enough variables. Usage: astra.create_proj_geom(parallel, detector_spacing, det_count, angles)')
         return {'type': 'parallel', 'DetectorWidth': args[0], 'DetectorCount': args[1], 'ProjectionAngles': args[2]}
     elif intype == 'parallel_vec':
         if len(args) < 2:
-            raise Exception('not enough variables: astra_create_proj_geom(parallel_vec, det_count, V)')
+            raise AstraError('Not enough variables. Usage: astra.create_proj_geom(parallel_vec, det_count, V)')
         if not args[1].shape[1] == 6:
-            raise Exception('V should be a Nx6 matrix, with N the number of projections')
+            raise AstraError('V should be a Nx6 matrix, with N the number of projections')
         return {'type':'parallel_vec', 'DetectorCount':args[0], 'Vectors':args[1]}
     elif intype == 'fanflat':
         if len(args) < 5:
-            raise Exception('not enough variables: astra_create_proj_geom(fanflat, det_width, det_count, angles, source_origin, origin_det)')
+            raise AstraError('Not enough variables. Usage: astra.create_proj_geom(fanflat, det_width, det_count, angles, source_origin, origin_det)')
         return {'type': 'fanflat', 'DetectorWidth': args[0], 'DetectorCount': args[1], 'ProjectionAngles': args[2], 'DistanceOriginSource': args[3], 'DistanceOriginDetector': args[4]}
     elif intype == 'fanflat_vec':
         if len(args) < 2:
-            raise Exception('not enough variables: astra_create_proj_geom(fanflat_vec, det_count, V)')
+            raise AstraError('Not enough variables. Usage: astra.create_proj_geom(fanflat_vec, det_count, V)')
         if not args[1].shape[1] == 6:
-            raise Exception('V should be a Nx6 matrix, with N the number of projections')
+            raise AstraError('V should be a Nx6 matrix, with N the number of projections')
         return {'type':'fanflat_vec', 'DetectorCount':args[0], 'Vectors':args[1]}
     elif intype == 'parallel3d':
         if len(args) < 5:
-            raise Exception('not enough variables: astra_create_proj_geom(parallel3d, detector_spacing_x, detector_spacing_y, det_row_count, det_col_count, angles)')
+            raise AstraError('Not enough variables. Usage: astra.reate_proj_geom(parallel3d, detector_spacing_x, detector_spacing_y, det_row_count, det_col_count, angles)')
         return {'type':'parallel3d', 'DetectorSpacingX':args[0], 'DetectorSpacingY':args[1], 'DetectorRowCount':args[2], 'DetectorColCount':args[3],'ProjectionAngles':args[4]}
     elif intype == 'cone':
         if len(args) < 7:
-            raise Exception('not enough variables: astra_create_proj_geom(cone, detector_spacing_x, detector_spacing_y, det_row_count, det_col_count, angles, source_origin, origin_det)')
+            raise AstraError('Not enough variables. Usage: astra.create_proj_geom(cone, detector_spacing_x, detector_spacing_y, det_row_count, det_col_count, angles, source_origin, origin_det)')
         return {'type': 'cone','DetectorSpacingX':args[0], 'DetectorSpacingY':args[1], 'DetectorRowCount':args[2],'DetectorColCount':args[3],'ProjectionAngles':args[4],'DistanceOriginSource': args[5],'DistanceOriginDetector':args[6]}
     elif intype == 'cone_vec':
         if len(args) < 3:
-            raise Exception('not enough variables: astra_create_proj_geom(cone_vec, det_row_count, det_col_count, V)')
+            raise AstraError('Not enough variables. Usage: astra.create_proj_geom(cone_vec, det_row_count, det_col_count, V)')
         if not args[2].shape[1] == 12:
-            raise Exception('V should be a Nx12 matrix, with N the number of projections')
+            raise AstraError('V should be a Nx12 matrix, with N the number of projections')
         return {'type': 'cone_vec','DetectorRowCount':args[0],'DetectorColCount':args[1],'Vectors':args[2]}
     elif intype == 'parallel3d_vec':
         if len(args) < 3:
-            raise Exception('not enough variables: astra_create_proj_geom(parallel3d_vec, det_row_count, det_col_count, V)')
+            raise AstraError('Not enough variables. Usage: astra.create_proj_geom(parallel3d_vec, det_row_count, det_col_count, V)')
         if not args[2].shape[1] == 12:
-            raise Exception('V should be a Nx12 matrix, with N the number of projections')
+            raise AstraError('V should be a Nx12 matrix, with N the number of projections')
         return {'type': 'parallel3d_vec','DetectorRowCount':args[0],'DetectorColCount':args[1],'Vectors':args[2]}
     elif intype == 'sparse_matrix':
         if len(args) < 4:
-            raise Exception(
-                'not enough variables: astra_create_proj_geom(sparse_matrix, det_width, det_count, angles, matrix_id)')
+            raise AstraError(
+                'Not enough variables. Usage: astra.create_proj_geom(sparse_matrix, det_width, det_count, angles, matrix_id)')
         return {'type': 'sparse_matrix', 'DetectorWidth': args[0], 'DetectorCount': args[1], 'ProjectionAngles': args[2], 'MatrixID': args[3]}
     else:
-        raise Exception('Error: unknown type ' + intype)
+        raise AstraError('Unknown projection geometry type: ' + intype)
 
 
 def create_backprojection(data, proj_id, returnData=True):
@@ -554,7 +555,7 @@ def create_projector(proj_type, proj_geom, vol_geom, options=None):
 
 """
     if proj_type == 'blob':
-        raise Exception('Blob type not yet implemented')
+        raise NotImplementedError('Blob type not yet implemented')
     cfg = astra_dict(proj_type)
     cfg['ProjectionGeometry'] = proj_geom
     cfg['VolumeGeometry'] = vol_geom

--- a/python/astra/data2d_c.pyx
+++ b/python/astra/data2d_c.pyx
@@ -87,7 +87,8 @@ def create(datatype, geometry, data=None, link=False):
     if link:
         geom_shape = geom_size(geometry)
         if data.shape != geom_shape:
-            raise ValueError("The dimensions of the data do not match those specified in the geometry: {} != {}".format(data.shape, geom_shape))
+            raise ValueError("The dimensions of the data do not match those specified in the geometry: "
+                             "{} (data) != {} (geometry)".format(data.shape, geom_shape))
 
     if datatype == '-vol':
         cfg = utils.dictToConfig(six.b('VolumeGeometry'), geometry)
@@ -128,7 +129,7 @@ def create(datatype, geometry, data=None, link=False):
         del ppGeometry
         del cfg
     else:
-        raise ValueError("Invalid datatype.  Please specify '-vol' or '-sino'.")
+        raise ValueError("Invalid datatype. Please specify '-vol' or '-sino'")
 
     if not pDataObject2D.isInitialized():
         del pDataObject2D
@@ -146,7 +147,8 @@ cdef fillDataObject(CFloat32Data2D * obj, data):
             obj_shape = (obj.getHeight(), obj.getWidth())
             if data.shape != obj_shape:
                 raise ValueError(
-                  "The dimensions of the data do not match those specified in the geometry: {} != {}".format(data.shape, obj_shape))
+                  "The dimensions of the data do not match those specified in the geometry: "
+                  "{} (data) != {} (geometry)".format(data.shape, obj_shape))
             fillDataObjectArray(obj, np.ascontiguousarray(data,dtype=np.float32))
         else:
             fillDataObjectScalar(obj, np.float32(data))
@@ -165,9 +167,9 @@ cdef fillDataObjectArray(CFloat32Data2D * obj, float [:,::1] data):
 cdef CFloat32Data2D * getObject(i) except NULL:
     cdef CFloat32Data2D * pDataObject = man2d.get(i)
     if pDataObject == NULL:
-        raise ValueError("Data object not found")
+        raise AstraError("Data object not found")
     if not pDataObject.isInitialized():
-        raise RuntimeError("Data object not initialized properly.")
+        raise AstraError("Data object not initialized properly")
     return pDataObject
 
 
@@ -186,15 +188,15 @@ def get_geometry(i):
         pDataObject3 = <CFloat32VolumeData2D * >pDataObject
         geom = utils.configToDict(pDataObject3.getGeometry().getConfiguration())
     else:
-        raise RuntimeError("Not a known data object")
+        raise AstraError("Not a known data object")
     return geom
 
 cdef CProjector2D * getProjector(i) except NULL:
     cdef CProjector2D * proj = manProj.get(i)
     if proj == NULL:
-        raise RuntimeError("Projector not initialized.")
+        raise AstraError("Projector not found")
     if not proj.isInitialized():
-        raise RuntimeError("Projector not initialized.")
+        raise AstraError("Projector not initialized")
     return proj
 
 def check_compatible(i, proj_id):
@@ -209,7 +211,7 @@ def check_compatible(i, proj_id):
         pDataObject3 = <CFloat32VolumeData2D * >pDataObject
         return pDataObject3.getGeometry().isEqual(proj.getVolumeGeometry())
     else:
-        raise RuntimeError("Not a known data object")
+        raise AstraError("Not a known data object type")
 
 def change_geometry(i, geom):
     cdef Config *cfg
@@ -242,7 +244,8 @@ def change_geometry(i, geom):
             del ppGeometry
             del cfg
             raise ValueError(
-                "The dimensions of the data do not match those specified in the geometry: {} != {}", obj_shape, geom_shape)
+                "The dimensions of the data do not match those specified in the geometry: "
+                "{} (data) != {} (geometry)", obj_shape, geom_shape)
         pDataObject2.changeGeometry(ppGeometry)
         del ppGeometry
         del cfg
@@ -260,12 +263,13 @@ def change_geometry(i, geom):
             del cfg
             del pGeometry
             raise ValueError(
-                "The dimensions of the data do not match those specified in the geometry: {} != {}", obj_shape, geom_shape)
+                "The dimensions of the data do not match those specified in the geometry: "
+                "{} (data) != {} (geometry)", obj_shape, geom_shape)
         pDataObject3.changeGeometry(pGeometry)
         del cfg
         del pGeometry
     else:
-        raise RuntimeError("Not a known data object")
+        raise AstraError("Not a known data object")
 
 @cython.boundscheck(False)
 @cython.wraparound(False)

--- a/python/astra/data2d_c.pyx
+++ b/python/astra/data2d_c.pyx
@@ -49,6 +49,7 @@ np.import_array()
 from .PyIncludes cimport *
 from . cimport utils
 from .utils import wrap_from_bytes
+from .log import AstraError
 
 from .pythonutils import geom_size
 
@@ -94,7 +95,7 @@ def create(datatype, geometry, data=None, link=False):
         if not pGeometry.initialize(cfg[0]):
             del cfg
             del pGeometry
-            raise RuntimeError('Geometry class not initialized.')
+            raise AstraError('Geometry class could not be initialized', append_log=True)
         if link:
             pCustom = <CFloat32CustomMemory*> new CFloat32CustomPython(data)
             pDataObject2D = <CFloat32Data2D * > new CFloat32VolumeData2D(pGeometry, pCustom)
@@ -118,7 +119,7 @@ def create(datatype, geometry, data=None, link=False):
         if not ppGeometry.initialize(cfg[0]):
             del cfg
             del ppGeometry
-            raise RuntimeError('Geometry class not initialized.')
+            raise AstraError('Geometry class could not be initialized', append_log=True)
         if link:
             pCustom = <CFloat32CustomMemory*> new CFloat32CustomPython(data)
             pDataObject2D = <CFloat32Data2D * > new CFloat32ProjectionData2D(ppGeometry, pCustom)
@@ -131,7 +132,7 @@ def create(datatype, geometry, data=None, link=False):
 
     if not pDataObject2D.isInitialized():
         del pDataObject2D
-        raise RuntimeError("Couldn't initialize data object.")
+        raise AstraError("Couldn't initialize data object", append_log=True)
 
     if not link: fillDataObject(pDataObject2D, data)
 
@@ -234,7 +235,7 @@ def change_geometry(i, geom):
         if not ppGeometry.initialize(cfg[0]):
             del cfg
             del ppGeometry
-            raise RuntimeError('Geometry class not initialized.')
+            AstraError('Geometry class could not be initialized', append_log=True)
         geom_shape = (ppGeometry.getProjectionAngleCount(), ppGeometry.getDetectorCount())
         obj_shape = (pDataObject2.getAngleCount(), pDataObject2.getDetectorCount())
         if geom_shape != obj_shape:
@@ -252,7 +253,7 @@ def change_geometry(i, geom):
         if not pGeometry.initialize(cfg[0]):
             del cfg
             del pGeometry
-            raise RuntimeError('Geometry class not initialized.')
+            raise AstraError('Geometry class could not be initialized', append_log=True)
         geom_shape = (pGeometry.getGridRowCount(), pGeometry.getGridColCount())
         obj_shape = (pDataObject3.getHeight(), pDataObject3.getWidth())
         if geom_shape != obj_shape:

--- a/python/astra/data2d_c.pyx
+++ b/python/astra/data2d_c.pyx
@@ -87,8 +87,8 @@ def create(datatype, geometry, data=None, link=False):
     if link:
         geom_shape = geom_size(geometry)
         if data.shape != geom_shape:
-            raise ValueError("The dimensions of the data do not match those specified in the geometry: "
-                             "{} (data) != {} (geometry)".format(data.shape, geom_shape))
+            raise ValueError("The dimensions of the data {} do not match those "
+                             "specified in the geometry {}".format(data.shape, geom_shape))
 
     if datatype == '-vol':
         cfg = utils.dictToConfig(six.b('VolumeGeometry'), geometry)
@@ -149,8 +149,8 @@ cdef fillDataObject(CFloat32Data2D * obj, data):
             obj_shape = (obj.getHeight(), obj.getWidth())
             if data.shape != obj_shape:
                 raise ValueError(
-                  "The dimensions of the data do not match those specified in the geometry: "
-                  "{} (data) != {} (geometry)".format(data.shape, obj_shape))
+                  "The dimensions of the data {} do not match those specified "
+                  "in the geometry {}".format(data.shape, obj_shape))
             fillDataObjectArray(obj, np.ascontiguousarray(data,dtype=np.float32))
         else:
             fillDataObjectScalar(obj, np.float32(data))
@@ -245,9 +245,8 @@ def change_geometry(i, geom):
         if geom_shape != obj_shape:
             del ppGeometry
             del cfg
-            raise ValueError(
-                "The dimensions of the data do not match those specified in the geometry: "
-                "{} (data) != {} (geometry)", obj_shape, geom_shape)
+            raise ValueError("The dimensions of the data {} do not match those "
+                             "specified in the geometry {}".format(obj_shape, geom_shape))
         pDataObject2.changeGeometry(ppGeometry)
         del ppGeometry
         del cfg
@@ -264,9 +263,8 @@ def change_geometry(i, geom):
         if geom_shape != obj_shape:
             del cfg
             del pGeometry
-            raise ValueError(
-                "The dimensions of the data do not match those specified in the geometry: "
-                "{} (data) != {} (geometry)", obj_shape, geom_shape)
+            raise ValueError("The dimensions of the data {} do not match those "
+                             "specified in the geometry {}".format(obj_shape, geom_shape))
         pDataObject3.changeGeometry(pGeometry)
         del cfg
         del pGeometry

--- a/python/astra/data2d_c.pyx
+++ b/python/astra/data2d_c.pyx
@@ -115,8 +115,10 @@ def create(datatype, geometry, data=None, link=False):
             ppGeometry = <CProjectionGeometry2D * >new CFanFlatVecProjectionGeometry2D()
         elif (tpe == 'parallel_vec'):
             ppGeometry = <CProjectionGeometry2D * >new CParallelVecProjectionGeometry2D()
-        else:
+        elif (tpe == 'parallel'):
             ppGeometry = <CProjectionGeometry2D * >new CParallelProjectionGeometry2D()
+        else:
+            raise ValueError("'{}' is not a valid 2D geometry type".format(tpe))
         if not ppGeometry.initialize(cfg[0]):
             del cfg
             del ppGeometry

--- a/python/astra/data3d.py
+++ b/python/astra/data3d.py
@@ -55,7 +55,7 @@ def link(datatype, geometry, data):
     
     """
     if not isinstance(data,np.ndarray) and not isinstance(data,GPULink):
-        raise TypeError("Input should be a numpy ndarray or GPULink object")
+        raise TypeError("Input should be a numpy.ndarray or GPULink object")
     if isinstance(data, np.ndarray):
         checkArrayForLink(data)
     return d.create(datatype,geometry,data,True)

--- a/python/astra/data3d_c.pyx
+++ b/python/astra/data3d_c.pyx
@@ -45,6 +45,7 @@ from .PyXMLDocument cimport XMLDocument
 from . cimport utils
 from .utils import wrap_from_bytes
 from .utils cimport linkVolFromGeometry, linkProjFromGeometry, createProjectionGeometry3D, createVolumeGeometry3D
+from .log import AstraError
 
 from .pythonutils import geom_size, GPULink
 
@@ -105,7 +106,7 @@ def create(datatype,geometry,data=None, link=False):
 
     if not pDataObject3D.isInitialized():
         del pDataObject3D
-        raise RuntimeError("Couldn't initialize data object.")
+        raise AstraError("Couldn't initialize data object", append_log=True)
 
     if not link:
         fillDataObject(dynamic_cast_mem_safe(pDataObject3D), data)

--- a/python/astra/data3d_c.pyx
+++ b/python/astra/data3d_c.pyx
@@ -85,8 +85,8 @@ def create(datatype,geometry,data=None, link=False):
         else:
             raise TypeError("data should be a numpy.ndarray or a GPULink object")
         if geom_shape != data_shape:
-            raise ValueError("The dimensions of the data do not match those specified in the geometry: "
-                             "{} (data) != {} (geometry)".format(data_shape, geom_shape))
+            raise ValueError("The dimensions of the data {} do not match those "
+                             "specified in the geometry {}".format(data_shape, geom_shape))
 
     if datatype == '-vol':
         pGeometry = createVolumeGeometry3D(geometry)
@@ -139,8 +139,8 @@ def change_geometry(i, geom):
         obj_shape = (pDataObject2.getDetectorRowCount(), pDataObject2.getAngleCount(), pDataObject2.getDetectorColCount())
         if geom_shape != obj_shape:
             del ppGeometry
-            raise ValueError("The dimensions of the data do not match those specified in the geometry: "
-                             "{} (data) != {} (geometry)".format(obj_shape, geom_shape))
+            raise ValueError("The dimensions of the data {} do not match those "
+                             "specified in the geometry {}".format(obj_shape, geom_shape))
         pDataObject2.changeGeometry(ppGeometry)
         del ppGeometry
 
@@ -151,8 +151,8 @@ def change_geometry(i, geom):
         obj_shape = (pDataObject3.getSliceCount(), pDataObject3.getRowCount(), pDataObject3.getColCount())
         if geom_shape != obj_shape:
             del pGeometry
-            raise ValueError("The dimensions of the data do not match those specified in the geometry."
-                             "{} (data) != {} (geometry)".format(obj_shape, geom_shape))
+            raise ValueError("The dimensions of the data {} do not match those "
+                             "specified in the geometry {}".format(obj_shape, geom_shape))
         pDataObject3.changeGeometry(pGeometry)
         del pGeometry
 
@@ -167,8 +167,8 @@ cdef fillDataObject(CFloat32Data3DMemory * obj, data):
         if isinstance(data, np.ndarray):
             obj_shape = (obj.getDepth(), obj.getHeight(), obj.getWidth())
             if data.shape != obj_shape:
-                raise ValueError("The dimensions of the data do not match those specified in the geometry: "
-                                 "{} (data) != {} (geometry)".format(data.shape, obj_shape))
+                raise ValueError("The dimensions of the data {} do not match those "
+                                 "specified in the geometry {}".format(data.shape, obj_shape))
             fillDataObjectArray(obj, np.ascontiguousarray(data,dtype=np.float32))
         else:
             fillDataObjectScalar(obj, np.float32(data))

--- a/python/astra/data3d_c.pyx
+++ b/python/astra/data3d_c.pyx
@@ -64,7 +64,7 @@ cdef extern from *:
 cdef CFloat32Data3DMemory * dynamic_cast_mem_safe(CFloat32Data3D *obj) except NULL:
     cdef CFloat32Data3DMemory *ret = dynamic_cast_mem(obj)
     if not ret:
-        raise RuntimeError("Not a memory 3D data object")
+        raise AstraError("Not a memory 3D data object")
     return ret
 
 
@@ -85,7 +85,8 @@ def create(datatype,geometry,data=None, link=False):
         else:
             raise TypeError("data should be a numpy.ndarray or a GPULink object")
         if geom_shape != data_shape:
-            raise ValueError("The dimensions of the data do not match those specified in the geometry: {} != {}".format(data_shape, geom_shape))
+            raise ValueError("The dimensions of the data do not match those specified in the geometry: "
+                             "{} (data) != {} (geometry)".format(data_shape, geom_shape))
 
     if datatype == '-vol':
         pGeometry = createVolumeGeometry3D(geometry)
@@ -102,7 +103,7 @@ def create(datatype,geometry,data=None, link=False):
             pDataObject3D = new CFloat32ProjectionData3DMemory(ppGeometry)
         del ppGeometry
     else:
-        raise ValueError("Invalid datatype.  Please specify '-vol' or '-proj3d'.")
+        raise ValueError("Invalid datatype. Please specify '-vol' or '-proj3d'")
 
     if not pDataObject3D.isInitialized():
         del pDataObject3D
@@ -124,7 +125,7 @@ def get_geometry(i):
         pDataObject3 = <CFloat32VolumeData3DMemory * >pDataObject
         geom = utils.configToDict(pDataObject3.getGeometry().getConfiguration())
     else:
-        raise RuntimeError("Not a known data object")
+        raise AstraError("Not a known data object")
     return geom
 
 def change_geometry(i, geom):
@@ -138,8 +139,8 @@ def change_geometry(i, geom):
         obj_shape = (pDataObject2.getDetectorRowCount(), pDataObject2.getAngleCount(), pDataObject2.getDetectorColCount())
         if geom_shape != obj_shape:
             del ppGeometry
-            raise ValueError(
-                "The dimensions of the data do not match those specified in the geometry: {} != {}".format(obj_shape, geom_shape))
+            raise ValueError("The dimensions of the data do not match those specified in the geometry: "
+                             "{} (data) != {} (geometry)".format(obj_shape, geom_shape))
         pDataObject2.changeGeometry(ppGeometry)
         del ppGeometry
 
@@ -150,13 +151,13 @@ def change_geometry(i, geom):
         obj_shape = (pDataObject3.getSliceCount(), pDataObject3.getRowCount(), pDataObject3.getColCount())
         if geom_shape != obj_shape:
             del pGeometry
-            raise ValueError(
-                "The dimensions of the data do not match those specified in the geometry.".format(obj_shape, geom_shape))
+            raise ValueError("The dimensions of the data do not match those specified in the geometry."
+                             "{} (data) != {} (geometry)".format(obj_shape, geom_shape))
         pDataObject3.changeGeometry(pGeometry)
         del pGeometry
 
     else:
-        raise RuntimeError("Not a known data object")
+        raise AstraError("Not a known data object")
 
 
 cdef fillDataObject(CFloat32Data3DMemory * obj, data):
@@ -166,8 +167,8 @@ cdef fillDataObject(CFloat32Data3DMemory * obj, data):
         if isinstance(data, np.ndarray):
             obj_shape = (obj.getDepth(), obj.getHeight(), obj.getWidth())
             if data.shape != obj_shape:
-                raise ValueError(
-                  "The dimensions of the data do not match those specified in the geometry: {} != {}".format(data.shape, obj_shape))
+                raise ValueError("The dimensions of the data do not match those specified in the geometry: "
+                                 "{} (data) != {} (geometry)".format(data.shape, obj_shape))
             fillDataObjectArray(obj, np.ascontiguousarray(data,dtype=np.float32))
         else:
             fillDataObjectScalar(obj, np.float32(data))
@@ -186,9 +187,9 @@ cdef fillDataObjectArray(CFloat32Data3DMemory * obj, float [:,:,::1] data):
 cdef CFloat32Data3D * getObject(i) except NULL:
     cdef CFloat32Data3D * pDataObject = man3d.get(i)
     if pDataObject == NULL:
-        raise ValueError("Data object not found")
+        raise AstraError("Data object not found")
     if not pDataObject.isInitialized():
-        raise RuntimeError("Data object not initialized properly.")
+        raise AstraError("Data object not initialized properly")
     return pDataObject
 
 @cython.boundscheck(False)

--- a/python/astra/experimental.pyx
+++ b/python/astra/experimental.pyx
@@ -71,24 +71,24 @@ IF HAVE_CUDA==True:
 
     def do_composite(projector_id, vol_ids, proj_ids, mode, t):
         if mode != MODE_ADD and mode != MODE_SET:
-            raise RuntimeError("internal error: wrong composite mode")
+            raise AstraError("Internal error: wrong composite mode")
         cdef vector[CFloat32VolumeData3D *] vol
         cdef CFloat32VolumeData3D * pVolObject
         cdef CFloat32ProjectionData3D * pProjObject
         for v in vol_ids:
             pVolObject = dynamic_cast_vol_mem(man3d.get(v))
             if pVolObject == NULL:
-                raise Exception("Data object not found")
+                raise AstraError("Data object not found")
             if not pVolObject.isInitialized():
-                raise Exception("Data object not initialized properly")
+                raise AstraError("Data object not initialized properly")
             vol.push_back(pVolObject)
         cdef vector[CFloat32ProjectionData3D *] proj
         for v in proj_ids:
             pProjObject = dynamic_cast_proj_mem(man3d.get(v))
             if pProjObject == NULL:
-                raise Exception("Data object not found")
+                raise AstraError("Data object not found")
             if not pProjObject.isInitialized():
-                raise Exception("Data object not initialized properly")
+                raise AstraError("Data object not initialized properly")
             proj.push_back(pProjObject)
         cdef CCompositeGeometryManager m
         cdef CProjector3D * projector = manProj.get(projector_id) # may be NULL
@@ -99,7 +99,7 @@ IF HAVE_CUDA==True:
             if not m.doBP(projector, vol, proj, mode):
                 raise AstraError("Failed to perform BP", append_log=True)
         else:
-            raise RuntimeError("internal error: wrong composite op type")
+            raise AstraError("Internal error: wrong composite op type")
 
     def do_composite_FP(projector_id, vol_ids, proj_ids):
         do_composite(projector_id, vol_ids, proj_ids, MODE_SET, "FP")
@@ -116,14 +116,14 @@ IF HAVE_CUDA==True:
         cdef CFloat32ProjectionData3D * pProjObject
         pVolObject = dynamic_cast_vol_mem(man3d.get(vol_id))
         if pVolObject == NULL:
-            raise Exception("Data object not found")
+            raise AstraError("Data object not found")
         if not pVolObject.isInitialized():
-            raise Exception("Data object not initialized properly")
+            raise AstraError("Data object not initialized properly")
         pProjObject = dynamic_cast_proj_mem(man3d.get(proj_id))
         if pProjObject == NULL:
-            raise Exception("Data object not found")
+            raise AstraError("Data object not found")
         if not pProjObject.isInitialized():
-            raise Exception("Data object not initialized properly")
+            raise AstraError("Data object not initialized properly")
         cdef CCompositeGeometryManager m
         cdef CProjector3D * projector = manProj.get(projector_id) # may be NULL
         if not m.doFDK(projector, pVolObject, pProjObject, False, NULL, MODE_ADD):
@@ -134,10 +134,10 @@ IF HAVE_CUDA==True:
 
     def direct_FPBP3D(projector_id, vol, proj, mode, t):
         if mode != MODE_ADD and mode != MODE_SET:
-            raise RuntimeError("internal error: wrong composite mode")
+            raise AstraError("Internal error: wrong composite mode")
         cdef CProjector3D * projector = manProj.get(projector_id)
         if projector == NULL:
-            raise Exception("Projector not found")
+            raise AstraError("Projector not found")
         cdef CVolumeGeometry3D *pGeometry = projector.getVolumeGeometry()
         cdef CProjectionGeometry3D *ppGeometry = projector.getProjectionGeometry()
         cdef CFloat32VolumeData3D * pVol = linkVolFromGeometry(pGeometry, vol)
@@ -155,7 +155,7 @@ IF HAVE_CUDA==True:
                 if not m.doBP(projector, vols, projs, mode):
                     AstraError("Failed to perform BP", append_log=True)
             else:
-                raise RuntimeError("internal error: wrong op type")
+                AstraError("Internal error: wrong op type")
         finally:
             del pVol
             del pProj

--- a/python/astra/experimental.pyx
+++ b/python/astra/experimental.pyx
@@ -31,6 +31,7 @@ include "config.pxi"
 from . cimport utils
 from .utils import wrap_from_bytes
 from .utils cimport createProjectionGeometry3D
+from .log import AstraError
 
 IF HAVE_CUDA==True:
 
@@ -93,10 +94,10 @@ IF HAVE_CUDA==True:
         cdef CProjector3D * projector = manProj.get(projector_id) # may be NULL
         if t == "FP":
             if not m.doFP(projector, vol, proj, mode):
-                raise Exception("Failed to perform FP")
+                raise AstraError("Failed to perform FP", append_log=True)
         elif t == "BP":
             if not m.doBP(projector, vol, proj, mode):
-                raise Exception("Failed to perform BP")
+                raise AstraError("Failed to perform BP", append_log=True)
         else:
             raise RuntimeError("internal error: wrong composite op type")
 
@@ -126,7 +127,7 @@ IF HAVE_CUDA==True:
         cdef CCompositeGeometryManager m
         cdef CProjector3D * projector = manProj.get(projector_id) # may be NULL
         if not m.doFDK(projector, pVolObject, pProjObject, False, NULL, MODE_ADD):
-            raise Exception("Failed to perform FDK")
+            raise AstraError("Failed to perform FDK", append_log=True)
 
     from . cimport utils
     from .utils cimport linkVolFromGeometry, linkProjFromGeometry
@@ -149,10 +150,10 @@ IF HAVE_CUDA==True:
         try:
             if t == "FP":
                 if not m.doFP(projector, vols, projs, mode):
-                    raise Exception("Failed to perform FP")
+                    AstraError("Failed to perform FP", append_log=True)
             elif t == "BP":
                 if not m.doBP(projector, vols, projs, mode):
-                    raise Exception("Failed to perform BP")
+                    AstraError("Failed to perform BP", append_log=True)
             else:
                 raise RuntimeError("internal error: wrong op type")
         finally:

--- a/python/astra/functions.py
+++ b/python/astra/functions.py
@@ -44,6 +44,7 @@ from . import projector
 from . import algorithm
 from . import pythonutils
 
+from .log import AstraError
 
 
 def clear():
@@ -268,8 +269,7 @@ def geom_2vec(proj_geom):
         'parallel3d_vec', proj_geom['DetectorRowCount'], proj_geom['DetectorColCount'], vectors)
 
     else:
-        raise ValueError(
-        'No suitable vector geometry found for type: ' + proj_geom['type'])
+        raise AstraError('No suitable vector geometry found for type: ' + proj_geom['type'])
     return proj_geom_out
 
 
@@ -302,7 +302,7 @@ def geom_postalignment(proj_geom, factor):
         if len(factor) > 1:
             V[:,3:6] = V[:,3:6] + factor[1] * V[:,9:12]
     else:
-        raise RuntimeError('No suitable geometry for postalignment: ' + proj_geom['type'])
+        raise AstraError(proj_geom['type'] + 'geometry is not suitable for postalignment')
 
     return proj_geom
 

--- a/python/astra/log.py
+++ b/python/astra/log.py
@@ -150,3 +150,19 @@ def setOutputFile(filename, level):
     :type level: :class:`int`
     """
     l.log_setOutputFile(filename, level)
+
+class AstraError(Exception):
+    def __init__(self, message='', append_log=False):
+        """Error in Astra Toolbox operation.
+
+        :param message: Error message, defaults to empty string.
+        :type message: str, optional
+        :param append_log: Append last error message recorded by the Astra
+            shared library to the Python error message, defaults to False.
+        :type append_log: bool, optional
+        """
+        if append_log:
+            last_err_msg = l.log_getLastErrMsg()
+            if last_err_msg:
+                message += ': ' + last_err_msg
+        super(AstraError, self).__init__(message)

--- a/python/astra/log_c.pyx
+++ b/python/astra/log_c.pyx
@@ -27,6 +27,7 @@
 # distutils: libraries = astra
 
 import six
+from libcpp.string cimport string
 
 cdef extern from "astra/Logging.h" namespace "astra":
     cdef enum log_level:
@@ -50,6 +51,7 @@ cdef extern from "astra/Logging.h" namespace "astra::CLogger":
     void disableFile()
     void setFormatFile(const char *fmt)
     void setFormatScreen(const char *fmt)
+    string getLastErrMsg()
 
 def log_debug(sfile, sline, message):
     cstr = list(map(six.b,(sfile,message)))
@@ -101,3 +103,6 @@ def log_setOutputScreen(fd, level):
 def log_setOutputFile(filename, level):
     cstr = six.b(filename)
     setOutputFile(cstr, enumList[level])
+
+def log_getLastErrMsg():
+    return getLastErrMsg().decode('UTF-8')

--- a/python/astra/matrix_c.pyx
+++ b/python/astra/matrix_c.pyx
@@ -42,6 +42,7 @@ from . cimport PyMatrixManager
 from .PyMatrixManager cimport CMatrixManager
 from .PyIncludes cimport *
 from .utils import wrap_from_bytes
+from .log import AstraError
 
 cdef CMatrixManager * manM = <CMatrixManager * >PyMatrixManager.getSingletonPtr()
 
@@ -87,7 +88,7 @@ def create(data):
     pMatrix = new CSparseMatrix(data.shape[0], data.shape[1], data.nnz)
     if not pMatrix.isInitialized():
         del pMatrix
-        raise Exception("Couldn't initialize data object.")
+        raise AstraError("Couldn't initialize data object", append_log=True)
     try:
         csr_matrix_to_astra(data,pMatrix)
     except:

--- a/python/astra/matrix_c.pyx
+++ b/python/astra/matrix_c.pyx
@@ -63,9 +63,9 @@ cdef int csr_matrix_to_astra(data,CSparseMatrix *mat) except -1:
     else:
         csrD = data.tocsr()
     if not mat.isInitialized():
-        raise Exception("Couldn't initialize data object.")
+        raise AstraError("Provided matrix object was not initialized")
     if csrD.nnz > mat.m_lSize or csrD.shape[0] > mat.m_iHeight:
-        raise Exception("Matrix too large to store in this object.")
+        raise AstraError("Matrix too large to store in this object")
     for i in range(len(csrD.indptr)):
         mat.m_plRowStarts[i] = csrD.indptr[i]
     for i in range(csrD.nnz):
@@ -93,16 +93,16 @@ def create(data):
         csr_matrix_to_astra(data,pMatrix)
     except:
         del pMatrix
-        raise Exception("Failed to create data object.")
+        raise AstraError("Failed to create data object")
 
     return manM.store(pMatrix)
 
 cdef CSparseMatrix * getObject(i) except NULL:
     cdef CSparseMatrix * pDataObject = manM.get(i)
     if pDataObject == NULL:
-        raise Exception("Data object not found")
+        raise AstraError("Data object not found")
     if not pDataObject.isInitialized():
-        raise Exception("Data object not initialized properly.")
+        raise AstraError("Data object not initialized properly")
     return pDataObject
 
 

--- a/python/astra/plugin.py
+++ b/python/astra/plugin.py
@@ -29,6 +29,7 @@ from . import data2d
 from . import data2d_c
 from . import data3d
 from . import projector
+from .log import AstraError
 import inspect
 import traceback
 
@@ -59,7 +60,7 @@ class base(object):
         if not reqKeys.issubset(cfgKeys):
             for key in reqKeys.difference(cfgKeys):
                 log.error("Required option '" + key + "' for plugin '" + self.__class__.__name__ + "' not specified")
-            raise ValueError("Missing required options")
+            raise AstraError("Missing required options")
 
         if not cfgKeys.issubset(reqKeys | optKeys):
             log.warn(self.__class__.__name__ + ": unused configuration option: " + str(list(cfgKeys.difference(reqKeys | optKeys))))
@@ -77,9 +78,9 @@ class ReconstructionAlgorithm2D(base):
         self.vg = projector.volume_geometry(self.pid)
         self.pg = projector.projection_geometry(self.pid)
         if not data2d_c.check_compatible(cfg['ProjectionDataId'], self.pid):
-            raise ValueError("Projection data and projector not compatible")
+            raise AstraError("Projection data and projector not compatible")
         if not data2d_c.check_compatible(cfg['ReconstructionDataId'], self.pid):
-            raise ValueError("Reconstruction data and projector not compatible")
+            raise AstraError("Reconstruction data and projector not compatible")
         super(ReconstructionAlgorithm2D,self).astra_init(cfg)
 
 class ReconstructionAlgorithm3D(base):

--- a/python/astra/projector3d_c.pyx
+++ b/python/astra/projector3d_c.pyx
@@ -57,7 +57,7 @@ def create(config):
     proj = PyProjector3DFactory.getSingletonPtr().create(cfg.self.getAttribute(six.b('type')))
     if proj == NULL:
         del cfg
-        raise Exception("Unknown Projector3D type.")
+        raise AstraError("Unknown Projector3D type")
     if not proj.initialize(cfg[0]):
         del cfg
         del proj
@@ -84,9 +84,9 @@ def info():
 cdef CProjector3D * getObject(i) except NULL:
     cdef CProjector3D * proj = manProj.get(i)
     if proj == NULL:
-        raise Exception("Projector not initialized.")
+        raise AstraError("Projector not found")
     if not proj.isInitialized():
-        raise Exception("Projector not initialized.")
+        raise AstraError("Projector not initialized")
     return proj
 
 
@@ -107,15 +107,15 @@ def volume_geometry(i):
 
 
 def weights_single_ray(i, projection_index, detector_index):
-    raise Exception("Not yet implemented")
+    raise NotImplementedError("Not yet implemented")
 
 
 def weights_projection(i, projection_index):
-    raise Exception("Not yet implemented")
+    raise NotImplementedError("Not yet implemented")
 
 
 def splat(i, row, col):
-    raise Exception("Not yet implemented")
+    raise NotImplementedError("Not yet implemented")
 
 def is_cuda(i):
     cdef CProjector3D * proj = getObject(i)

--- a/python/astra/projector3d_c.pyx
+++ b/python/astra/projector3d_c.pyx
@@ -31,6 +31,7 @@ from .PyIncludes cimport *
 
 from . cimport utils
 from .utils import wrap_from_bytes
+from .log import AstraError
 
 from . cimport PyProjector3DFactory
 from .PyProjector3DFactory cimport CProjector3DFactory
@@ -60,7 +61,7 @@ def create(config):
     if not proj.initialize(cfg[0]):
         del cfg
         del proj
-        raise Exception("Unable to initialize Projector3D.")
+        raise AstraError("Unable to initialize Projector3D", append_log=True)
     del cfg
     return manProj.store(proj)
 

--- a/python/astra/projector_c.pyx
+++ b/python/astra/projector_c.pyx
@@ -31,6 +31,7 @@ from .PyIncludes cimport *
 
 from . cimport utils
 from .utils import wrap_from_bytes
+from .log import AstraError
 
 from . cimport PyProjector2DFactory
 from .PyProjector2DFactory cimport CProjector2DFactory
@@ -64,7 +65,7 @@ def create(config):
     if not proj.initialize(cfg[0]):
         del cfg
         del proj
-        raise Exception("Unable to initialize Projector2D.")
+        raise AstraError("Unable to initialize Projector2D", append_log=True)
     del cfg
     return manProj.store(proj)
 

--- a/python/astra/projector_c.pyx
+++ b/python/astra/projector_c.pyx
@@ -61,7 +61,7 @@ def create(config):
     proj = PyProjector2DFactory.getSingletonPtr().create(cfg.self.getAttribute(six.b('type')))
     if proj == NULL:
         del cfg
-        raise Exception("Unknown Projector2D.")
+        raise AstraError("Unknown Projector2D type")
     if not proj.initialize(cfg[0]):
         del cfg
         del proj
@@ -88,9 +88,9 @@ def info():
 cdef CProjector2D * getObject(i) except NULL:
     cdef CProjector2D * proj = manProj.get(i)
     if proj == NULL:
-        raise Exception("Projector not initialized.")
+        raise AstraError("Projector not found")
     if not proj.isInitialized():
-        raise Exception("Projector not initialized.")
+        raise AstraError("Projector not initialized")
     return proj
 
 
@@ -111,15 +111,15 @@ def volume_geometry(i):
 
 
 def weights_single_ray(i, projection_index, detector_index):
-    raise Exception("Not yet implemented")
+    raise NotImplementedError("Not yet implemented")
 
 
 def weights_projection(i, projection_index):
-    raise Exception("Not yet implemented")
+    raise NotImplementedError("Not yet implemented")
 
 
 def splat(i, row, col):
-    raise Exception("Not yet implemented")
+    raise NotImplementedError("Not yet implemented")
 
 def is_cuda(i):
     cdef CProjector2D * proj = getObject(i)
@@ -138,8 +138,8 @@ def matrix(i):
     cdef CSparseMatrix * mat = proj.getMatrix()
     if mat == NULL:
         del mat
-        raise Exception("Data object not found")
+        raise AstraError("Data object not found")
     if not mat.isInitialized():
         del mat
-        raise Exception("Data object not initialized properly.")
+        raise AstraError("Data object not initialized properly")
     return manM.store(mat)

--- a/python/astra/pythonutils.py
+++ b/python/astra/pythonutils.py
@@ -71,7 +71,7 @@ def checkArrayForLink(data):
     """
 
     if not isinstance(data, np.ndarray):
-        raise ValueError("Numpy array should be numpy.ndarray")
+        raise ValueError("Data should be numpy.ndarray")
     if data.dtype != np.float32:
         raise ValueError("Numpy array should be float32")
     if not (data.flags['C_CONTIGUOUS'] and data.flags['ALIGNED']):

--- a/python/astra/utils.pyx
+++ b/python/astra/utils.pyx
@@ -251,8 +251,8 @@ cdef CFloat32VolumeData3D* linkVolFromGeometry(CVolumeGeometry3D *pGeometry, dat
     elif isinstance(data, GPULink):
         data_shape = (data.z, data.y, data.x)
     if geom_shape != data_shape:
-        raise ValueError("The dimensions of the data do not match those specified in the geometry: "
-                         "{} (data) != {} (geometry)".format(data_shape, geom_shape))
+        raise ValueError("The dimensions of the data {} do not match those "
+                         "specified in the geometry {}".format(data_shape, geom_shape))
 
     if isinstance(data, np.ndarray):
         checkArrayForLink(data)
@@ -276,8 +276,8 @@ cdef CFloat32ProjectionData3D* linkProjFromGeometry(CProjectionGeometry3D *pGeom
     elif isinstance(data, GPULink):
         data_shape = (data.z, data.y, data.x)
     if geom_shape != data_shape:
-        raise ValueError("The dimensions of the data do not match those specified in the geometry: "
-                         "{} (data) != {} (geometry)".format(data_shape, geom_shape))
+        raise ValueError("The dimensions of the data {} do not match those "
+                         "specified in the geometry {}".format(data_shape, geom_shape))
 
     if isinstance(data, np.ndarray):
         checkArrayForLink(data)

--- a/python/astra/utils.pyx
+++ b/python/astra/utils.pyx
@@ -308,7 +308,7 @@ cdef CProjectionGeometry3D* createProjectionGeometry3D(geometry) except NULL:
     elif (tpe == "cone_vec"):
         pGeometry = <CProjectionGeometry3D*> new CConeVecProjectionGeometry3D();
     else:
-        raise ValueError(tpe + " is an invalid geometry type")
+        raise ValueError("'{}' is not a valid 3D geometry type".format(tpe))
 
     if not pGeometry.initialize(cfg[0]):
         del cfg

--- a/python/astra/utils.pyx
+++ b/python/astra/utils.pyx
@@ -64,10 +64,9 @@ cdef Config * dictToConfig(string rootname, dc) except NULL:
     cfg.initialize(rootname)
     try:
         readDict(cfg.self, dc)
-    except Exception:
+    except:
         del cfg
-        exc = sys.exc_info()
-        raise exc[0], exc[1], exc[2]
+        raise
     return cfg
 
 def convert_item(item):

--- a/python/astra/utils.pyx
+++ b/python/astra/utils.pyx
@@ -46,6 +46,7 @@ from .PyXMLDocument cimport XMLNode
 from .PyIncludes cimport *
 
 from .pythonutils import GPULink, checkArrayForLink
+from .log import AstraError
 
 cdef extern from "CFloat32CustomPython.h":
     cdef cppclass CFloat32CustomPython:
@@ -313,7 +314,7 @@ cdef CProjectionGeometry3D* createProjectionGeometry3D(geometry) except NULL:
     if not pGeometry.initialize(cfg[0]):
         del cfg
         del pGeometry
-        raise RuntimeError('Geometry class not initialized.')
+        raise AstraError('Geometry class could not be initialized', append_log=True)
 
     del cfg
 
@@ -327,7 +328,7 @@ cdef CVolumeGeometry3D* createVolumeGeometry3D(geometry) except NULL:
     if not pGeometry.initialize(cfg[0]):
         del cfg
         del pGeometry
-        raise RuntimeError('Geometry class not initialized.')
+        raise AstraError('Geometry class could not be initialized', append_log=True)
 
     del cfg
 

--- a/python/astra/utils.pyx
+++ b/python/astra/utils.pyx
@@ -122,7 +122,7 @@ cdef bool readDict(XMLNode root, _dc) except False:
             elif val.ndim == 1:
                 listbase.setContent(data, val.shape[0])
             else:
-                raise Exception("Only 1 or 2 dimensions are allowed")
+                raise AstraError("Only 1 or 2 dimensions are allowed")
         elif isinstance(val, dict):
             if item == six.b('option') or item == six.b('options') or item == six.b('Option') or item == six.b('Options'):
                 readOptions(root, val)
@@ -147,7 +147,7 @@ cdef bool readOptions(XMLNode node, dc) except False:
     for item in dc:
         val = dc[item]
         if node.hasOption(item):
-            raise Exception('Duplicate Option: %s' % item)
+            raise AstraError('Duplicate Option: %s' % item)
         if isinstance(val, builtins.list) or isinstance(val, tuple):
             val = np.array(val,dtype=np.float64)
         if isinstance(val, np.ndarray):
@@ -162,7 +162,7 @@ cdef bool readOptions(XMLNode node, dc) except False:
             elif val.ndim == 1:
                 listbase.setContent(data, val.shape[0])
             else:
-                raise Exception("Only 1 or 2 dimensions are allowed")
+                raise AstraError("Only 1 or 2 dimensions are allowed")
         else:
             if isinstance(val, builtins.bool):
                 val = int(val)
@@ -252,8 +252,8 @@ cdef CFloat32VolumeData3D* linkVolFromGeometry(CVolumeGeometry3D *pGeometry, dat
     elif isinstance(data, GPULink):
         data_shape = (data.z, data.y, data.x)
     if geom_shape != data_shape:
-        raise ValueError(
-            "The dimensions of the data do not match those specified in the geometry: {} != {}".format(data_shape, geom_shape))
+        raise ValueError("The dimensions of the data do not match those specified in the geometry: "
+                         "{} (data) != {} (geometry)".format(data_shape, geom_shape))
 
     if isinstance(data, np.ndarray):
         checkArrayForLink(data)
@@ -264,7 +264,7 @@ cdef CFloat32VolumeData3D* linkVolFromGeometry(CVolumeGeometry3D *pGeometry, dat
             hnd = wrapHandle(<float*>PyLong_AsVoidPtr(data.ptr), data.x, data.y, data.z, data.pitch/4)
             pDataObject3D = new CFloat32VolumeData3DGPU(pGeometry, hnd)
         ELSE:
-            raise NotImplementedError("CUDA support is not enabled in ASTRA")
+            raise AstraError("CUDA support is not enabled in ASTRA")
     else:
         raise TypeError("data should be a numpy.ndarray or a GPULink object")
     return pDataObject3D
@@ -277,8 +277,8 @@ cdef CFloat32ProjectionData3D* linkProjFromGeometry(CProjectionGeometry3D *pGeom
     elif isinstance(data, GPULink):
         data_shape = (data.z, data.y, data.x)
     if geom_shape != data_shape:
-        raise ValueError(
-            "The dimensions of the data do not match those specified in the geometry: {} != {}".format(data_shape, geom_shape))
+        raise ValueError("The dimensions of the data do not match those specified in the geometry: "
+                         "{} (data) != {} (geometry)".format(data_shape, geom_shape))
 
     if isinstance(data, np.ndarray):
         checkArrayForLink(data)
@@ -289,7 +289,7 @@ cdef CFloat32ProjectionData3D* linkProjFromGeometry(CProjectionGeometry3D *pGeom
             hnd = wrapHandle(<float*>PyLong_AsVoidPtr(data.ptr), data.x, data.y, data.z, data.pitch/4)
             pDataObject3D = new CFloat32ProjectionData3DGPU(pGeometry, hnd)
         ELSE:
-            raise NotImplementedError("CUDA support is not enabled in ASTRA")
+            raise AstraError("CUDA support is not enabled in ASTRA")
     else:
         raise TypeError("data should be a numpy.ndarray or a GPULink object")
     return pDataObject3D
@@ -309,7 +309,7 @@ cdef CProjectionGeometry3D* createProjectionGeometry3D(geometry) except NULL:
     elif (tpe == "cone_vec"):
         pGeometry = <CProjectionGeometry3D*> new CConeVecProjectionGeometry3D();
     else:
-        raise ValueError("Invalid geometry type.")
+        raise ValueError(tpe + " is an invalid geometry type")
 
     if not pGeometry.initialize(cfg[0]):
         del cfg

--- a/src/ArtAlgorithm.cpp
+++ b/src/ArtAlgorithm.cpp
@@ -29,6 +29,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/AstraObjectManager.h"
 
+#include "astra/Logging.h"
+
 using namespace std;
 
 namespace astra {

--- a/src/BackProjectionAlgorithm.cpp
+++ b/src/BackProjectionAlgorithm.cpp
@@ -30,6 +30,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 #include "astra/AstraObjectManager.h"
 #include "astra/DataProjectorPolicies.h"
 
+#include "astra/Logging.h"
+
 using namespace std;
 
 namespace astra {

--- a/src/CglsAlgorithm.cpp
+++ b/src/CglsAlgorithm.cpp
@@ -29,6 +29,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/AstraObjectManager.h"
 
+#include "astra/Logging.h"
+
 using namespace std;
 
 namespace astra {

--- a/src/CompositeGeometryManager.cpp
+++ b/src/CompositeGeometryManager.cpp
@@ -1413,6 +1413,7 @@ static bool doJob(const CCompositeGeometryManager::TJobSet::const_iterator& iter
 	CFloat32CustomGPUMemory *dstMem = createGPUMemoryHandler(output->pData);
 
 	bool ok = dstMem->allocateGPUMemory(outx, outy, outz, zero ? astraCUDA3d::INIT_ZERO : astraCUDA3d::INIT_NO);
+	// TODO: cleanup and return error code after any error
 	if (!ok) ASTRA_ERROR("Error allocating GPU memory");
 
 	if (!zero) {

--- a/src/ConeVecProjectionGeometry3D.cpp
+++ b/src/ConeVecProjectionGeometry3D.cpp
@@ -27,6 +27,7 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/ConeVecProjectionGeometry3D.h"
 #include "astra/Utilities.h"
+#include "astra/Logging.h"
 
 #include <cstring>
 

--- a/src/CudaDartMaskAlgorithm.cpp
+++ b/src/CudaDartMaskAlgorithm.cpp
@@ -35,6 +35,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/AstraObjectManager.h"
 
+#include "astra/Logging.h"
+
 using namespace std;
 
 namespace astra {

--- a/src/CudaDartMaskAlgorithm3D.cpp
+++ b/src/CudaDartMaskAlgorithm3D.cpp
@@ -34,6 +34,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/AstraObjectManager.h"
 
+#include "astra/Logging.h"
+
 using namespace std;
 
 namespace astra {

--- a/src/CudaDartSmoothingAlgorithm.cpp
+++ b/src/CudaDartSmoothingAlgorithm.cpp
@@ -35,6 +35,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/AstraObjectManager.h"
 
+#include "astra/Logging.h"
+
 using namespace std;
 
 namespace astra {

--- a/src/CudaDartSmoothingAlgorithm3D.cpp
+++ b/src/CudaDartSmoothingAlgorithm3D.cpp
@@ -34,6 +34,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/AstraObjectManager.h"
 
+#include "astra/Logging.h"
+
 using namespace std;
 
 namespace astra {

--- a/src/CudaDataOperationAlgorithm.cpp
+++ b/src/CudaDataOperationAlgorithm.cpp
@@ -36,6 +36,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/AstraObjectManager.h"
 
+#include "astra/Logging.h"
+
 #include <algorithm>
 
 using namespace std;

--- a/src/CudaForwardProjectionAlgorithm3D.cpp
+++ b/src/CudaForwardProjectionAlgorithm3D.cpp
@@ -118,8 +118,7 @@ bool CCudaForwardProjectionAlgorithm3D::initialize(const Config& _cfg)
 		id = StringUtil::stringToInt(node.getContent(), -1);
 		m_pProjector = CProjector3DManager::getSingleton().get(id);
 		if (!m_pProjector) {
-			// Report this explicitly since projector is optional
-			ASTRA_ERROR("ProjectorId is not a valid id");
+			ASTRA_WARN("Optional parameter ProjectorId is not a valid id");
 		}
 	}
 	CC.markNodeParsed("ProjectorId");

--- a/src/CudaProjector2D.cpp
+++ b/src/CudaProjector2D.cpp
@@ -27,6 +27,7 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/CudaProjector2D.h"
 
+#include "astra/Logging.h"
 
 namespace astra
 {

--- a/src/CudaProjector3D.cpp
+++ b/src/CudaProjector3D.cpp
@@ -33,6 +33,7 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 #include "astra/ConeProjectionGeometry3D.h"
 #include "astra/ConeVecProjectionGeometry3D.h"
 
+#include "astra/Logging.h"
 
 namespace astra
 {

--- a/src/CudaRoiSelectAlgorithm.cpp
+++ b/src/CudaRoiSelectAlgorithm.cpp
@@ -35,6 +35,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/AstraObjectManager.h"
 
+#include "astra/Logging.h"
+
 using namespace std;
 
 namespace astra {

--- a/src/FanFlatBeamLineKernelProjector2D.cpp
+++ b/src/FanFlatBeamLineKernelProjector2D.cpp
@@ -33,6 +33,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/DataProjectorPolicies.h"
 
+#include "astra/Logging.h"
+
 using namespace std;
 using namespace astra;
 

--- a/src/FanFlatBeamStripKernelProjector2D.cpp
+++ b/src/FanFlatBeamStripKernelProjector2D.cpp
@@ -32,6 +32,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/DataProjectorPolicies.h"
 
+#include "astra/Logging.h"
+
 using namespace std;
 using namespace astra;
 

--- a/src/FanFlatProjectionGeometry2D.cpp
+++ b/src/FanFlatProjectionGeometry2D.cpp
@@ -29,6 +29,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/GeometryUtil2D.h"
 
+#include "astra/Logging.h"
+
 #include <cstring>
 #include <sstream>
 

--- a/src/FanFlatVecProjectionGeometry2D.cpp
+++ b/src/FanFlatVecProjectionGeometry2D.cpp
@@ -27,6 +27,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/FanFlatVecProjectionGeometry2D.h"
 
+#include "astra/Logging.h"
+
 #include <cstring>
 #include <sstream>
 

--- a/src/Filters.cpp
+++ b/src/Filters.cpp
@@ -405,6 +405,7 @@ float *genFilter(const SFilterConfig &_cfg,
 		default:
 		{
 			ASTRA_ERROR("Cannot serve requested filter");
+			return NULL;
 		}
 	}
 
@@ -524,6 +525,8 @@ SFilterConfig getFilterConfigForAlgorithm(const Config& _cfg, CAlgorithm *_alg)
 			}
 		} catch (const astra::StringUtil::bad_cast &e) {
 			ASTRA_ERROR("%s is not a valid id", nodeName);
+			c.m_eType = FILTER_ERROR;
+			return c;
 		}
 		break;
 	default:
@@ -562,6 +565,8 @@ SFilterConfig getFilterConfigForAlgorithm(const Config& _cfg, CAlgorithm *_alg)
 			}
 		} catch (const astra::StringUtil::bad_cast &e) {
 			ASTRA_ERROR("%s must be numerical", nodeName);
+			c.m_eType = FILTER_ERROR;
+			return c;
 		}
 		break;
 	default:
@@ -592,6 +597,8 @@ SFilterConfig getFilterConfigForAlgorithm(const Config& _cfg, CAlgorithm *_alg)
 			}
 		} catch (const astra::StringUtil::bad_cast &e) {
 			ASTRA_ERROR("%s must be numerical", nodeName);
+			c.m_eType = FILTER_ERROR;
+			return c;
 		}
 		break;
 	}

--- a/src/ForwardProjectionAlgorithm.cpp
+++ b/src/ForwardProjectionAlgorithm.cpp
@@ -30,6 +30,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 #include "astra/AstraObjectManager.h"
 #include "astra/DataProjectorPolicies.h"
 
+#include "astra/Logging.h"
+
 using namespace std;
 
 namespace astra {

--- a/src/Logging.cpp
+++ b/src/Logging.cpp
@@ -128,6 +128,7 @@ void CLogger::error(const char *sfile, int sline, const char *fmt, ...)
         clog_error(sfile,sline,1,fmt,apf);
         va_end(apf);
     }
+	_setLastErrMsg(sfile,sline,fmt,ap);
 }
 
 void CLogger::_setLevel(int id, log_level m_eLevel)
@@ -182,6 +183,22 @@ void CLogger::_assureIsInitialized()
 	}
 }
 
+void CLogger::_setLastErrMsg(const char *sfile, int sline, const char *fmt, va_list ap)
+{
+	va_list ap_copy;
+	va_copy(ap_copy, ap);
+	char buf[1024];
+	vsprintf(buf, fmt, ap_copy);
+	m_sLastErrMsg.assign(buf);
+}
+
+std::string CLogger::getLastErrMsg()
+{
+	std::string err_msg = m_sLastErrMsg;
+	m_sLastErrMsg.clear();
+	return err_msg;
+}
+
 void CLogger::setFormatFile(const char *fmt)
 {
 	if(m_bFileProvided){
@@ -209,3 +226,4 @@ bool CLogger::m_bEnabledScreen = true;
 bool CLogger::m_bEnabledFile = true;
 bool CLogger::m_bFileProvided = false;
 bool CLogger::m_bInitialized = false;
+std::string CLogger::m_sLastErrMsg;

--- a/src/ParallelBeamBlobKernelProjector2D.cpp
+++ b/src/ParallelBeamBlobKernelProjector2D.cpp
@@ -32,6 +32,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/DataProjectorPolicies.h"
 
+#include "astra/Logging.h"
+
 using namespace std;
 using namespace astra;
 

--- a/src/ParallelBeamDistanceDrivenProjector2D.cpp
+++ b/src/ParallelBeamDistanceDrivenProjector2D.cpp
@@ -32,6 +32,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/DataProjectorPolicies.h"
 
+#include "astra/Logging.h"
+
 namespace astra {
 
 #include "astra/ParallelBeamDistanceDrivenProjector2D.inl"

--- a/src/ParallelBeamLineKernelProjector2D.cpp
+++ b/src/ParallelBeamLineKernelProjector2D.cpp
@@ -32,6 +32,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/DataProjectorPolicies.h"
 
+#include "astra/Logging.h"
+
 using namespace std;
 using namespace astra;
 

--- a/src/ParallelBeamLinearKernelProjector2D.cpp
+++ b/src/ParallelBeamLinearKernelProjector2D.cpp
@@ -32,6 +32,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/DataProjectorPolicies.h"
 
+#include "astra/Logging.h"
+
 using namespace std;
 using namespace astra;
 

--- a/src/ParallelBeamStripKernelProjector2D.cpp
+++ b/src/ParallelBeamStripKernelProjector2D.cpp
@@ -32,6 +32,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/DataProjectorPolicies.h"
 
+#include "astra/Logging.h"
+
 using namespace std;
 using namespace astra;
 

--- a/src/ParallelVecProjectionGeometry2D.cpp
+++ b/src/ParallelVecProjectionGeometry2D.cpp
@@ -27,6 +27,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/ParallelVecProjectionGeometry2D.h"
 
+#include "astra/Logging.h"
+
 #include <cstring>
 #include <sstream>
 

--- a/src/ParallelVecProjectionGeometry3D.cpp
+++ b/src/ParallelVecProjectionGeometry3D.cpp
@@ -27,6 +27,7 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/ParallelVecProjectionGeometry3D.h"
 #include "astra/Utilities.h"
+#include "astra/Logging.h"
 
 #include <cstring>
 

--- a/src/ProjectionGeometry2D.cpp
+++ b/src/ProjectionGeometry2D.cpp
@@ -26,6 +26,7 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "astra/ProjectionGeometry2D.h"
+#include "astra/Logging.h"
 
 using namespace std;
 

--- a/src/ProjectionGeometry3D.cpp
+++ b/src/ProjectionGeometry3D.cpp
@@ -26,6 +26,7 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "astra/ProjectionGeometry3D.h"
+#include "astra/Logging.h"
 
 using namespace std;
 

--- a/src/Projector2D.cpp
+++ b/src/Projector2D.cpp
@@ -33,6 +33,7 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 #include "astra/SparseMatrixProjectionGeometry2D.h"
 #include "astra/SparseMatrix.h"
 
+#include "astra/Logging.h"
 
 namespace astra
 {

--- a/src/Projector3D.cpp
+++ b/src/Projector3D.cpp
@@ -33,6 +33,7 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 #include "astra/ConeProjectionGeometry3D.h"
 #include "astra/ConeVecProjectionGeometry3D.h"
 
+#include "astra/Logging.h"
 
 namespace astra
 {

--- a/src/ReconstructionAlgorithm2D.cpp
+++ b/src/ReconstructionAlgorithm2D.cpp
@@ -92,8 +92,8 @@ bool CReconstructionAlgorithm2D::initialize(const Config& _cfg)
 		id = StringUtil::stringToInt(node.getContent(), -1);
 		m_pProjector = CProjector2DManager::getSingleton().get(id);
 		if (!m_pProjector) {
-			// Report this explicitly since projector is optional
 			ASTRA_ERROR("ProjectorId is not a valid id");
+			return false;
 		}
 	}
 	CC.markNodeParsed("ProjectorId");
@@ -138,6 +138,7 @@ bool CReconstructionAlgorithm2D::initialize(const Config& _cfg)
 		} catch (const astra::StringUtil::bad_cast &e) {
 			m_fMinValue = 0.0f;
 			ASTRA_ERROR("MinConstraint must be numerical");
+			return false;
 		}
 		CC.markOptionParsed("MinConstraint");
 	} else {
@@ -150,6 +151,7 @@ bool CReconstructionAlgorithm2D::initialize(const Config& _cfg)
 			} catch (const astra::StringUtil::bad_cast &e) {
 				m_fMinValue = 0.0f;
 				ASTRA_ERROR("MinConstraintValue must be numerical");
+				return false;
 			}
 			CC.markOptionParsed("MinConstraintValue");
 		}
@@ -161,6 +163,7 @@ bool CReconstructionAlgorithm2D::initialize(const Config& _cfg)
 		} catch (const astra::StringUtil::bad_cast &e) {
 			m_fMinValue = 255.0f;
 			ASTRA_ERROR("MaxConstraint must be numerical");
+			return false;
 		}
 		CC.markOptionParsed("MaxConstraint");
 	} else {
@@ -173,6 +176,7 @@ bool CReconstructionAlgorithm2D::initialize(const Config& _cfg)
 			} catch (const astra::StringUtil::bad_cast &e) {
 				m_fMaxValue = 255.0f;
 				ASTRA_ERROR("MaxConstraintValue must be numerical");
+				return false;
 			}
 			CC.markOptionParsed("MaxConstraintValue");
 		}

--- a/src/ReconstructionAlgorithm3D.cpp
+++ b/src/ReconstructionAlgorithm3D.cpp
@@ -157,6 +157,7 @@ bool CReconstructionAlgorithm3D::initialize(const Config& _cfg)
 		} catch (const astra::StringUtil::bad_cast &e) {
 			m_fMinValue = 0.0f;
 			ASTRA_ERROR("MinConstraint must be numerical");
+			return false;
 		}
 		CC.markOptionParsed("MinConstraint");
 	} else {
@@ -169,6 +170,7 @@ bool CReconstructionAlgorithm3D::initialize(const Config& _cfg)
 			} catch (const astra::StringUtil::bad_cast &e) {
 				m_fMinValue = 0.0f;
 				ASTRA_ERROR("MinConstraintValue must be numerical");
+				return false;
 			}
 			CC.markOptionParsed("MinConstraintValue");
 		}
@@ -180,6 +182,7 @@ bool CReconstructionAlgorithm3D::initialize(const Config& _cfg)
 		} catch (const astra::StringUtil::bad_cast &e) {
 			m_fMinValue = 255.0f;
 			ASTRA_ERROR("MaxConstraint must be numerical");
+			return false;
 		}
 		CC.markOptionParsed("MaxConstraint");
 	} else {
@@ -192,6 +195,7 @@ bool CReconstructionAlgorithm3D::initialize(const Config& _cfg)
 			} catch (const astra::StringUtil::bad_cast &e) {
 				m_fMaxValue = 255.0f;
 				ASTRA_ERROR("MaxConstraintValue must be numerical");
+				return false;
 			}
 			CC.markOptionParsed("MaxConstraintValue");
 		}

--- a/src/ReconstructionAlgorithm3D.cpp
+++ b/src/ReconstructionAlgorithm3D.cpp
@@ -112,8 +112,7 @@ bool CReconstructionAlgorithm3D::initialize(const Config& _cfg)
 		id = StringUtil::stringToInt(node.getContent(), -1);
 		m_pProjector = CProjector3DManager::getSingleton().get(id);
 		if (!m_pProjector) {
-			// Report this explicitly since projector is optional
-			ASTRA_ERROR("ProjectorId is not a valid id");
+			ASTRA_WARN("Optional parameter ProjectorId is not a valid id");
 		}
 	}
 	CC.markNodeParsed("ProjectorId");

--- a/src/SartAlgorithm.cpp
+++ b/src/SartAlgorithm.cpp
@@ -30,6 +30,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 #include "astra/AstraObjectManager.h"
 #include "astra/DataProjectorPolicies.h"
 
+#include "astra/Logging.h"
+
 using namespace std;
 
 namespace astra {

--- a/src/SirtAlgorithm.cpp
+++ b/src/SirtAlgorithm.cpp
@@ -30,6 +30,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 #include "astra/AstraObjectManager.h"
 #include "astra/DataProjectorPolicies.h"
 
+#include "astra/Logging.h"
+
 using namespace std;
 
 namespace astra {

--- a/src/SparseMatrixProjectionGeometry2D.cpp
+++ b/src/SparseMatrixProjectionGeometry2D.cpp
@@ -29,6 +29,7 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/AstraObjectManager.h"
 
+#include "astra/Logging.h"
 
 using namespace std;
 

--- a/src/SparseMatrixProjector2D.cpp
+++ b/src/SparseMatrixProjector2D.cpp
@@ -31,6 +31,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/DataProjectorPolicies.h"
 
+#include "astra/Logging.h"
+
 using namespace std;
 using namespace astra;
 

--- a/src/VolumeGeometry2D.cpp
+++ b/src/VolumeGeometry2D.cpp
@@ -27,6 +27,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/VolumeGeometry2D.h"
 
+#include "astra/Logging.h"
+
 #include <cmath>
 
 namespace astra

--- a/src/VolumeGeometry3D.cpp
+++ b/src/VolumeGeometry3D.cpp
@@ -26,6 +26,7 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "astra/VolumeGeometry3D.h"
+#include "astra/Logging.h"
 
 namespace astra
 {


### PR DESCRIPTION
Specifically, attempt to achieve the following:

1. Make error messages originating in the shared lib appear more obviously in Python and Matlab.

The solution I chose is to store the last error message in `CLogger` object and append it to the high level Python/Matlab exception when raised. It's not ideal because only the last message is stored, and it's difficult to guarantee that every error in the shared library with be propagated to Python/Matlab interface. Therefore, all error messages are still printed to `stdout` as a backup.

2. Improve informativeness and style of error messages.