### PR TITLE
Improve CUDA stream handling

### DIFF
--- a/cuda/2d/arith.cu
+++ b/cuda/2d/arith.cu
@@ -288,152 +288,223 @@ __global__ void devDDFtoD(float* pfOut, const float* pfIn1, const float* pfIn2, 
 
 
 template<typename op>
-void processVolCopy(float* out, const SDimensions& dims)
+bool processVolCopy(float* out, const SDimensions& dims)
 {
 	float* D_out;
 	size_t width = dims.iVolWidth;
-
 	unsigned int pitch;
-	allocateVolumeData(D_out, pitch, dims);
-	copyVolumeToDevice(out, width, dims, D_out, pitch);
 
-	processVol<op>(D_out, pitch, dims);
+	bool ok = true;
 
-	copyVolumeFromDevice(out, width, dims, D_out, pitch);
+	ok &= allocateVolumeData(D_out, pitch, dims);
+	if (!ok)
+		return false;
+	ok &= copyVolumeToDevice(out, width, dims, D_out, pitch);
+
+	ok &= processVol<op>(D_out, pitch, dims);
+
+	ok &= copyVolumeFromDevice(out, width, dims, D_out, pitch);
 
 	cudaFree(D_out);
+	return ok;
 }
 
 template<typename op>
-void processVolCopy(float* out, float param, const SDimensions& dims)
+bool processVolCopy(float* out, float param, const SDimensions& dims)
 {
 	float* D_out;
 	size_t width = dims.iVolWidth;
-
 	unsigned int pitch;
-	allocateVolumeData(D_out, pitch, dims);
-	copyVolumeToDevice(out, width, dims, D_out, pitch);
 
-	processVol<op>(D_out, param, pitch, dims);
+	bool ok = true;
 
-	copyVolumeFromDevice(out, width, dims, D_out, pitch);
+	ok &= allocateVolumeData(D_out, pitch, dims);
+	if (!ok)
+		return false;
+
+	ok &= copyVolumeToDevice(out, width, dims, D_out, pitch);
+
+	ok &= processVol<op>(D_out, param, pitch, dims);
+
+	ok &= copyVolumeFromDevice(out, width, dims, D_out, pitch);
 
 	cudaFree(D_out);
+	return ok;
 }
 
 template<typename op>
-void processVolCopy(float* out1, float* out2, float param1, float param2, const SDimensions& dims)
+bool processVolCopy(float* out1, float* out2, float param1, float param2, const SDimensions& dims)
 {
 	float* D_out1;
 	float* D_out2;
 	size_t width = dims.iVolWidth;
-
 	unsigned int pitch;
-	allocateVolumeData(D_out1, pitch, dims);
-	copyVolumeToDevice(out1, width, dims, D_out1, pitch);
-	allocateVolumeData(D_out2, pitch, dims);
-	copyVolumeToDevice(out2, width, dims, D_out2, pitch);
 
-	processVol<op>(D_out1, D_out2, param1, param2, pitch, dims);
+	bool ok = true;
 
-	copyVolumeFromDevice(out1, width, dims, D_out1, pitch);
-	copyVolumeFromDevice(out2, width, dims, D_out2, pitch);
+	ok &= allocateVolumeData(D_out1, pitch, dims);
+	if (!ok)
+		return false;
+	ok &= allocateVolumeData(D_out2, pitch, dims);
+	if (!ok) {
+		cudaFree(D_out1);
+		return false;
+	}
+
+	ok &= copyVolumeToDevice(out1, width, dims, D_out1, pitch);
+	ok &= copyVolumeToDevice(out2, width, dims, D_out2, pitch);
+
+	ok &= processVol<op>(D_out1, D_out2, param1, param2, pitch, dims);
+
+	ok &= copyVolumeFromDevice(out1, width, dims, D_out1, pitch);
+	ok &= copyVolumeFromDevice(out2, width, dims, D_out2, pitch);
 
 	cudaFree(D_out1);
 	cudaFree(D_out2);
+	return ok;
 }
 
 
 template<typename op>
-void processVolCopy(float* out, const float* in, const SDimensions& dims)
+bool processVolCopy(float* out, const float* in, const SDimensions& dims)
 {
 	float* D_out;
 	float* D_in;
 	size_t width = dims.iVolWidth;
-
 	unsigned int pitch;
-	allocateVolumeData(D_out, pitch, dims);
-	copyVolumeToDevice(out, width, dims, D_out, pitch);
-	allocateVolumeData(D_in, pitch, dims);
-	copyVolumeToDevice(in, width, dims, D_in, pitch);
 
-	processVol<op>(D_out, D_in, pitch, dims);
+	bool ok = true;
 
-	copyVolumeFromDevice(out, width, dims, D_out, pitch);
+	ok &= allocateVolumeData(D_out, pitch, dims);
+	if (!ok)
+		return false;
+	ok &= allocateVolumeData(D_in, pitch, dims);
+	if (!ok) {
+		cudaFree(D_out);
+		return false;
+	}
+
+	ok &= copyVolumeToDevice(out, width, dims, D_out, pitch);
+	ok &= copyVolumeToDevice(in, width, dims, D_in, pitch);
+
+	ok &= processVol<op>(D_out, D_in, pitch, dims);
+
+	ok &= copyVolumeFromDevice(out, width, dims, D_out, pitch);
 
 	cudaFree(D_out);
 	cudaFree(D_in);
+	return ok;
 }
 
 template<typename op>
-void processVolCopy(float* out, const float* in, float param, const SDimensions& dims)
+bool processVolCopy(float* out, const float* in, float param, const SDimensions& dims)
 {
 	float* D_out;
 	float* D_in;
 	size_t width = dims.iVolWidth;
-
 	unsigned int pitch;
-	allocateVolumeData(D_out, pitch, dims);
-	copyVolumeToDevice(out, width, dims, D_out, pitch);
-	allocateVolumeData(D_in, pitch, dims);
-	copyVolumeToDevice(in, width, dims, D_in, pitch);
 
-	processVol<op>(D_out, D_in, param, pitch, dims);
+	bool ok = true;
 
-	copyVolumeFromDevice(out, width, dims, D_out, pitch);
+	ok &= allocateVolumeData(D_out, pitch, dims);
+	if (!ok)
+		return false;
+	ok &= allocateVolumeData(D_in, pitch, dims);
+	if (!ok) {
+		cudaFree(D_out);
+		return false;
+	}
+
+	ok &= copyVolumeToDevice(out, width, dims, D_out, pitch);
+	ok &= copyVolumeToDevice(in, width, dims, D_in, pitch);
+
+	ok &= processVol<op>(D_out, D_in, param, pitch, dims);
+
+	ok &= copyVolumeFromDevice(out, width, dims, D_out, pitch);
 
 	cudaFree(D_out);
 	cudaFree(D_in);
+	return ok;
 }
 
 template<typename op>
-void processVolCopy(float* out, const float* in1, const float* in2, const SDimensions& dims)
+bool processVolCopy(float* out, const float* in1, const float* in2, const SDimensions& dims)
 {
 	float* D_out;
 	float* D_in1;
 	float* D_in2;
 	size_t width = dims.iVolWidth;
-
 	unsigned int pitch;
-	allocateVolumeData(D_out, pitch, dims);
-	copyVolumeToDevice(out, width, dims, D_out, pitch);
-	allocateVolumeData(D_in1, pitch, dims);
-	copyVolumeToDevice(in1, width, dims, D_in1, pitch);
-	allocateVolumeData(D_in2, pitch, dims);
-	copyVolumeToDevice(in2, width, dims, D_in2, pitch);
 
-	processVol<op>(D_out, D_in1, D_in2, pitch, dims);
+	bool ok = true;
 
-	copyVolumeFromDevice(out, width, dims, D_out, pitch);
+	ok &= allocateVolumeData(D_out, pitch, dims);
+	if (!ok)
+		return false;
+	ok &= allocateVolumeData(D_in1, pitch, dims);
+	if (!ok) {
+		cudaFree(D_out);
+		return false;
+	}
+	ok &= allocateVolumeData(D_in2, pitch, dims);
+	if (!ok) {
+		cudaFree(D_out);
+		cudaFree(D_in1);
+		return false;
+	}
+
+	ok &= copyVolumeToDevice(out, width, dims, D_out, pitch);
+	ok &= copyVolumeToDevice(in1, width, dims, D_in1, pitch);
+	ok &= copyVolumeToDevice(in2, width, dims, D_in2, pitch);
+
+	ok &= processVol<op>(D_out, D_in1, D_in2, pitch, dims);
+
+	ok &= copyVolumeFromDevice(out, width, dims, D_out, pitch);
 
 	cudaFree(D_out);
 	cudaFree(D_in1);
 	cudaFree(D_in2);
+	return ok;
 }
 
 template<typename op>
-void processVolCopy(float* out, const float* in1, const float* in2, float param, const SDimensions& dims)
+bool processVolCopy(float* out, const float* in1, const float* in2, float param, const SDimensions& dims)
 {
 	float* D_out;
 	float* D_in1;
 	float* D_in2;
 	size_t width = dims.iVolWidth;
-
 	unsigned int pitch;
-	allocateVolumeData(D_out, pitch, dims);
-	copyVolumeToDevice(out, width, dims, D_out, pitch);
-	allocateVolumeData(D_in1, pitch, dims);
-	copyVolumeToDevice(in1, width, dims, D_in1, pitch);
-	allocateVolumeData(D_in2, pitch, dims);
-	copyVolumeToDevice(in2, width, dims, D_in2, pitch);
 
-	processVol<op>(D_out, D_in1, D_in2, param, pitch, dims);
+	bool ok = true;
 
-	copyVolumeFromDevice(out, width, dims, D_out, pitch);
+	ok &= allocateVolumeData(D_out, pitch, dims);
+	if (!ok)
+		return false;
+	ok &= allocateVolumeData(D_in1, pitch, dims);
+	if (!ok) {
+		cudaFree(D_out);
+		return false;
+	}
+	ok &= allocateVolumeData(D_in2, pitch, dims);
+	if (!ok) {
+		cudaFree(D_out);
+		cudaFree(D_in1);
+		return false;
+	}
+
+	ok &= copyVolumeToDevice(out, width, dims, D_out, pitch);
+	ok &= copyVolumeToDevice(in1, width, dims, D_in1, pitch);
+	ok &= copyVolumeToDevice(in2, width, dims, D_in2, pitch);
+
+	ok &= processVol<op>(D_out, D_in1, D_in2, param, pitch, dims);
+
+	ok &= copyVolumeFromDevice(out, width, dims, D_out, pitch);
 
 	cudaFree(D_out);
 	cudaFree(D_in1);
 	cudaFree(D_in2);
+	return ok;
 }
 
 
@@ -444,81 +515,109 @@ void processVolCopy(float* out, const float* in1, const float* in2, float param,
 
 
 template<typename op>
-void processData(float* pfOut, unsigned int pitch, unsigned int width, unsigned int height)
+bool processData(float* pfOut, unsigned int pitch, unsigned int width, unsigned int height, std::optional<cudaStream_t> _stream)
 {
+	StreamHelper stream(_stream);
+	if (!stream)
+		return false;
+
 	dim3 blockSize(16,16);
 	dim3 gridSize((width+15)/16, (height+511)/512);
 
-	devtoD<op, 32><<<gridSize, blockSize>>>(pfOut, pitch, width, height);
+	devtoD<op, 32><<<gridSize, blockSize, 0, stream()>>>(pfOut, pitch, width, height);
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	return stream.syncIfSync(__FUNCTION__);
 }
 
 template<typename op>
-void processData(float* pfOut, float fParam, unsigned int pitch, unsigned int width, unsigned int height)
+bool processData(float* pfOut, float fParam, unsigned int pitch, unsigned int width, unsigned int height, std::optional<cudaStream_t> _stream)
 {
+	StreamHelper stream(_stream);
+	if (!stream)
+		return false;
+
 	dim3 blockSize(16,16);
 	dim3 gridSize((width+15)/16, (height+15)/16);
 
-	devFtoD<op, 32><<<gridSize, blockSize>>>(pfOut, fParam, pitch, width, height);
+	devFtoD<op, 32><<<gridSize, blockSize, 0, stream()>>>(pfOut, fParam, pitch, width, height);
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	return stream.syncIfSync(__FUNCTION__);
 }
 
 template<typename op>
-void processData(float* pfOut1, float* pfOut2, float fParam1, float fParam2, unsigned int pitch, unsigned int width, unsigned int height)
+bool processData(float* pfOut1, float* pfOut2, float fParam1, float fParam2, unsigned int pitch, unsigned int width, unsigned int height, std::optional<cudaStream_t> _stream)
 {
+	StreamHelper stream(_stream);
+	if (!stream)
+		return false;
+
 	dim3 blockSize(16,16);
 	dim3 gridSize((width+15)/16, (height+15)/16);
 
-	devFFtoDD<op, 32><<<gridSize, blockSize>>>(pfOut1, pfOut2, fParam1, fParam2, pitch, width, height);
+	devFFtoDD<op, 32><<<gridSize, blockSize, 0, stream()>>>(pfOut1, pfOut2, fParam1, fParam2, pitch, width, height);
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	return stream.syncIfSync(__FUNCTION__);
 }
 
 
 template<typename op>
-void processData(float* pfOut, const float* pfIn, unsigned int pitch, unsigned int width, unsigned int height)
+bool processData(float* pfOut, const float* pfIn, unsigned int pitch, unsigned int width, unsigned int height, std::optional<cudaStream_t> _stream)
 {
+	StreamHelper stream(_stream);
+	if (!stream)
+		return false;
+
 	dim3 blockSize(16,16);
 	dim3 gridSize((width+15)/16, (height+15)/16);
 
-	devDtoD<op, 32><<<gridSize, blockSize>>>(pfOut, pfIn, pitch, width, height);
+	devDtoD<op, 32><<<gridSize, blockSize, 0, stream()>>>(pfOut, pfIn, pitch, width, height);
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	return stream.syncIfSync(__FUNCTION__);
 }
 
 template<typename op>
-void processData(float* pfOut, const float* pfIn, float fParam, unsigned int pitch, unsigned int width, unsigned int height)
+bool processData(float* pfOut, const float* pfIn, float fParam, unsigned int pitch, unsigned int width, unsigned int height, std::optional<cudaStream_t> _stream)
 {
+	StreamHelper stream(_stream);
+	if (!stream)
+		return false;
+
 	dim3 blockSize(16,16);
 	dim3 gridSize((width+15)/16, (height+15)/16);
 
-	devDFtoD<op, 32><<<gridSize, blockSize>>>(pfOut, pfIn, fParam, pitch, width, height);
+	devDFtoD<op, 32><<<gridSize, blockSize, 0, stream()>>>(pfOut, pfIn, fParam, pitch, width, height);
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	return stream.syncIfSync(__FUNCTION__);
 }
 
 template<typename op>
-void processData(float* pfOut, const float* pfIn1, const float* pfIn2, float fParam, unsigned int pitch, unsigned int width, unsigned int height)
+bool processData(float* pfOut, const float* pfIn1, const float* pfIn2, float fParam, unsigned int pitch, unsigned int width, unsigned int height, std::optional<cudaStream_t> _stream)
 {
+	StreamHelper stream(_stream);
+	if (!stream)
+		return false;
+
 	dim3 blockSize(16,16);
 	dim3 gridSize((width+15)/16, (height+15)/16);
 
-	devDDFtoD<op, 32><<<gridSize, blockSize>>>(pfOut, pfIn1, pfIn2, fParam, pitch, width, height);
+	devDDFtoD<op, 32><<<gridSize, blockSize, 0, stream()>>>(pfOut, pfIn1, pfIn2, fParam, pitch, width, height);
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	return stream.syncIfSync(__FUNCTION__);
 }
 
 template<typename op>
-void processData(float* pfOut, const float* pfIn1, const float* pfIn2, unsigned int pitch, unsigned int width, unsigned int height)
+bool processData(float* pfOut, const float* pfIn1, const float* pfIn2, unsigned int pitch, unsigned int width, unsigned int height, std::optional<cudaStream_t> _stream)
 {
+	StreamHelper stream(_stream);
+	if (!stream)
+		return false;
+
 	dim3 blockSize(16,16);
 	dim3 gridSize((width+15)/16, (height+15)/16);
 
-	devDDtoD<op, 32><<<gridSize, blockSize>>>(pfOut, pfIn1, pfIn2, pitch, width, height);
+	devDDtoD<op, 32><<<gridSize, blockSize, 0, stream()>>>(pfOut, pfIn1, pfIn2, pitch, width, height);
 
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
+	return stream.syncIfSync(__FUNCTION__);
 }
 
 
@@ -529,92 +628,92 @@ void processData(float* pfOut, const float* pfIn1, const float* pfIn2, unsigned 
 
 
 template<typename op>
-void processVol(float* out, unsigned int pitch, const SDimensions& dims)
+bool processVol(float* out, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream)
 {
-	processData<op>(out, pitch, dims.iVolWidth, dims.iVolHeight);
+	return processData<op>(out, pitch, dims.iVolWidth, dims.iVolHeight, _stream);
 }
 
 template<typename op>
-void processVol(float* out, float param, unsigned int pitch, const SDimensions& dims)
+bool processVol(float* out, float param, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream)
 {
-	processData<op>(out, param, pitch, dims.iVolWidth, dims.iVolHeight);
+	return processData<op>(out, param, pitch, dims.iVolWidth, dims.iVolHeight, _stream);
 }
 
 template<typename op>
-void processVol(float* out1, float* out2, float param1, float param2, unsigned int pitch, const SDimensions& dims)
+bool processVol(float* out1, float* out2, float param1, float param2, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream)
 {
-	processData<op>(out1, out2, param1, param2, pitch, dims.iVolWidth, dims.iVolHeight);
-}
-
-
-template<typename op>
-void processVol(float* out, const float* in, unsigned int pitch, const SDimensions& dims)
-{
-	processData<op>(out, in, pitch, dims.iVolWidth, dims.iVolHeight);
-}
-
-template<typename op>
-void processVol(float* out, const float* in, float param, unsigned int pitch, const SDimensions& dims)
-{
-	processData<op>(out, in, param, pitch, dims.iVolWidth, dims.iVolHeight);
-}
-
-template<typename op>
-void processVol(float* out, const float* in1, const float* in2, unsigned int pitch, const SDimensions& dims)
-{
-	processData<op>(out, in1, in2, pitch, dims.iVolWidth, dims.iVolHeight);
-}
-
-template<typename op>
-void processVol(float* out, const float* in1, const float* in2, float param, unsigned int pitch, const SDimensions& dims)
-{
-	processData<op>(out, in2, in2, param, pitch, dims.iVolWidth, dims.iVolHeight);
-}
-
-
-
-
-template<typename op>
-void processSino(float* out, unsigned int pitch, const SDimensions& dims)
-{
-	processData<op>(out, pitch, dims.iProjDets, dims.iProjAngles);
-}
-
-template<typename op>
-void processSino(float* out, float param, unsigned int pitch, const SDimensions& dims)
-{
-	processData<op>(out, param, pitch, dims.iProjDets, dims.iProjAngles);
-}
-
-template<typename op>
-void processSino(float* out1, float* out2, float param1, float param2, unsigned int pitch, const SDimensions& dims)
-{
-	processData<op>(out1, out2, param1, param2, pitch, dims.iProjDets, dims.iProjAngles);
+	return processData<op>(out1, out2, param1, param2, pitch, dims.iVolWidth, dims.iVolHeight, _stream);
 }
 
 
 template<typename op>
-void processSino(float* out, const float* in, unsigned int pitch, const SDimensions& dims)
+bool processVol(float* out, const float* in, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream)
 {
-	processData<op>(out, in, pitch, dims.iProjDets, dims.iProjAngles);
+	return processData<op>(out, in, pitch, dims.iVolWidth, dims.iVolHeight, _stream);
 }
 
 template<typename op>
-void processSino(float* out, const float* in, float param, unsigned int pitch, const SDimensions& dims)
+bool processVol(float* out, const float* in, float param, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream)
 {
-	processData<op>(out, in, param, pitch, dims.iProjDets, dims.iProjAngles);
+	return processData<op>(out, in, param, pitch, dims.iVolWidth, dims.iVolHeight, _stream);
 }
 
 template<typename op>
-void processSino(float* out, const float* in1, const float* in2, unsigned int pitch, const SDimensions& dims)
+bool processVol(float* out, const float* in1, const float* in2, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream)
 {
-	processData<op>(out, in1, in2, pitch, dims.iProjDets, dims.iProjAngles);
+	return processData<op>(out, in1, in2, pitch, dims.iVolWidth, dims.iVolHeight, _stream);
 }
 
 template<typename op>
-void processSino(float* out, const float* in1, const float* in2, float param, unsigned int pitch, const SDimensions& dims)
+bool processVol(float* out, const float* in1, const float* in2, float param, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream)
 {
-	processData<op>(out, in2, in2, param, pitch, dims.iProjDets, dims.iProjAngles);
+	return processData<op>(out, in2, in2, param, pitch, dims.iVolWidth, dims.iVolHeight, _stream);
+}
+
+
+
+
+template<typename op>
+bool processSino(float* out, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream)
+{
+	return processData<op>(out, pitch, dims.iProjDets, dims.iProjAngles, _stream);
+}
+
+template<typename op>
+bool processSino(float* out, float param, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream)
+{
+	return processData<op>(out, param, pitch, dims.iProjDets, dims.iProjAngles, _stream);
+}
+
+template<typename op>
+bool processSino(float* out1, float* out2, float param1, float param2, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream)
+{
+	return processData<op>(out1, out2, param1, param2, pitch, dims.iProjDets, dims.iProjAngles, _stream);
+}
+
+
+template<typename op>
+bool processSino(float* out, const float* in, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream)
+{
+	return processData<op>(out, in, pitch, dims.iProjDets, dims.iProjAngles, _stream);
+}
+
+template<typename op>
+bool processSino(float* out, const float* in, float param, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream)
+{
+	return processData<op>(out, in, param, pitch, dims.iProjDets, dims.iProjAngles, _stream);
+}
+
+template<typename op>
+bool processSino(float* out, const float* in1, const float* in2, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream)
+{
+	return processData<op>(out, in1, in2, pitch, dims.iProjDets, dims.iProjAngles, _stream);
+}
+
+template<typename op>
+bool processSino(float* out, const float* in1, const float* in2, float param, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream)
+{
+	return processData<op>(out, in2, in2, param, pitch, dims.iProjDets, dims.iProjAngles, _stream);
 }
 
 
@@ -640,40 +739,40 @@ void processSino(float* out, const float* in1, const float* in2, float param, un
 
 
 #define INST_DFtoD(name) \
-  template void processVolCopy<name>(float* out, const float* in, float param, const SDimensions& dims); \
-  template void processVol<name>(float* out, const float* in, float param, unsigned int pitch, const SDimensions& dims); \
-  template void processSino<name>(float* out, const float* in, float param, unsigned int pitch, const SDimensions& dims);
+  template bool processVolCopy<name>(float* out, const float* in, float param, const SDimensions& dims); \
+  template bool processVol<name>(float* out, const float* in, float param, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream); \
+  template bool processSino<name>(float* out, const float* in, float param, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream);
 
 #define INST_DtoD(name) \
-  template void processVolCopy<name>(float* out, const float* in, const SDimensions& dims); \
-  template void processVol<name>(float* out, const float* in, unsigned int pitch, const SDimensions& dims); \
-  template void processSino<name>(float* out, const float* in, unsigned int pitch, const SDimensions& dims);
+  template bool processVolCopy<name>(float* out, const float* in, const SDimensions& dims); \
+  template bool processVol<name>(float* out, const float* in, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream); \
+  template bool processSino<name>(float* out, const float* in, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream);
 
 #define INST_DDtoD(name) \
-  template void processVolCopy<name>(float* out, const float* in1, const float* in2, const SDimensions& dims); \
-  template void processVol<name>(float* out, const float* in1, const float* in2, unsigned int pitch, const SDimensions& dims); \
-  template void processSino<name>(float* out, const float* in1, const float* in2, unsigned int pitch, const SDimensions& dims);
+  template bool processVolCopy<name>(float* out, const float* in1, const float* in2, const SDimensions& dims); \
+  template bool processVol<name>(float* out, const float* in1, const float* in2, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream); \
+  template bool processSino<name>(float* out, const float* in1, const float* in2, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream);
 
 #define INST_DDFtoD(name) \
-  template void processVolCopy<name>(float* out, const float* in1, const float* in2, float fParam, const SDimensions& dims); \
-  template void processVol<name>(float* out, const float* in1, const float* in2, float fParam, unsigned int pitch, const SDimensions& dims); \
-  template void processSino<name>(float* out, const float* in1, const float* in2, float fParam, unsigned int pitch, const SDimensions& dims);
+  template bool processVolCopy<name>(float* out, const float* in1, const float* in2, float fParam, const SDimensions& dims); \
+  template bool processVol<name>(float* out, const float* in1, const float* in2, float fParam, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream); \
+  template bool processSino<name>(float* out, const float* in1, const float* in2, float fParam, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream);
 
 
 #define INST_toD(name) \
-  template void processVolCopy<name>(float* out, const SDimensions& dims); \
-  template void processVol<name>(float* out, unsigned int pitch, const SDimensions& dims); \
-  template void processSino<name>(float* out, unsigned int pitch, const SDimensions& dims);
+  template bool processVolCopy<name>(float* out, const SDimensions& dims); \
+  template bool processVol<name>(float* out, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream); \
+  template bool processSino<name>(float* out, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream);
 
 #define INST_FtoD(name) \
-  template void processVolCopy<name>(float* out, float param, const SDimensions& dims); \
-  template void processVol<name>(float* out, float param, unsigned int pitch, const SDimensions& dims); \
-  template void processSino<name>(float* out, float param, unsigned int pitch, const SDimensions& dims);
+  template bool processVolCopy<name>(float* out, float param, const SDimensions& dims); \
+  template bool processVol<name>(float* out, float param, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream); \
+  template bool processSino<name>(float* out, float param, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream);
 
 #define INST_FFtoDD(name) \
-  template void processVolCopy<name>(float* out1, float* out2, float fParam1, float fParam2, const SDimensions& dims); \
-  template void processVol<name>(float* out1, float* out2, float fParam1, float fParam2, unsigned int pitch, const SDimensions& dims); \
-  template void processSino<name>(float* out1, float* out2, float fParam1, float fParam2, unsigned int pitch, const SDimensions& dims);
+  template bool processVolCopy<name>(float* out1, float* out2, float fParam1, float fParam2, const SDimensions& dims); \
+  template bool processVol<name>(float* out1, float* out2, float fParam1, float fParam2, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream); \
+  template bool processSino<name>(float* out1, float* out2, float fParam1, float fParam2, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream);
 
 
 

--- a/cuda/2d/fan_bp.cu
+++ b/cuda/2d/fan_bp.cu
@@ -218,10 +218,14 @@ double det2(const Vec2 &a, const Vec2 &b) {
 	return a.x * b.y - a.y * b.x;
 }
 
+using TransferConstantsBuffer = TransferConstantsBuffer_t<DevFanParams>;
 
-bool transferConstants(const SFanProjection* angles, unsigned int iProjAngles, bool FBP)
+bool transferConstants(const SFanProjection* angles, unsigned int iProjAngles, bool FBP,
+                       TransferConstantsBuffer& buf, cudaStream_t stream)
 {
-	DevFanParams *p = new DevFanParams[iProjAngles];
+	DevFanParams *p = &(std::get<0>(buf.d))[0];
+
+	bool ok = checkCuda(cudaStreamWaitEvent(stream, buf.event, 0), "transferConstants wait");
 
 	// We need three values in the kernel:
 	// projected coordinates of pixels on the detector:
@@ -265,19 +269,18 @@ bool transferConstants(const SFanProjection* angles, unsigned int iProjAngles, b
 		p[i].fDenY = -fScale * u.x;
 	}
 
-	// TODO: Check for errors
-	cudaMemcpyToSymbol(gC_C, p, iProjAngles*sizeof(DevFanParams), 0, cudaMemcpyHostToDevice);
+	ok &= checkCuda(cudaMemcpyToSymbolAsync(gC_C, p, iProjAngles*sizeof(DevFanParams), 0, cudaMemcpyHostToDevice, stream), "transferConstants transfer");
 
-	delete [] p;
+	ok &= checkCuda(cudaEventRecord(buf.event, stream), "transferConstants event");
 
-	return true;
+	return ok;
 }
 
 
 bool FanBP_internal(float* D_volumeData, unsigned int volumePitch,
            float* D_projData, unsigned int projPitch,
            const SDimensions& dims, const SFanProjection* angles,
-           float fOutputScale)
+           float fOutputScale, cudaStream_t stream)
 {
 	assert(dims.iProjAngles <= g_MaxAngles);
 
@@ -285,18 +288,9 @@ bool FanBP_internal(float* D_volumeData, unsigned int volumePitch,
 	if (!createTextureObjectPitch2D(D_projData, D_texObj, projPitch, dims.iProjDets, dims.iProjAngles))
 		return false;
 
-	bool ok = transferConstants(angles, dims.iProjAngles, false);
-	if (!ok) {
-		cudaDestroyTextureObject(D_texObj);
-		return false;
-	}
-
 	dim3 dimBlock(g_blockSlices, g_blockSliceSize);
 	dim3 dimGrid((dims.iVolWidth+g_blockSlices-1)/g_blockSlices,
 	             (dims.iVolHeight+g_blockSliceSize-1)/g_blockSliceSize);
-
-	cudaStream_t stream;
-	cudaStreamCreate(&stream);
 
 	for (unsigned int i = 0; i < dims.iProjAngles; i += g_anglesPerBlock) {
 		if (dims.iRaysPerPixelDim > 1)
@@ -305,9 +299,7 @@ bool FanBP_internal(float* D_volumeData, unsigned int volumePitch,
 			devFanBP<false><<<dimGrid, dimBlock, 0, stream>>>(D_volumeData, volumePitch, D_texObj, i, dims, fOutputScale);
 	}
 
-	ok = checkCuda(cudaStreamSynchronize(stream), "FanBP");
-
-	cudaStreamDestroy(stream);
+	bool ok = checkCuda(cudaStreamSynchronize(stream), "FanBP");
 
 	cudaDestroyTextureObject(D_texObj);
 
@@ -317,7 +309,7 @@ bool FanBP_internal(float* D_volumeData, unsigned int volumePitch,
 bool FanBP_FBPWeighted_internal(float* D_volumeData, unsigned int volumePitch,
            float* D_projData, unsigned int projPitch,
            const SDimensions& dims, const SFanProjection* angles,
-           float fOutputScale)
+           float fOutputScale, cudaStream_t stream)
 {
 	assert(dims.iProjAngles <= g_MaxAngles);
 
@@ -325,26 +317,15 @@ bool FanBP_FBPWeighted_internal(float* D_volumeData, unsigned int volumePitch,
 	if (!createTextureObjectPitch2D(D_projData, D_texObj, projPitch, dims.iProjDets, dims.iProjAngles))
 		return false;
 
-	bool ok = transferConstants(angles, dims.iProjAngles, true);
-	if (!ok) {
-		cudaDestroyTextureObject(D_texObj);
-		return false;
-	}
-
 	dim3 dimBlock(g_blockSlices, g_blockSliceSize);
 	dim3 dimGrid((dims.iVolWidth+g_blockSlices-1)/g_blockSlices,
 	             (dims.iVolHeight+g_blockSliceSize-1)/g_blockSliceSize);
-
-	cudaStream_t stream;
-	cudaStreamCreate(&stream);
 
 	for (unsigned int i = 0; i < dims.iProjAngles; i += g_anglesPerBlock) {
 		devFanBP<true><<<dimGrid, dimBlock, 0, stream>>>(D_volumeData, volumePitch, D_texObj, i, dims, fOutputScale);
 	}
 
-	ok = checkCuda(cudaStreamSynchronize(stream), "FanBP_FBPWeighted");
-
-	cudaStreamDestroy(stream);
+	bool ok = checkCuda(cudaStreamSynchronize(stream), "FanBP_FBPWeighted");
 
 	cudaDestroyTextureObject(D_texObj);
 
@@ -358,13 +339,22 @@ bool FanBP_SART(float* D_volumeData, unsigned int volumePitch,
                 const SDimensions& dims, const SFanProjection* angles,
                 float fOutputScale)
 {
-	// only one angle
-	cudaTextureObject_t D_texObj;
-	if (!createTextureObjectPitch2D(D_projData, D_texObj, projPitch, dims.iProjDets, 1, cudaAddressModeClamp))
+	TransferConstantsBuffer tcbuf(1);
+
+	cudaStream_t stream;
+	if (!checkCuda(cudaStreamCreate(&stream), "FanBP_SART stream"))
 		return false;
 
-	bool ok = transferConstants(angles + angle, 1, false);
+	// only one angle
+	cudaTextureObject_t D_texObj;
+	if (!createTextureObjectPitch2D(D_projData, D_texObj, projPitch, dims.iProjDets, 1, cudaAddressModeClamp)) {
+		cudaStreamDestroy(stream);
+		return false;
+	}
+
+	bool ok = transferConstants(angles + angle, 1, false, tcbuf, stream);
 	if (!ok) {
+		cudaStreamDestroy(stream);
 		cudaDestroyTextureObject(D_texObj);
 		return false;
 	}
@@ -373,10 +363,11 @@ bool FanBP_SART(float* D_volumeData, unsigned int volumePitch,
 	dim3 dimGrid((dims.iVolWidth+g_blockSlices-1)/g_blockSlices,
 	             (dims.iVolHeight+g_blockSliceSize-1)/g_blockSliceSize);
 
-	devFanBP_SART<<<dimGrid, dimBlock>>>(D_volumeData, volumePitch, D_texObj, dims, fOutputScale);
+	devFanBP_SART<<<dimGrid, dimBlock, 0, stream>>>(D_volumeData, volumePitch, D_texObj, dims, fOutputScale);
 
-	ok = checkCuda(cudaThreadSynchronize(), "FanBP_SART");
+	ok = checkCuda(cudaStreamSynchronize(stream), "FanBP_SART");
 
+	cudaStreamDestroy(stream);
 	cudaDestroyTextureObject(D_texObj);
 
 	return ok;
@@ -387,6 +378,14 @@ bool FanBP(float* D_volumeData, unsigned int volumePitch,
            const SDimensions& dims, const SFanProjection* angles,
            float fOutputScale)
 {
+	TransferConstantsBuffer tcbuf(g_MaxAngles);
+
+	cudaStream_t stream;
+	if (!checkCuda(cudaStreamCreate(&stream), "FanBP stream"))
+		return false;
+
+	bool ok = true;
+
 	for (unsigned int iAngle = 0; iAngle < dims.iProjAngles; iAngle += g_MaxAngles) {
 		SDimensions subdims = dims;
 		unsigned int iEndAngle = iAngle + g_MaxAngles;
@@ -394,14 +393,20 @@ bool FanBP(float* D_volumeData, unsigned int volumePitch,
 			iEndAngle = dims.iProjAngles;
 		subdims.iProjAngles = iEndAngle - iAngle;
 
-		bool ret;
-		ret = FanBP_internal(D_volumeData, volumePitch,
+		ok &= transferConstants(angles, dims.iProjAngles, false, tcbuf, stream);
+		if (!ok)
+			break;
+
+		ok &= FanBP_internal(D_volumeData, volumePitch,
 		                  D_projData + iAngle * projPitch, projPitch,
-		                  subdims, angles + iAngle, fOutputScale);
-		if (!ret)
-			return false;
+		                  subdims, angles + iAngle, fOutputScale, stream);
+		if (!ok)
+			break;
 	}
-	return true;
+
+	ok &= checkCuda(cudaStreamSynchronize(stream), "fan_bp");
+	cudaStreamDestroy(stream);
+	return ok;
 }
 
 bool FanBP_FBPWeighted(float* D_volumeData, unsigned int volumePitch,
@@ -409,6 +414,14 @@ bool FanBP_FBPWeighted(float* D_volumeData, unsigned int volumePitch,
            const SDimensions& dims, const SFanProjection* angles,
            float fOutputScale)
 {
+	TransferConstantsBuffer tcbuf(g_MaxAngles);
+
+	cudaStream_t stream;
+	if (!checkCuda(cudaStreamCreate(&stream), "FanBP_FBPWeighted stream"))
+		return false;
+
+	bool ok = true;
+
 	for (unsigned int iAngle = 0; iAngle < dims.iProjAngles; iAngle += g_MaxAngles) {
 		SDimensions subdims = dims;
 		unsigned int iEndAngle = iAngle + g_MaxAngles;
@@ -416,15 +429,20 @@ bool FanBP_FBPWeighted(float* D_volumeData, unsigned int volumePitch,
 			iEndAngle = dims.iProjAngles;
 		subdims.iProjAngles = iEndAngle - iAngle;
 
-		bool ret;
-		ret = FanBP_FBPWeighted_internal(D_volumeData, volumePitch,
-		                  D_projData + iAngle * projPitch, projPitch,
-		                  subdims, angles + iAngle, fOutputScale);
+		ok = transferConstants(angles, dims.iProjAngles, true, tcbuf, stream);
+		if (!ok)
+			break;
 
-		if (!ret)
-			return false;
+		ok = FanBP_FBPWeighted_internal(D_volumeData, volumePitch,
+		                  D_projData + iAngle * projPitch, projPitch,
+		                  subdims, angles + iAngle, fOutputScale, stream);
+		if (!ok)
+			break;
 	}
-	return true;
+
+	ok &= checkCuda(cudaStreamSynchronize(stream), "fan_bp_fbpweighted");
+	cudaStreamDestroy(stream);
+	return ok;
 }
 
 

--- a/cuda/3d/arith3d.cu
+++ b/cuda/3d/arith3d.cu
@@ -216,106 +216,6 @@ __global__ void devDDFtoD(float* pfOut, const float* pfIn1, const float* pfIn2, 
 
 
 template<typename op>
-void processVol(CUdeviceptr* out, unsigned int pitch, unsigned int width, unsigned int height)
-{
-	dim3 blockSize(16,16);
-	dim3 gridSize((width+15)/16, (height+511)/512);
-
-	float *pfOut = (float*)out;
-
-	devtoD<op, 32><<<gridSize, blockSize>>>(pfOut, pitch, width, height);
-
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
-}
-
-template<typename op>
-void processVol(CUdeviceptr* out, float fParam, unsigned int pitch, unsigned int width, unsigned int height)
-{
-	dim3 blockSize(16,16);
-	dim3 gridSize((width+15)/16, (height+15)/16);
-
-	float *pfOut = (float*)out;
-
-	devFtoD<op, 32><<<gridSize, blockSize>>>(pfOut, fParam, pitch, width, height);
-
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
-}
-
-template<typename op>
-void processVol(CUdeviceptr* out, const CUdeviceptr* in, unsigned int pitch, unsigned int width, unsigned int height)
-{
-	dim3 blockSize(16,16);
-	dim3 gridSize((width+15)/16, (height+15)/16);
-
-	float *pfOut = (float*)out;
-	const float *pfIn = (const float*)in;
-
-	devDtoD<op, 32><<<gridSize, blockSize>>>(pfOut, pfIn, pitch, width, height);
-
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
-}
-
-template<typename op>
-void processVol(CUdeviceptr* out, const CUdeviceptr* in, float fParam, unsigned int pitch, unsigned int width, unsigned int height)
-{
-	dim3 blockSize(16,16);
-	dim3 gridSize((width+15)/16, (height+15)/16);
-
-	float *pfOut = (float*)out;
-	const float *pfIn = (const float*)in;
-
-	devDFtoD<op, 32><<<gridSize, blockSize>>>(pfOut, pfIn, fParam, pitch, width, height);
-
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
-}
-
-template<typename op>
-void processVol(CUdeviceptr* out, const CUdeviceptr* in1, const CUdeviceptr* in2, float fParam, unsigned int pitch, unsigned int width, unsigned int height)
-{
-	dim3 blockSize(16,16);
-	dim3 gridSize((width+15)/16, (height+15)/16);
-
-	float *pfOut = (float*)out;
-	const float *pfIn1 = (const float*)in1;
-	const float *pfIn2 = (const float*)in2;
-
-	devDDFtoD<op, 32><<<gridSize, blockSize>>>(pfOut, pfIn1, pfIn2, fParam, pitch, width, height);
-
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
-}
-
-template<typename op>
-void processVol(CUdeviceptr* out, const CUdeviceptr* in1, const CUdeviceptr* in2, unsigned int pitch, unsigned int width, unsigned int height)
-{
-	dim3 blockSize(16,16);
-	dim3 gridSize((width+15)/16, (height+15)/16);
-
-	float *pfOut = (float*)out;
-	const float *pfIn1 = (const float*)in1;
-	const float *pfIn2 = (const float*)in2;
-
-	devDDtoD<op, 32><<<gridSize, blockSize>>>(pfOut, pfIn1, pfIn2, pitch, width, height);
-
-	checkCuda(cudaThreadSynchronize(), __FUNCTION__);
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-template<typename op>
 void processVol3D(cudaPitchedPtr& out, const SDimensions3D& dims)
 {
 	dim3 blockSize(16,16);
@@ -561,33 +461,27 @@ void processSino3D(cudaPitchedPtr& out, const cudaPitchedPtr& in1, const cudaPit
 
 
 #define INST_DFtoD(name) \
-  template void processVol<name>(CUdeviceptr* out, const CUdeviceptr* in, float fParam, unsigned int pitch, unsigned int width, unsigned int height); \
   template void processVol3D<name>(cudaPitchedPtr& out, const cudaPitchedPtr& in, float fParam, const SDimensions3D& dims); \
   template void processSino3D<name>(cudaPitchedPtr& out, const cudaPitchedPtr& in, float fParam, const SDimensions3D& dims);
 
 #define INST_DtoD(name) \
-  template void processVol<name>(CUdeviceptr* out, const CUdeviceptr* in, unsigned int pitch, unsigned int width, unsigned int height); \
   template void processVol3D<name>(cudaPitchedPtr& out, const cudaPitchedPtr& in, const SDimensions3D& dims); \
   template void processSino3D<name>(cudaPitchedPtr& out, const cudaPitchedPtr& in, const SDimensions3D& dims);
 
 #define INST_DDtoD(name) \
-  template void processVol<name>(CUdeviceptr* out, const CUdeviceptr* in1, const CUdeviceptr* in2, unsigned int pitch, unsigned int width, unsigned int height); \
   template void processVol3D<name>(cudaPitchedPtr& out, const cudaPitchedPtr& in1, const cudaPitchedPtr& in2, const SDimensions3D& dims); \
   template void processSino3D<name>(cudaPitchedPtr& out, const cudaPitchedPtr& in1, const cudaPitchedPtr& in2, const SDimensions3D& dims);
 
 #define INST_DDFtoD(name) \
-  template void processVol<name>(CUdeviceptr* out, const CUdeviceptr* in1, const CUdeviceptr* in2, float fParam, unsigned int pitch, unsigned int width, unsigned int height); \
   template void processVol3D<name>(cudaPitchedPtr& out, const cudaPitchedPtr& in1, const cudaPitchedPtr& in2, float fParam, const SDimensions3D& dims); \
   template void processSino3D<name>(cudaPitchedPtr& out, const cudaPitchedPtr& in1, const cudaPitchedPtr& in2, float fParam, const SDimensions3D& dims);
 
 
 #define INST_toD(name) \
-  template void processVol<name>(CUdeviceptr* out, unsigned int pitch, unsigned int width, unsigned int height); \
   template void processVol3D<name>(cudaPitchedPtr& out, const SDimensions3D& dims); \
   template void processSino3D<name>(cudaPitchedPtr& out, const SDimensions3D& dims);
 
 #define INST_FtoD(name) \
-  template void processVol<name>(CUdeviceptr* out, float fParam, unsigned int pitch, unsigned int width, unsigned int height); \
   template void processVol3D<name>(cudaPitchedPtr& out, float fParam, const SDimensions3D& dims); \
   template void processSino3D<name>(cudaPitchedPtr& out, float fParam, const SDimensions3D& dims);
 

--- a/cuda/3d/fdk.cu
+++ b/cuda/3d/fdk.cu
@@ -36,8 +36,6 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include <cstdio>
 #include <cassert>
-#include <iostream>
-#include <list>
 #include <vector>
 
 #include <cuda.h>
@@ -276,14 +274,13 @@ bool FDK_Filter(cudaPitchedPtr D_projData,
 	int iPaddedDetCount = calcNextPowerOfTwo(2 * dims.iProjU);
 	int iHalfFFTSize = astra::calcFFTFourierSize(iPaddedDetCount);
 
-
-	cufftComplex *pHostFilter = new cufftComplex[dims.iProjAngles * iHalfFFTSize];
-	memset(pHostFilter, 0, sizeof(cufftComplex) * dims.iProjAngles * iHalfFFTSize);
+	// TODO: We could free this vector earlier, once the async memcpy is done
+	std::vector<cufftComplex> pHostFilter(dims.iProjAngles * iHalfFFTSize);
 
 	if (pfFilter == 0){
 		astra::SFilterConfig filter;
 		filter.m_eType = astra::FILTER_RAMLAK;
-		astraCUDA::genCuFFTFilter(filter, dims.iProjAngles, pHostFilter, iPaddedDetCount, iHalfFFTSize);
+		astraCUDA::genCuFFTFilter(filter, dims.iProjAngles, &pHostFilter[0], iPaddedDetCount, iHalfFFTSize);
 	} else {
 		for (int i = 0; i < dims.iProjAngles * iHalfFFTSize; i++) {
 			pHostFilter[i].x = pfFilter[i];
@@ -291,25 +288,48 @@ bool FDK_Filter(cudaPitchedPtr D_projData,
 		}
 	}
 
+	cudaStream_t stream;
+	if (!checkCuda(cudaStreamCreate(&stream), "FDK_Filter stream"))
+		return false;
+
 	cufftComplex * D_filter;
 
-	astraCUDA::allocateComplexOnDevice(dims.iProjAngles, iHalfFFTSize, &D_filter);
-	astraCUDA::uploadComplexArrayToDevice(dims.iProjAngles, iHalfFFTSize, pHostFilter, D_filter);
+	if (!astraCUDA::allocateComplexOnDevice(dims.iProjAngles, iHalfFFTSize, &D_filter)) {
+		cudaStreamDestroy(stream);
+		return false;
+	}
 
-	delete [] pHostFilter;
-
+	if (!astraCUDA::uploadComplexArrayToDevice(dims.iProjAngles, iHalfFFTSize, &pHostFilter[0], D_filter, stream)) {
+		astraCUDA::freeComplexOnDevice(D_filter);
+		cudaStreamDestroy(stream);
+		return false;
+	}
 
 	cufftHandle planF;
 	cufftHandle planI;
 
 	if (!checkCufft(cufftPlan1d(&planF, iPaddedDetCount, CUFFT_R2C, dims.iProjAngles), "FDK filter FFT plan")) {
+		cudaStreamDestroy(stream);
+		astraCUDA::freeComplexOnDevice(D_filter);
+		return false;
+	}
+	if (!checkCufft(cufftSetStream(planF, stream), "FDK filter FFT plan stream")) {
+		cudaStreamDestroy(stream);
 		astraCUDA::freeComplexOnDevice(D_filter);
 		return false;
 	}
 
 	if (!checkCufft(cufftPlan1d(&planI, iPaddedDetCount, CUFFT_C2R, dims.iProjAngles), "FDK filter IFFT plan")) {
+		cudaStreamDestroy(stream);
 		astraCUDA::freeComplexOnDevice(D_filter);
 		cufftDestroy(planF);
+		return false;
+	}
+	if (!checkCufft(cufftSetStream(planI, stream), "FDK filter IFFT plan stream")) {
+		cudaStreamDestroy(stream);
+		astraCUDA::freeComplexOnDevice(D_filter);
+		cufftDestroy(planF);
+		cufftDestroy(planI);
 		return false;
 	}
 
@@ -320,13 +340,19 @@ bool FDK_Filter(cudaPitchedPtr D_projData,
 	float* D_sinoData = (float*)D_projData.ptr;
 
 	cufftComplex * D_pcSinoFFT = NULL;
-	astraCUDA::allocateComplexOnDevice(dims.iProjAngles, iHalfFFTSize, &D_pcSinoFFT);
 
-	bool ok = true;
+	if (!astraCUDA::allocateComplexOnDevice(dims.iProjAngles, iHalfFFTSize, &D_pcSinoFFT)) {
+		cudaStreamDestroy(stream);
+		astraCUDA::freeComplexOnDevice(D_filter);
+		cufftDestroy(planF);
+		cufftDestroy(planI);
+		return false;
+	}
 
 	float * D_pfPadded = NULL;
 	size_t bufferMemSize = sizeof(float) * dims.iProjAngles * iPaddedDetCount;
 	if (!checkCuda(cudaMalloc((void **)&D_pfPadded, bufferMemSize), "FDK filter malloc")) {
+		cudaStreamDestroy(stream);
 		astraCUDA::freeComplexOnDevice(D_pcSinoFFT);
 		astraCUDA::freeComplexOnDevice(D_filter);
 		cufftDestroy(planF);
@@ -334,26 +360,29 @@ bool FDK_Filter(cudaPitchedPtr D_projData,
 		return false;
 	}
 
+	bool ok = true;
 
 	for (int v = 0; v < dims.iProjV; ++v) {
-		if (!checkCuda(cudaMemset(D_pfPadded, 0, bufferMemSize), "FDK filter memset")) {
+		if (!checkCuda(cudaMemsetAsync(D_pfPadded, 0, bufferMemSize, stream), "FDK filter memset")) {
 			ok = false;
 			break;
 		}
 
 		// pitched memcpy 2D to handle both source pitch and target padding
-		if (!checkCuda(cudaMemcpy2D(D_pfPadded, iPaddedDetCount*sizeof(float), D_sinoData, projPitch*sizeof(float), dims.iProjU*sizeof(float), dims.iProjAngles, cudaMemcpyDeviceToDevice), "FDK filter memcpy")) {
+		if (!checkCuda(cudaMemcpy2DAsync(D_pfPadded, iPaddedDetCount*sizeof(float), D_sinoData, projPitch*sizeof(float), dims.iProjU*sizeof(float), dims.iProjAngles, cudaMemcpyDeviceToDevice, stream), "FDK filter memcpy")) {
 			ok = false;
 			break;
 		}
-
 
 		if (!checkCufft(cufftExecR2C(planF, (cufftReal *)D_pfPadded, D_pcSinoFFT), "FDK filter forward exec")) {
 			ok = false;
 			break;
 		}
 
-		astraCUDA::applyFilter(dims.iProjAngles, iHalfFFTSize, D_pcSinoFFT, D_filter);
+		if (!astraCUDA::applyFilter(dims.iProjAngles, iHalfFFTSize, D_pcSinoFFT, D_filter, stream)) {
+			ok = false;
+			break;
+		}
 
 		// Getting rid of the const qualifier is due to cufft API issue?
 		if (!checkCufft(cufftExecC2R(planI, (cufftComplex *)D_pcSinoFFT,
@@ -363,15 +392,18 @@ bool FDK_Filter(cudaPitchedPtr D_projData,
 			break;
 		}
 
-		astraCUDA::rescaleInverseFourier(dims.iProjAngles, iPaddedDetCount, D_pfPadded);
+		if (!astraCUDA::rescaleInverseFourier(dims.iProjAngles, iPaddedDetCount, D_pfPadded, stream)) {
+			ok = false;
+			break;
+		}
 
-		if (!checkCuda(cudaMemset(D_sinoData, 0, sizeof(float) * dims.iProjAngles * projPitch), "FDK filter memset")) {
+		if (!checkCuda(cudaMemsetAsync(D_sinoData, 0, sizeof(float) * dims.iProjAngles * projPitch, stream), "FDK filter memset")) {
 			ok = false;
 			break;
 		}
 
 		// pitched memcpy 2D to handle both source padding and target pitch
-		if (!checkCuda(cudaMemcpy2D(D_sinoData, projPitch*sizeof(float), D_pfPadded, iPaddedDetCount*sizeof(float), dims.iProjU*sizeof(float), dims.iProjAngles, cudaMemcpyDeviceToDevice), "FDK filter memcpy")) {
+		if (!checkCuda(cudaMemcpy2DAsync(D_sinoData, projPitch*sizeof(float), D_pfPadded, iPaddedDetCount*sizeof(float), dims.iProjU*sizeof(float), dims.iProjAngles, cudaMemcpyDeviceToDevice, stream), "FDK filter memcpy")) {
 			ok = false;
 			break;
 		}
@@ -379,9 +411,7 @@ bool FDK_Filter(cudaPitchedPtr D_projData,
 		D_sinoData += (dims.iProjAngles * projPitch);
 	}
 
-	if (!checkCuda(cudaDeviceSynchronize(), "FDK filter sync")) {
-		ok = false;
-	}
+	ok &= checkCuda(cudaStreamSynchronize(stream), "FDK filter sync");
 
 	cufftDestroy(planF);
 	cufftDestroy(planI);
@@ -389,6 +419,8 @@ bool FDK_Filter(cudaPitchedPtr D_projData,
 	cudaFree(D_pfPadded);
 	astraCUDA::freeComplexOnDevice(D_pcSinoFFT);
 	astraCUDA::freeComplexOnDevice(D_filter);
+
+	cudaStreamDestroy(stream);
 
 	return ok;
 }

--- a/cuda/3d/par3d_bp.cu
+++ b/cuda/3d/par3d_bp.cu
@@ -30,8 +30,6 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include <cstdio>
 #include <cassert>
-#include <iostream>
-#include <list>
 
 #include <cuda.h>
 
@@ -199,10 +197,16 @@ __global__ void dev_par3D_BP_SS(void* D_volData, unsigned int volPitch, cudaText
 
 }
 
-bool transferConstants(const SPar3DProjection* angles, unsigned int iProjAngles, const SProjectorParams3D& params)
+using TransferConstantsBuffer = TransferConstantsBuffer_t<DevPar3DParams, float>;
+
+bool transferConstants(const SPar3DProjection* angles, unsigned int iProjAngles, const SProjectorParams3D& params, TransferConstantsBuffer& buf, cudaStream_t stream)
 {
-	DevPar3DParams *p = new DevPar3DParams[iProjAngles];
-	float *s = new float[iProjAngles];
+	DevPar3DParams *p = &(std::get<0>(buf.d))[0];
+	float *s = &(std::get<1>(buf.d))[0];
+
+	// We use an event to assure that the previous transferConstants has completed before
+	// re-using the buffer. (Even if it is very unlikely that it hasn't.)
+	bool ok = checkCuda(cudaStreamWaitEvent(stream, buf.event, 0), "transferConstants wait");
 
 	for (unsigned int i = 0; i < iProjAngles; ++i) {
 		Vec3 u(angles[i].fDetUX, angles[i].fDetUY, angles[i].fDetUZ);
@@ -223,13 +227,12 @@ bool transferConstants(const SPar3DProjection* angles, unsigned int iProjAngles,
 		s[i] = 1.0 / scaled_cross3(u,v,Vec3(params.fVolScaleX,params.fVolScaleY,params.fVolScaleZ)).norm();
 	}
 
-	cudaMemcpyToSymbol(gC_C, p, iProjAngles*sizeof(DevPar3DParams), 0, cudaMemcpyHostToDevice);
-	cudaMemcpyToSymbol(gC_scale, s, iProjAngles*sizeof(float), 0, cudaMemcpyHostToDevice);
+	ok &= checkCuda(cudaMemcpyToSymbolAsync(gC_C, p, iProjAngles*sizeof(DevPar3DParams), 0, cudaMemcpyHostToDevice, stream), "transferConstants transfer C");
+	ok &= checkCuda(cudaMemcpyToSymbolAsync(gC_scale, s, iProjAngles*sizeof(float), 0, cudaMemcpyHostToDevice, stream), "transferConstants transfer scale");
 
-	delete[] p;
-	delete[] s;
+	ok &= checkCuda(cudaEventRecord(buf.event, stream), "transferConstants event");
 
-	return true;
+	return ok;
 }
 
 bool Par3DBP_Array(cudaPitchedPtr D_volumeData,
@@ -237,9 +240,17 @@ bool Par3DBP_Array(cudaPitchedPtr D_volumeData,
                    const SDimensions3D& dims, const SPar3DProjection* angles,
                    const SProjectorParams3D& params)
 {
+	TransferConstantsBuffer tcbuf(g_MaxAngles);
+
 	cudaTextureObject_t D_texObj;
 	if (!createTextureObject3D(D_projArray, D_texObj))
 		return false;
+
+	cudaStream_t stream;
+	if (!checkCuda(cudaStreamCreate(&stream), "Par3DBP_Array stream")) {
+		cudaDestroyTextureObject(D_texObj);
+		return false;
+	}
 
 	float fOutputScale = params.fOutputScale * params.fVolScaleX * params.fVolScaleY * params.fVolScaleZ;
 
@@ -250,7 +261,7 @@ bool Par3DBP_Array(cudaPitchedPtr D_volumeData,
 		if (th + angleCount > dims.iProjAngles)
 			angleCount = dims.iProjAngles - th;
 
-		ok = transferConstants(angles, angleCount, params);
+		ok = transferConstants(angles, angleCount, params, tcbuf, stream);
 		if (!ok)
 			break;
 
@@ -265,16 +276,17 @@ bool Par3DBP_Array(cudaPitchedPtr D_volumeData,
 			// printf("Calling BP: %d, %dx%d, %dx%d to %p\n", i, dimBlock.x, dimBlock.y, dimGrid.x, dimGrid.y, (void*)D_volumeData.ptr); 
 			if (params.iRaysPerVoxelDim == 1) {
 				if (dims.iVolZ == 1) {
-					dev_par3D_BP<1><<<dimGrid, dimBlock>>>(D_volumeData.ptr, D_volumeData.pitch/sizeof(float), D_texObj, i, th, dims, fOutputScale);
+					dev_par3D_BP<1><<<dimGrid, dimBlock, 0, stream>>>(D_volumeData.ptr, D_volumeData.pitch/sizeof(float), D_texObj, i, th, dims, fOutputScale);
 				} else {
-					dev_par3D_BP<g_volBlockZ><<<dimGrid, dimBlock>>>(D_volumeData.ptr, D_volumeData.pitch/sizeof(float), D_texObj, i, th, dims, fOutputScale);
+					dev_par3D_BP<g_volBlockZ><<<dimGrid, dimBlock, 0, stream>>>(D_volumeData.ptr, D_volumeData.pitch/sizeof(float), D_texObj, i, th, dims, fOutputScale);
 				}
 			} else
-				dev_par3D_BP_SS<<<dimGrid, dimBlock>>>(D_volumeData.ptr, D_volumeData.pitch/sizeof(float), D_texObj, i, th, dims, params.iRaysPerVoxelDim, fOutputScale);
+				dev_par3D_BP_SS<<<dimGrid, dimBlock, 0, stream>>>(D_volumeData.ptr, D_volumeData.pitch/sizeof(float), D_texObj, i, th, dims, params.iRaysPerVoxelDim, fOutputScale);
 		}
 
-		// TODO: Consider not synchronizing here, if possible.
-		ok = checkCuda(cudaThreadSynchronize(), "cone_bp");
+		// After kernels are done, signal we're ready to transfer new constants
+		ok = checkCuda(cudaEventRecord(tcbuf.event, stream), "Par3DBP event");
+
 		if (!ok)
 			break;
 
@@ -283,9 +295,12 @@ bool Par3DBP_Array(cudaPitchedPtr D_volumeData,
 
 	}
 
-	cudaDestroyTextureObject(D_texObj);
+	ok = checkCuda(cudaStreamSynchronize(stream), "Par3DBP sync");
 
-	return true;
+	cudaDestroyTextureObject(D_texObj);
+	cudaStreamDestroy(stream);
+
+	return ok;
 }
 
 bool Par3DBP(cudaPitchedPtr D_volumeData,

--- a/cuda/3d/par3d_fp.cu
+++ b/cuda/3d/par3d_fp.cu
@@ -30,8 +30,6 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include <cstdio>
 #include <cassert>
-#include <iostream>
-#include <list>
 
 #include <cuda.h>
 
@@ -113,12 +111,18 @@ struct SCALE_NONCUBE {
 	__device__ float scale(float a1, float a2) const { return sqrt(a1*a1*fScale1+a2*a2*fScale2+1.0f) * fOutputScale; }
 };
 
-bool transferConstants(const SPar3DProjection* angles, unsigned int iProjAngles)
-{
-	// transfer angles to constant memory
-	float* tmp = new float[iProjAngles];
+using TransferConstantsBuffer = TransferConstantsBuffer_t<float>;
 
-#define TRANSFER_TO_CONSTANT(name) do { for (unsigned int i = 0; i < iProjAngles; ++i) tmp[i] = angles[i].f##name ; cudaMemcpyToSymbol(gC_##name, tmp, iProjAngles*sizeof(float), 0, cudaMemcpyHostToDevice); } while (0)
+bool transferConstants(const SPar3DProjection* angles, unsigned int iProjAngles,
+                       TransferConstantsBuffer& buf, cudaStream_t stream)
+{
+	float* tmp = &(std::get<0>(buf.d))[0];
+
+	// We use an event to assure that the previous transferConstants has completed before
+	// re-using the buffer. (Even if it is very unlikely that it hasn't.)
+	bool ok = checkCuda(cudaStreamWaitEvent(stream, buf.event, 0), "transferConstants wait");
+
+#define TRANSFER_TO_CONSTANT(name) do { for (unsigned int i = 0; i < iProjAngles; ++i) tmp[i] = angles[i].f##name ; ok &= checkCuda(cudaMemcpyToSymbolAsync(gC_##name, tmp, iProjAngles*sizeof(float), 0, cudaMemcpyHostToDevice, stream), "transferConstants transfer"); } while (0)
 
 	TRANSFER_TO_CONSTANT(RayX);
 	TRANSFER_TO_CONSTANT(RayY);
@@ -134,8 +138,6 @@ bool transferConstants(const SPar3DProjection* angles, unsigned int iProjAngles)
 	TRANSFER_TO_CONSTANT(DetVZ);
 
 #undef TRANSFER_TO_CONSTANT
-
-	delete[] tmp;
 
 	return true;
 }
@@ -424,12 +426,8 @@ bool Par3DFP_Array_internal(cudaPitchedPtr D_projData,
                    cudaTextureObject_t D_texObj,
                    const SDimensions3D& dims,
                    unsigned int angleCount, const SPar3DProjection* angles,
-                   const SProjectorParams3D& params)
+                   const SProjectorParams3D& params, cudaStream_t stream)
 {
-	if (!transferConstants(angles, angleCount))
-		return false;
-
-	std::list<cudaStream_t> streams;
 	dim3 dimBlock(g_detBlockU, g_anglesPerBlock); // region size, angles
 
 	// Run over all angles, grouping them into groups of the same
@@ -497,11 +495,6 @@ bool Par3DFP_Array_internal(cudaPitchedPtr D_projData,
 				dim3 dimGrid(
 				             ((dims.iProjU+g_detBlockU-1)/g_detBlockU)*((dims.iProjV+g_detBlockV-1)/g_detBlockV),
 (blockEnd-blockStart+g_anglesPerBlock-1)/g_anglesPerBlock);
-				// TODO: consider limiting number of handle (chaotic) geoms
-				//       with many alternating directions
-				cudaStream_t stream;
-				cudaStreamCreate(&stream);
-				streams.push_back(stream);
 
 				// printf("angle block: %d to %d, %d (%dx%d, %dx%d)\n", blockStart, blockEnd, blockDirection, dimGrid.x, dimGrid.y, dimBlock.x, dimBlock.y);
 
@@ -541,16 +534,9 @@ bool Par3DFP_Array_internal(cudaPitchedPtr D_projData,
 		}
 	}
 
-	bool ok = true;
-
-	for (std::list<cudaStream_t>::iterator iter = streams.begin(); iter != streams.end(); ++iter) {
-		ok &= checkCuda(cudaStreamSynchronize(*iter), "par3d_fp");
-		cudaStreamDestroy(*iter);
-	}
-
 	// printf("%f\n", toc(t));
 
-	return ok;
+	return true;
 }
 
 bool Par3DFP(cudaPitchedPtr D_volumeData,
@@ -558,39 +544,62 @@ bool Par3DFP(cudaPitchedPtr D_volumeData,
              const SDimensions3D& dims, const SPar3DProjection* angles,
              const SProjectorParams3D& params)
 {
+	TransferConstantsBuffer tcbuf(g_MaxAngles);
+
+	cudaStream_t stream;
+	if (!checkCuda(cudaStreamCreate(&stream), "Par3DFP stream"))
+		return false;
 
 	// transfer volume to array
 	cudaArray* cuArray = allocateVolumeArray(dims);
-	transferVolumeToArray(D_volumeData, cuArray, dims);
+	if (!cuArray) {
+		cudaStreamDestroy(stream);
+		return false;
+	}
 
 	cudaTextureObject_t D_texObj;
 	if (!createTextureObject3D(cuArray, D_texObj)) {
+		cudaStreamDestroy(stream);
 		cudaFreeArray(cuArray);
 		return false;
 	}
 
-	bool ret;
+	if (!transferVolumeToArray(D_volumeData, cuArray, dims, stream)) {
+		cudaDestroyTextureObject(D_texObj);
+		cudaStreamDestroy(stream);
+		cudaFreeArray(cuArray);
+		return false;
+	}
+
+	bool ok = true;
 
 	for (unsigned int iAngle = 0; iAngle < dims.iProjAngles; iAngle += g_MaxAngles) {
 		unsigned int iEndAngle = iAngle + g_MaxAngles;
 		if (iEndAngle >= dims.iProjAngles)
 			iEndAngle = dims.iProjAngles;
 
+		ok = transferConstants(angles + iAngle, iEndAngle - iAngle, tcbuf, stream);
+		if (!ok)
+			break;
+
+
 		cudaPitchedPtr D_subprojData = D_projData;
 		D_subprojData.ptr = (char*)D_projData.ptr + iAngle * D_projData.pitch;
 
-		ret = Par3DFP_Array_internal(D_subprojData, D_texObj,
+		ok = Par3DFP_Array_internal(D_subprojData, D_texObj,
 		                             dims, iEndAngle - iAngle, angles + iAngle,
-		                             params);
-		if (!ret)
+		                             params, stream);
+		if (!ok)
 			break;
 	}
 
+	ok &= checkCuda(cudaStreamSynchronize(stream), "Par3DFP sync");
+
 	cudaDestroyTextureObject(D_texObj);
-
 	cudaFreeArray(cuArray);
+	cudaStreamDestroy(stream);
 
-	return ret;
+	return ok;
 }
 
 
@@ -600,29 +609,17 @@ bool Par3DFP_SumSqW(cudaPitchedPtr D_volumeData,
                     const SDimensions3D& dims, const SPar3DProjection* angles,
                     const SProjectorParams3D& params)
 {
-	// transfer angles to constant memory
-	float* tmp = new float[dims.iProjAngles];
+	TransferConstantsBuffer tcbuf(dims.iProjAngles);
 
-#define TRANSFER_TO_CONSTANT(name) do { for (unsigned int i = 0; i < dims.iProjAngles; ++i) tmp[i] = angles[i].f##name ; cudaMemcpyToSymbol(gC_##name, tmp, dims.iProjAngles*sizeof(float), 0, cudaMemcpyHostToDevice); } while (0)
+	cudaStream_t stream;
+	if (!checkCuda(cudaStreamCreate(&stream), "Par3DFP_SumSqW stream"))
+		return false;
 
-	TRANSFER_TO_CONSTANT(RayX);
-	TRANSFER_TO_CONSTANT(RayY);
-	TRANSFER_TO_CONSTANT(RayZ);
-	TRANSFER_TO_CONSTANT(DetSX);
-	TRANSFER_TO_CONSTANT(DetSY);
-	TRANSFER_TO_CONSTANT(DetSZ);
-	TRANSFER_TO_CONSTANT(DetUX);
-	TRANSFER_TO_CONSTANT(DetUY);
-	TRANSFER_TO_CONSTANT(DetUZ);
-	TRANSFER_TO_CONSTANT(DetVX);
-	TRANSFER_TO_CONSTANT(DetVY);
-	TRANSFER_TO_CONSTANT(DetVZ);
+	if (!transferConstants(angles, dims.iProjAngles, tcbuf, stream)) {
+		cudaStreamDestroy(stream);
+		return false;
+	}
 
-#undef TRANSFER_TO_CONSTANT
-
-	delete[] tmp;
-
-	std::list<cudaStream_t> streams;
 	dim3 dimBlock(g_detBlockU, g_anglesPerBlock); // region size, angles
 
 	// Run over all angles, grouping them into groups of the same
@@ -682,11 +679,6 @@ bool Par3DFP_SumSqW(cudaPitchedPtr D_volumeData,
 				dim3 dimGrid(
 				             ((dims.iProjU+g_detBlockU-1)/g_detBlockU)*((dims.iProjV+g_detBlockV-1)/g_detBlockV),
 (blockEnd-blockStart+g_anglesPerBlock-1)/g_anglesPerBlock);
-				// TODO: check if we can't immediately
-				//       destroy the stream after use
-				cudaStream_t stream;
-				cudaStreamCreate(&stream);
-				streams.push_back(stream);
 
 				// printf("angle block: %d to %d, %d (%dx%d, %dx%d)\n", blockStart, blockEnd, blockDirection, dimGrid.x, dimGrid.y, dimBlock.x, dimBlock.y);
 
@@ -729,12 +721,8 @@ bool Par3DFP_SumSqW(cudaPitchedPtr D_volumeData,
 		}
 	}
 
-	bool ok = true;
-
-	for (std::list<cudaStream_t>::iterator iter = streams.begin(); iter != streams.end(); ++iter) {
-		ok &= checkCuda(cudaStreamSynchronize(*iter), "Par3DFP_SumSqW");
-		cudaStreamDestroy(*iter);
-	}
+	bool ok = checkCuda(cudaStreamSynchronize(stream), "Par3DFP_SumSqW");
+	cudaStreamDestroy(stream);
 
 	// printf("%f\n", toc(t));
 

--- a/include/astra/cuda/2d/arith.h
+++ b/include/astra/cuda/2d/arith.h
@@ -28,6 +28,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 #ifndef _CUDA_ARITH_H
 #define _CUDA_ARITH_H
 
+#include <optional>
+
 #include <cuda.h>
 
 namespace astraCUDA {
@@ -55,29 +57,21 @@ struct opSetMaskedValues;
 struct opMulMask;
 
 
-template<typename op> void processVolCopy(float* out, const SDimensions& dims);
-template<typename op> void processVolCopy(float* out, float param, const SDimensions& dims);
-template<typename op> void processVolCopy(float* out1, float* out2, float param1, float param2, const SDimensions& dims);
-template<typename op> void processVolCopy(float* out, const float* in, const SDimensions& dims);
-template<typename op> void processVolCopy(float* out, const float* in, float param, const SDimensions& dims);
-template<typename op> void processVolCopy(float* out, const float* in1, const float* in2, const SDimensions& dims);
-template<typename op> void processVolCopy(float* out, const float* in1, const float* in2, float param, const SDimensions& dims);
+template<typename op> bool processVol(float* out, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processVol(float* out, float fParam, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processVol(float* out1, float* out2, float fParam1, float fParam2, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processVol(float* out, const float* in, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processVol(float* out, const float* in, float fParam, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processVol(float* out, const float* in1, const float* in2, float fParam, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processVol(float* out, const float* in1, const float* in2, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream = {});
 
-template<typename op> void processVol(float* out, unsigned int pitch, const SDimensions& dims);
-template<typename op> void processVol(float* out, float fParam, unsigned int pitch, const SDimensions& dims);
-template<typename op> void processVol(float* out1, float* out2, float fParam1, float fParam2, unsigned int pitch, const SDimensions& dims);
-template<typename op> void processVol(float* out, const float* in, unsigned int pitch, const SDimensions& dims);
-template<typename op> void processVol(float* out, const float* in, float fParam, unsigned int pitch, const SDimensions& dims);
-template<typename op> void processVol(float* out, const float* in1, const float* in2, float fParam, unsigned int pitch, const SDimensions& dims);
-template<typename op> void processVol(float* out, const float* in1, const float* in2, unsigned int pitch, const SDimensions& dims);
-
-template<typename op> void processSino(float* out, unsigned int pitch, const SDimensions& dims);
-template<typename op> void processSino(float* out, float fParam, unsigned int pitch, const SDimensions& dims);
-template<typename op> void processSino(float* out1, float* out2, float fParam1, float fParam2, unsigned int pitch, const SDimensions& dims);
-template<typename op> void processSino(float* out, const float* in, unsigned int pitch, const SDimensions& dims);
-template<typename op> void processSino(float* out, const float* in, float fParam, unsigned int pitch, const SDimensions& dims);
-template<typename op> void processSino(float* out, const float* in1, const float* in2, float fParam, unsigned int pitch, const SDimensions& dims);
-template<typename op> void processSino(float* out, const float* in1, const float* in2, unsigned int pitch, const SDimensions& dims);
+template<typename op> bool processSino(float* out, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processSino(float* out, float fParam, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processSino(float* out1, float* out2, float fParam1, float fParam2, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processSino(float* out, const float* in, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processSino(float* out, const float* in, float fParam, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processSino(float* out, const float* in1, const float* in2, float fParam, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processSino(float* out, const float* in1, const float* in2, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream = {});
 
 
 }

--- a/include/astra/cuda/2d/astra.h
+++ b/include/astra/cuda/2d/astra.h
@@ -122,5 +122,36 @@ _AstraExport bool setGPUIndex(int index);
 
 _AstraExport size_t availableGPUMemory();
 
+
+struct opAddScaled;
+struct opScaleAndAdd;
+struct opAddMulScaled;
+struct opAddMul;
+struct opAdd;
+struct opAdd2;
+struct opMul;
+struct opDiv;
+struct opMul2;
+struct opDividedBy;
+struct opInvert;
+struct opSet;
+struct opClampMin;
+struct opClampMax;
+struct opClampMinMask;
+struct opClampMaxMask;
+struct opSegmentAndMask;
+struct opSetMaskedValues;
+
+struct opMulMask;
+
+
+template<typename op> bool processVolCopy(float* out, const SDimensions& dims);
+template<typename op> bool processVolCopy(float* out, float param, const SDimensions& dims);
+template<typename op> bool processVolCopy(float* out1, float* out2, float param1, float param2, const SDimensions& dims);
+template<typename op> bool processVolCopy(float* out, const float* in, const SDimensions& dims);
+template<typename op> bool processVolCopy(float* out, const float* in, float param, const SDimensions& dims);
+template<typename op> bool processVolCopy(float* out, const float* in1, const float* in2, const SDimensions& dims);
+template<typename op> bool processVolCopy(float* out, const float* in1, const float* in2, float param, const SDimensions& dims);
+
 }
 #endif

--- a/include/astra/cuda/2d/fft.h
+++ b/include/astra/cuda/2d/fft.h
@@ -30,10 +30,15 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include <cufft.h>
 #include <cuda.h>
+#include <optional>
 
 #include "astra/Filters.h"
 
 namespace astraCUDA {
+
+// Functions taking an std::optional<cudaStream_t> will be
+// synchronous when not passed a stream. If they do get a stream,
+// the cuda parts might be partially or fully asynchronous.
 
 bool allocateComplexOnDevice(int _iProjectionCount,
                              int _iDetectorCount,
@@ -43,20 +48,24 @@ bool freeComplexOnDevice(cufftComplex * _pDevComplex);
 
 bool uploadComplexArrayToDevice(int _iProjectionCount, int _iDetectorCount,
                                 cufftComplex * _pHostComplexSource,
-                                cufftComplex * _pDevComplexTarget);
+                                cufftComplex * _pDevComplexTarget,
+                                std::optional<cudaStream_t> _stream = {});
 
 bool runCudaFFT(int _iProjectionCount, const float * D_pfSource,
                 int _iSourcePitch, int _iProjDets,
                 int _iPaddedSize,
-                cufftComplex * D_pcTarget);
+                cufftComplex * D_pcTarget,
+                std::optional<cudaStream_t> _stream = {});
 
 bool runCudaIFFT(int _iProjectionCount, const cufftComplex* D_pcSource,
                  float * D_pfTarget,
                  int _iTargetPitch, int _iProjDets,
-                 int _iPaddedSize);
+                 int _iPaddedSize,
+                 std::optional<cudaStream_t> _stream = {});
 
-void applyFilter(int _iProjectionCount, int _iFreqBinCount,
-                 cufftComplex * _pSinogram, cufftComplex * _pFilter);
+bool applyFilter(int _iProjectionCount, int _iFreqBinCount,
+                 cufftComplex * _pSinogram, cufftComplex * _pFilter,
+                 std::optional<cudaStream_t> _stream = {});
 
 void genCuFFTFilter(const astra::SFilterConfig &_cfg, int _iProjectionCount,
                    cufftComplex * _pFilter, int _iFFTRealDetectorCount,
@@ -65,8 +74,9 @@ void genCuFFTFilter(const astra::SFilterConfig &_cfg, int _iProjectionCount,
 void genIdenFilter(int _iProjectionCount, cufftComplex * _pFilter,
                    int _iFFTRealDetectorCount, int _iFFTFourierDetectorCount);
 
-void rescaleInverseFourier(int _iProjectionCount, int _iDetectorCount,
-                           float * _pfInFourierOutput);
+bool rescaleInverseFourier(int _iProjectionCount, int _iDetectorCount,
+                           float * _pfInFourierOutput,
+                           std::optional<cudaStream_t> _stream = {});
 
 }
 

--- a/include/astra/cuda/2d/util.h
+++ b/include/astra/cuda/2d/util.h
@@ -29,8 +29,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 #define _CUDA_UTIL_H
 
 #include <cuda.h>
-#include <driver_types.h>
 #include <string>
+#include <optional>
 
 #include "astra/Globals.h"
 
@@ -56,24 +56,69 @@ bool copySinogramToDevice(const float* in_data, unsigned int in_pitch,
 		float* outD_data, unsigned int out_pitch);
 
 bool allocateVolume(float*& D_ptr, unsigned int width, unsigned int height, unsigned int& pitch);
-bool zeroVolume(float* D_data, unsigned int pitch, unsigned int width, unsigned int height);
+bool zeroVolume(float* D_data, unsigned int pitch, unsigned int width, unsigned int height, std::optional<cudaStream_t> _stream = {});
 
 bool allocateVolumeData(float*& D_ptr, unsigned int& pitch, const SDimensions& dims);
 bool allocateProjectionData(float*& D_ptr, unsigned int& pitch, const SDimensions& dims);
-bool zeroVolumeData(float* D_ptr, unsigned int pitch, const SDimensions& dims);
-bool zeroProjectionData(float* D_ptr, unsigned int pitch, const SDimensions& dims);
+bool zeroVolumeData(float* D_ptr, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream = {});
+bool zeroProjectionData(float* D_ptr, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream = {});
 
-void duplicateVolumeData(float* D_dst, float* D_src, unsigned int pitch, const SDimensions& dims);
-void duplicateProjectionData(float* D_dst, float* D_src, unsigned int pitch, const SDimensions& dims);
+bool duplicateVolumeData(float* D_dst, float* D_src, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream = {});
+bool duplicateProjectionData(float* D_dst, float* D_src, unsigned int pitch, const SDimensions& dims, std::optional<cudaStream_t> _stream = {});
 
-bool createArrayAndTextureObject2D(float* data, cudaArray*& dataArray, cudaTextureObject_t& texObj, unsigned int pitch, unsigned int width, unsigned int height);
-bool createTextureObjectPitch2D(float* data, cudaTextureObject_t& texObj, unsigned int pitch, unsigned int width, unsigned int height, cudaTextureAddressMode mode = cudaAddressModeBorder);
+bool createArrayAndTextureObject2D(float* data, cudaArray*& dataArray, cudaTextureObject_t& texObj, unsigned int pitch, unsigned int width, unsigned int height, std::optional<cudaStream_t> _stream = {});
+bool createTextureObjectPitch2D(float* D_data, cudaTextureObject_t& texObj, unsigned int pitch, unsigned int width, unsigned int height, cudaTextureAddressMode mode = cudaAddressModeBorder);
 
 
 bool checkCuda(cudaError_t err, const char *msg);
 
 float dotProduct2D(float* D_data, unsigned int pitch,
-                   unsigned int width, unsigned int height);
+                   unsigned int width, unsigned int height,
+                   std::optional<cudaStream_t> _stream = {});
+
+
+// Helper class for functions taking a std::optional<cudaStream_t> argument.
+// If a stream isn't passed to us, create a new stream and destroy that in our destructor.
+class StreamHelper {
+public:
+	StreamHelper(std::optional<cudaStream_t> _stream) {
+		if (_stream) {
+			ok = true;
+			ownsStream = false;
+			stream = _stream.value();
+		} else {
+			ok = true;
+			ownsStream = true;
+			stream = 0;
+			ok &= checkCuda(cudaStreamCreate(&stream), "StreamHelper create");
+		}
+	}
+	~StreamHelper() {
+		if (ownsStream)
+			cudaStreamDestroy(stream);
+	}
+
+	cudaStream_t operator()() const { return stream; }
+
+	operator bool() const { return ok; }
+
+
+	// Sync on stream if not using an existing stream
+	bool syncIfSync(const char *msg) {
+		if (ownsStream)
+			return sync(msg);
+		else
+			return ok;
+	}
+	bool sync(const char *msg) {
+		ok &= checkCuda(cudaStreamSynchronize(stream), msg);
+		return ok;
+	}
+private:
+	bool ok;
+	bool ownsStream;
+	cudaStream_t stream;
+};
 
 }
 

--- a/include/astra/cuda/3d/arith3d.h
+++ b/include/astra/cuda/3d/arith3d.h
@@ -29,6 +29,7 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 #define _CUDA_ARITH3D_H
 
 #include <cuda.h>
+#include <optional>
 
 namespace astraCUDA3d {
 
@@ -45,19 +46,19 @@ struct opSet;
 struct opClampMin;
 struct opClampMax;
 
-template<typename op> void processVol3D(cudaPitchedPtr& out, const SDimensions3D& dims);
-template<typename op> void processVol3D(cudaPitchedPtr& out, float fParam, const SDimensions3D& dims);
-template<typename op> void processVol3D(cudaPitchedPtr& out, const cudaPitchedPtr& in, const SDimensions3D& dims);
-template<typename op> void processVol3D(cudaPitchedPtr& out, const cudaPitchedPtr& in, float fParam, const SDimensions3D& dims);
-template<typename op> void processVol3D(cudaPitchedPtr& out, const cudaPitchedPtr& in1, const cudaPitchedPtr& in2, float fParam, const SDimensions3D& dims);
-template<typename op> void processVol3D(cudaPitchedPtr& out, const cudaPitchedPtr& in1, const cudaPitchedPtr& in2, const SDimensions3D& dims);
+template<typename op> bool processVol3D(cudaPitchedPtr& out, const SDimensions3D& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processVol3D(cudaPitchedPtr& out, float fParam, const SDimensions3D& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processVol3D(cudaPitchedPtr& out, const cudaPitchedPtr& in, const SDimensions3D& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processVol3D(cudaPitchedPtr& out, const cudaPitchedPtr& in, float fParam, const SDimensions3D& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processVol3D(cudaPitchedPtr& out, const cudaPitchedPtr& in1, const cudaPitchedPtr& in2, float fParam, const SDimensions3D& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processVol3D(cudaPitchedPtr& out, const cudaPitchedPtr& in1, const cudaPitchedPtr& in2, const SDimensions3D& dims, std::optional<cudaStream_t> _stream = {});
 
-template<typename op> void processSino3D(cudaPitchedPtr& out, const SDimensions3D& dims);
-template<typename op> void processSino3D(cudaPitchedPtr& out, float fParam, const SDimensions3D& dims);
-template<typename op> void processSino3D(cudaPitchedPtr& out, const cudaPitchedPtr& in, const SDimensions3D& dims);
-template<typename op> void processSino3D(cudaPitchedPtr& out, const cudaPitchedPtr& in, float fParam, const SDimensions3D& dims);
-template<typename op> void processSino3D(cudaPitchedPtr& out, const cudaPitchedPtr& in1, const cudaPitchedPtr& in2, float fParam, const SDimensions3D& dims);
-template<typename op> void processSino3D(cudaPitchedPtr& out, const cudaPitchedPtr& in1, const cudaPitchedPtr& in2, const SDimensions3D& dims);
+template<typename op> bool processSino3D(cudaPitchedPtr& out, const SDimensions3D& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processSino3D(cudaPitchedPtr& out, float fParam, const SDimensions3D& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processSino3D(cudaPitchedPtr& out, const cudaPitchedPtr& in, const SDimensions3D& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processSino3D(cudaPitchedPtr& out, const cudaPitchedPtr& in, float fParam, const SDimensions3D& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processSino3D(cudaPitchedPtr& out, const cudaPitchedPtr& in1, const cudaPitchedPtr& in2, float fParam, const SDimensions3D& dims, std::optional<cudaStream_t> _stream = {});
+template<typename op> bool processSino3D(cudaPitchedPtr& out, const cudaPitchedPtr& in1, const cudaPitchedPtr& in2, const SDimensions3D& dims, std::optional<cudaStream_t> _stream = {});
 
 
 

--- a/include/astra/cuda/3d/arith3d.h
+++ b/include/astra/cuda/3d/arith3d.h
@@ -45,19 +45,6 @@ struct opSet;
 struct opClampMin;
 struct opClampMax;
 
-enum VolType {
-  SINO = 0,
-  VOL = 1
-};
-
-
-template<typename op, VolType t> void processVol(CUdeviceptr* out, unsigned int pitch, unsigned int width, unsigned int height);
-template<typename op, VolType t> void processVol(CUdeviceptr* out, float fParam, unsigned int pitch, unsigned int width, unsigned int height);
-template<typename op, VolType t> void processVol(CUdeviceptr* out, const CUdeviceptr* in, unsigned int pitch, unsigned int width, unsigned int height);
-template<typename op, VolType t> void processVol(CUdeviceptr* out, const CUdeviceptr* in, float fParam, unsigned int pitch, unsigned int width, unsigned int height);
-template<typename op, VolType t> void processVol(CUdeviceptr* out, const CUdeviceptr* in1, const CUdeviceptr* in2, float fParam, unsigned int pitch, unsigned int width, unsigned int height);
-template<typename op, VolType t> void processVol(CUdeviceptr* out, const CUdeviceptr* in1, const CUdeviceptr* in2, unsigned int pitch, unsigned int width, unsigned int height);
-
 template<typename op> void processVol3D(cudaPitchedPtr& out, const SDimensions3D& dims);
 template<typename op> void processVol3D(cudaPitchedPtr& out, float fParam, const SDimensions3D& dims);
 template<typename op> void processVol3D(cudaPitchedPtr& out, const cudaPitchedPtr& in, const SDimensions3D& dims);

--- a/include/astra/cuda/3d/util3d.h
+++ b/include/astra/cuda/3d/util3d.h
@@ -29,6 +29,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 #define _CUDA_UTIL3D_H
 
 #include <cuda.h>
+#include <optional>
+
 #include "dims3d.h"
 
 #ifndef M_PI
@@ -39,6 +41,8 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 namespace astraCUDA3d {
 
 using astraCUDA::checkCuda;
+using astraCUDA::TransferConstantsBuffer_t;
+using astraCUDA::StreamHelper;
 
 cudaPitchedPtr allocateVolumeData(const SDimensions3D& dims);
 cudaPitchedPtr allocateProjectionData(const SDimensions3D& dims);
@@ -52,9 +56,9 @@ bool duplicateVolumeData(cudaPitchedPtr& D_dest, const cudaPitchedPtr& D_src, co
 bool duplicateProjectionData(cudaPitchedPtr& D_dest, const cudaPitchedPtr& D_src, const SDimensions3D& dims); 
 
 
-bool transferProjectionsToArray(cudaPitchedPtr D_projData, cudaArray* array, const SDimensions3D& dims);
+bool transferProjectionsToArray(cudaPitchedPtr D_projData, cudaArray* array, const SDimensions3D& dims, std::optional<cudaStream_t> _stream = {});
 bool transferHostProjectionsToArray(const float *projData, cudaArray* array, const SDimensions3D& dims);
-bool transferVolumeToArray(cudaPitchedPtr D_volumeData, cudaArray* array, const SDimensions3D& dims);
+bool transferVolumeToArray(cudaPitchedPtr D_volumeData, cudaArray* array, const SDimensions3D& dims, std::optional<cudaStream_t> _stream = {});
 bool zeroProjectionArray(cudaArray* array, const SDimensions3D& dims);
 bool zeroVolumeArray(cudaArray* array, const SDimensions3D& dims);
 cudaArray* allocateProjectionArray(const SDimensions3D& dims);
@@ -114,7 +118,6 @@ static Vec3 scaled_cross3(const Vec3 &a, const Vec3 &b, const Vec3 &sc) {
 	ret.z *= sc.x * sc.y;
 	return ret;
 }
-
 
 }
 

--- a/src/CudaDataOperationAlgorithm.cpp
+++ b/src/CudaDataOperationAlgorithm.cpp
@@ -29,10 +29,7 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 #include "astra/CudaDataOperationAlgorithm.h"
 
-#include "astra/cuda/2d/algo.h"
-#include "astra/cuda/2d/darthelper.h"
 #include "astra/cuda/2d/astra.h"
-#include "astra/cuda/2d/arith.h"
 
 #include "astra/AstraObjectManager.h"
 


### PR DESCRIPTION
This adds stream support to CUDA utility functions, and improves various related things.

Many of them now take a `std::optional<cudaStream_t>` argument. If a stream is passed, the function will work on that stream, and might be asynchronous. If no stream is passed (which is the default), it will create its own stream, use that, and synchronize on that stream at the end of the function.

Using non-default streams everywhere prepares for using asynchronous memory transfers, and also will let the 'main' cuda functions use a single stream in the future. (These things are not part of this PR.)

Additionally, this is making more functions use similar code patterns and improves CUDA error handling.