### PR TITLE
Ensure that the vectors are 2D.

### DIFF
--- a/python/astra/pythonutils.py
+++ b/python/astra/pythonutils.py
@@ -56,8 +56,8 @@ def geom_size(geom, dim=None):
     elif geom['type'] == 'fanflat_vec' or geom['type'] == 'parallel_vec':
         s = (geom['Vectors'].shape[0], geom['DetectorCount'])
     elif geom['type'] == 'parallel3d_vec' or geom['type'] == 'cone_vec':
-        s = (geom['DetectorRowCount'], geom[
-             'Vectors'].shape[0], geom['DetectorColCount'])
+        s = (geom['DetectorRowCount'], np.atleast_2d(geom[
+             'Vectors']).shape[0], geom['DetectorColCount'])
 
     if dim != None:
         s = s[dim]


### PR DESCRIPTION
For some reason if you pass in vectors with a shape (1, 12) to reconstruct from a single image, the vectors array is flattened in data3d_c.pyx. It is easy to ensure that the input vectors array is the correct shape by applying this one line change.