### PR TITLE
Update CFloat32CustomPython.h

### DIFF
--- a/python/astra/CFloat32CustomPython.h
+++ b/python/astra/CFloat32CustomPython.h
@@ -4,7 +4,7 @@ public:
     {
         arr = arrIn;
         // Set pointer to numpy data pointer
-        m_fPtr = (float *)PyArray_DATA(arr);
+        m_fPtr = (float *)PyArray_DATA((PyArrayObject*)arr);
         // Increase reference count since ASTRA has a reference
         Py_INCREF(arr);
     }


### PR DESCRIPTION
This is required in order to compile on Ubuntu 24.04.

Otherwise results in the following error:

astra-toolbox/build/linux/python/cython/./astra/CFloat32CustomPython.h:7:40: error: cannot convert ‘PyObject*’ {aka ‘_object*’} to ‘const PyArrayObject*’ {aka ‘const tagPyArrayObject_fields*’}