### PR TITLE
Fix python prefix in installation

### DIFF
--- a/build/linux/Makefile.in
+++ b/build/linux/Makefile.in
@@ -503,7 +503,7 @@ install-python-site-packages: py
 	set_dist_dir --dist-dir=$(abs_top_builddir)/python/dist \
 	build $(PYBUILDER_BUILD_FLAGS) \
 	egg_info --egg-base=$(abs_top_builddir)/python \
-	install
+	install --prefix=$(prefix)
 else
 install-python-site-packages:
 install-python:


### PR DESCRIPTION
Dear astra-Team,

I tried to install the astra-toolbox on Linux, when I ran into the issue that the python part of astra does not honor the selected `--prefix` when running `make install`:

Steps to reproduce:
- Download Astra version 2.1.0 (or current git master)
- Follow the instructions in the README, just without cuda and with a custom prefix:
```
cd build/linux
./autogen.sh
./configure --prefix=<chosen prefix> \
            --with-python \
            --with-install-type=module
make
make install
```
- The generated Makefile will run the target `install-python-site-packages`
- That target will try to write to the default python prefix (`/usr/lib/python3.11/site-packages/` on my system) instead of somewhere below the chosen prefix

This is an issue since I wanted to try to create a package for the astra toolbox, and therefore need it to only install files into the packaging-directory, instead of the root filesystem.

(In case you are curious about that package, see here: https://aur.archlinux.org/packages/python-astra-toolbox )

This small change fixes that particular issue (on v2.1.0, it is basically the same: add `--prefix=$(prefix)` to the call of builder.py)


Version tested: v2.1.0 and current git master (2935d56b78b51b792a3584a28365df3a783ea277)


All the best,
Christian