### PR TITLE
Add support for DLPack arrays to data3d.link

### DIFF
--- a/build/linux/Makefile.in
+++ b/build/linux/Makefile.in
@@ -86,7 +86,7 @@ PYLIBDIR := $(shell $(PYTHON) -c 'from __future__ import print_function; from di
 PYLIBVER = `basename $(PYINCDIR)`
 CPPFLAGS += -DASTRA_PYTHON -I$(PYINCDIR)
 PYCPPFLAGS  := $(CPPFLAGS)
-PYCPPFLAGS  += -I../include
+PYCPPFLAGS  += -I../include -I../lib/include
 PYCXXFLAGS  := $(CXXFLAGS)
 
 # copy the current MODLDFLAGS to PYLDFLAGS, and then add flags for matlab/octave

--- a/include/astra/Data3D.h
+++ b/include/astra/Data3D.h
@@ -158,6 +158,7 @@ class _AstraExport CDataGPU : public CDataStorage {
 protected:
 	/** Handle for the memory block */
 	astraCUDA3d::MemHandle3D m_hnd;
+	CDataGPU() { }
 
 public:
 

--- a/lib/include/dlpack/dlpack.h
+++ b/lib/include/dlpack/dlpack.h
@@ -1,0 +1,332 @@
+/*!
+ *  Copyright (c) 2017 by Contributors
+ * \file dlpack.h
+ * \brief The common header of DLPack.
+ */
+#ifndef DLPACK_DLPACK_H_
+#define DLPACK_DLPACK_H_
+
+/**
+ * \brief Compatibility with C++
+ */
+#ifdef __cplusplus
+#define DLPACK_EXTERN_C extern "C"
+#else
+#define DLPACK_EXTERN_C
+#endif
+
+/*! \brief The current major version of dlpack */
+#define DLPACK_MAJOR_VERSION 1
+
+/*! \brief The current minor version of dlpack */
+#define DLPACK_MINOR_VERSION 0
+
+/*! \brief DLPACK_DLL prefix for windows */
+#ifdef _WIN32
+#ifdef DLPACK_EXPORTS
+#define DLPACK_DLL __declspec(dllexport)
+#else
+#define DLPACK_DLL __declspec(dllimport)
+#endif
+#else
+#define DLPACK_DLL
+#endif
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * \brief The DLPack version.
+ *
+ * A change in major version indicates that we have changed the
+ * data layout of the ABI - DLManagedTensorVersioned.
+ *
+ * A change in minor version indicates that we have added new
+ * code, such as a new device type, but the ABI is kept the same.
+ *
+ * If an obtained DLPack tensor has a major version that disagrees
+ * with the version number specified in this header file
+ * (i.e. major != DLPACK_MAJOR_VERSION), the consumer must call the deleter
+ * (and it is safe to do so). It is not safe to access any other fields
+ * as the memory layout will have changed.
+ *
+ * In the case of a minor version mismatch, the tensor can be safely used as
+ * long as the consumer knows how to interpret all fields. Minor version
+ * updates indicate the addition of enumeration values.
+ */
+typedef struct {
+  /*! \brief DLPack major version. */
+  uint32_t major;
+  /*! \brief DLPack minor version. */
+  uint32_t minor;
+} DLPackVersion;
+
+/*!
+ * \brief The device type in DLDevice.
+ */
+#ifdef __cplusplus
+typedef enum : int32_t {
+#else
+typedef enum {
+#endif
+  /*! \brief CPU device */
+  kDLCPU = 1,
+  /*! \brief CUDA GPU device */
+  kDLCUDA = 2,
+  /*!
+   * \brief Pinned CUDA CPU memory by cudaMallocHost
+   */
+  kDLCUDAHost = 3,
+  /*! \brief OpenCL devices. */
+  kDLOpenCL = 4,
+  /*! \brief Vulkan buffer for next generation graphics. */
+  kDLVulkan = 7,
+  /*! \brief Metal for Apple GPU. */
+  kDLMetal = 8,
+  /*! \brief Verilog simulator buffer */
+  kDLVPI = 9,
+  /*! \brief ROCm GPUs for AMD GPUs */
+  kDLROCM = 10,
+  /*!
+   * \brief Pinned ROCm CPU memory allocated by hipMallocHost
+   */
+  kDLROCMHost = 11,
+  /*!
+   * \brief Reserved extension device type,
+   * used for quickly test extension device
+   * The semantics can differ depending on the implementation.
+   */
+  kDLExtDev = 12,
+  /*!
+   * \brief CUDA managed/unified memory allocated by cudaMallocManaged
+   */
+  kDLCUDAManaged = 13,
+  /*!
+   * \brief Unified shared memory allocated on a oneAPI non-partititioned
+   * device. Call to oneAPI runtime is required to determine the device
+   * type, the USM allocation type and the sycl context it is bound to.
+   *
+   */
+  kDLOneAPI = 14,
+  /*! \brief GPU support for next generation WebGPU standard. */
+  kDLWebGPU = 15,
+  /*! \brief Qualcomm Hexagon DSP */
+  kDLHexagon = 16,
+  /*! \brief Microsoft MAIA devices */
+  kDLMAIA = 17,
+} DLDeviceType;
+
+/*!
+ * \brief A Device for Tensor and operator.
+ */
+typedef struct {
+  /*! \brief The device type used in the device. */
+  DLDeviceType device_type;
+  /*!
+   * \brief The device index.
+   * For vanilla CPU memory, pinned memory, or managed memory, this is set to 0.
+   */
+  int32_t device_id;
+} DLDevice;
+
+/*!
+ * \brief The type code options DLDataType.
+ */
+typedef enum {
+  /*! \brief signed integer */
+  kDLInt = 0U,
+  /*! \brief unsigned integer */
+  kDLUInt = 1U,
+  /*! \brief IEEE floating point */
+  kDLFloat = 2U,
+  /*!
+   * \brief Opaque handle type, reserved for testing purposes.
+   * Frameworks need to agree on the handle data type for the exchange to be well-defined.
+   */
+  kDLOpaqueHandle = 3U,
+  /*! \brief bfloat16 */
+  kDLBfloat = 4U,
+  /*!
+   * \brief complex number
+   * (C/C++/Python layout: compact struct per complex number)
+   */
+  kDLComplex = 5U,
+  /*! \brief boolean */
+  kDLBool = 6U,
+} DLDataTypeCode;
+
+/*!
+ * \brief The data type the tensor can hold. The data type is assumed to follow the
+ * native endian-ness. An explicit error message should be raised when attempting to
+ * export an array with non-native endianness
+ *
+ *  Examples
+ *   - float: type_code = 2, bits = 32, lanes = 1
+ *   - float4(vectorized 4 float): type_code = 2, bits = 32, lanes = 4
+ *   - int8: type_code = 0, bits = 8, lanes = 1
+ *   - std::complex<float>: type_code = 5, bits = 64, lanes = 1
+ *   - bool: type_code = 6, bits = 8, lanes = 1 (as per common array library convention, the underlying storage size of bool is 8 bits)
+ */
+typedef struct {
+  /*!
+   * \brief Type code of base types.
+   * We keep it uint8_t instead of DLDataTypeCode for minimal memory
+   * footprint, but the value should be one of DLDataTypeCode enum values.
+   * */
+  uint8_t code;
+  /*!
+   * \brief Number of bits, common choices are 8, 16, 32.
+   */
+  uint8_t bits;
+  /*! \brief Number of lanes in the type, used for vector types. */
+  uint16_t lanes;
+} DLDataType;
+
+/*!
+ * \brief Plain C Tensor object, does not manage memory.
+ */
+typedef struct {
+  /*!
+   * \brief The data pointer points to the allocated data. This will be CUDA
+   * device pointer or cl_mem handle in OpenCL. It may be opaque on some device
+   * types. This pointer is always aligned to 256 bytes as in CUDA. The
+   * `byte_offset` field should be used to point to the beginning of the data.
+   *
+   * Note that as of Nov 2021, multiply libraries (CuPy, PyTorch, TensorFlow,
+   * TVM, perhaps others) do not adhere to this 256 byte aligment requirement
+   * on CPU/CUDA/ROCm, and always use `byte_offset=0`.  This must be fixed
+   * (after which this note will be updated); at the moment it is recommended
+   * to not rely on the data pointer being correctly aligned.
+   *
+   * For given DLTensor, the size of memory required to store the contents of
+   * data is calculated as follows:
+   *
+   * \code{.c}
+   * static inline size_t GetDataSize(const DLTensor* t) {
+   *   size_t size = 1;
+   *   for (tvm_index_t i = 0; i < t->ndim; ++i) {
+   *     size *= t->shape[i];
+   *   }
+   *   size *= (t->dtype.bits * t->dtype.lanes + 7) / 8;
+   *   return size;
+   * }
+   * \endcode
+   *
+   * Note that if the tensor is of size zero, then the data pointer should be
+   * set to `NULL`.
+   */
+  void* data;
+  /*! \brief The device of the tensor */
+  DLDevice device;
+  /*! \brief Number of dimensions */
+  int32_t ndim;
+  /*! \brief The data type of the pointer*/
+  DLDataType dtype;
+  /*! \brief The shape of the tensor */
+  int64_t* shape;
+  /*!
+   * \brief strides of the tensor (in number of elements, not bytes)
+   *  can be NULL, indicating tensor is compact and row-majored.
+   */
+  int64_t* strides;
+  /*! \brief The offset in bytes to the beginning pointer to data */
+  uint64_t byte_offset;
+} DLTensor;
+
+/*!
+ * \brief C Tensor object, manage memory of DLTensor. This data structure is
+ *  intended to facilitate the borrowing of DLTensor by another framework. It is
+ *  not meant to transfer the tensor. When the borrowing framework doesn't need
+ *  the tensor, it should call the deleter to notify the host that the resource
+ *  is no longer needed.
+ *
+ * \note This data structure is used as Legacy DLManagedTensor
+ *       in DLPack exchange and is deprecated after DLPack v0.8
+ *       Use DLManagedTensorVersioned instead.
+ *       This data structure may get renamed or deleted in future versions.
+ *
+ * \sa DLManagedTensorVersioned
+ */
+typedef struct DLManagedTensor {
+  /*! \brief DLTensor which is being memory managed */
+  DLTensor dl_tensor;
+  /*! \brief the context of the original host framework of DLManagedTensor in
+   *   which DLManagedTensor is used in the framework. It can also be NULL.
+   */
+  void * manager_ctx;
+  /*!
+   * \brief Destructor - this should be called
+   * to destruct the manager_ctx  which backs the DLManagedTensor. It can be
+   * NULL if there is no way for the caller to provide a reasonable destructor.
+   * The destructor deletes the argument self as well.
+   */
+  void (*deleter)(struct DLManagedTensor * self);
+} DLManagedTensor;
+
+// bit masks used in in the DLManagedTensorVersioned
+
+/*! \brief bit mask to indicate that the tensor is read only. */
+#define DLPACK_FLAG_BITMASK_READ_ONLY (1UL << 0UL)
+
+/*!
+ * \brief bit mask to indicate that the tensor is a copy made by the producer.
+ *
+ * If set, the tensor is considered solely owned throughout its lifetime by the
+ * consumer, until the producer-provided deleter is invoked.
+ */
+#define DLPACK_FLAG_BITMASK_IS_COPIED (1UL << 1UL)
+
+/*!
+ * \brief A versioned and managed C Tensor object, manage memory of DLTensor.
+ *
+ * This data structure is intended to facilitate the borrowing of DLTensor by
+ * another framework. It is not meant to transfer the tensor. When the borrowing
+ * framework doesn't need the tensor, it should call the deleter to notify the
+ * host that the resource is no longer needed.
+ *
+ * \note This is the current standard DLPack exchange data structure.
+ */
+struct DLManagedTensorVersioned {
+  /*!
+   * \brief The API and ABI version of the current managed Tensor
+   */
+  DLPackVersion version;
+  /*!
+   * \brief the context of the original host framework.
+   *
+   * Stores DLManagedTensorVersioned is used in the
+   * framework. It can also be NULL.
+   */
+  void *manager_ctx;
+  /*!
+   * \brief Destructor.
+   *
+   * This should be called to destruct manager_ctx which holds the DLManagedTensorVersioned.
+   * It can be NULL if there is no way for the caller to provide a reasonable
+   * destructor. The destructor deletes the argument self as well.
+   */
+  void (*deleter)(struct DLManagedTensorVersioned *self);
+  /*!
+   * \brief Additional bitmask flags information about the tensor.
+   *
+   * By default the flags should be set to 0.
+   *
+   * \note Future ABI changes should keep everything until this field
+   *       stable, to ensure that deleter can be correctly called.
+   *
+   * \sa DLPACK_FLAG_BITMASK_READ_ONLY
+   * \sa DLPACK_FLAG_BITMASK_IS_COPIED
+   */
+  uint64_t flags;
+  /*! \brief DLTensor which is being memory managed */
+  DLTensor dl_tensor;
+};
+
+#ifdef __cplusplus
+}  // DLPACK_EXTERN_C
+#endif
+#endif  // DLPACK_DLPACK_H_

--- a/lib/licenses/dlpack.txt
+++ b/lib/licenses/dlpack.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017 by Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/python/astra/CFloat32CustomPython.h
+++ b/python/astra/CFloat32CustomPython.h
@@ -31,30 +31,3 @@ public:
 private:
     PyArrayObject* arr;
 };
-
-template<typename T>
-class CDataStoragePython : public astra::CDataMemory<T> {
-public:
-    CDataStoragePython(PyArrayObject *arrIn)
-    {
-        GILHelper gil; // hold GIL during this function
-
-        arr = arrIn;
-        // Set pointer to numpy data pointer
-        this->m_pfData = (T *)PyArray_DATA(arr);
-        // Increase reference count since ASTRA has a reference
-        Py_INCREF(arr);
-    }
-    virtual ~CDataStoragePython() {
-        GILHelper gil; // hold GIL during this function
-
-        // Decrease reference count since ASTRA object is destroyed
-        Py_DECREF(arr);
-
-        this->m_pfData = nullptr;
-    }
-
-
-private:
-    PyArrayObject* arr;
-};

--- a/python/astra/CFloat32CustomPython.h
+++ b/python/astra/CFloat32CustomPython.h
@@ -1,7 +1,21 @@
+class GILHelper {
+public:
+    GILHelper() {
+        state = PyGILState_Ensure();
+    }
+    ~GILHelper() {
+        PyGILState_Release(state);
+    }
+private:
+    PyGILState_STATE state;
+};
+
 class CFloat32CustomPython : public astra::CFloat32CustomMemory {
 public:
     CFloat32CustomPython(PyArrayObject * arrIn)
     {
+        GILHelper gil; // hold GIL during this function
+
         arr = arrIn;
         // Set pointer to numpy data pointer
         m_fPtr = (float *)PyArray_DATA(arr);
@@ -9,6 +23,8 @@ public:
         Py_INCREF(arr);
     }
     virtual ~CFloat32CustomPython() {
+        GILHelper gil; // hold GIL during this function
+
         // Decrease reference count since ASTRA object is destroyed
         Py_DECREF(arr);
     }
@@ -21,6 +37,8 @@ class CDataStoragePython : public astra::CDataMemory<T> {
 public:
     CDataStoragePython(PyArrayObject *arrIn)
     {
+        GILHelper gil; // hold GIL during this function
+
         arr = arrIn;
         // Set pointer to numpy data pointer
         this->m_pfData = (T *)PyArray_DATA(arr);
@@ -28,6 +46,8 @@ public:
         Py_INCREF(arr);
     }
     virtual ~CDataStoragePython() {
+        GILHelper gil; // hold GIL during this function
+
         // Decrease reference count since ASTRA object is destroyed
         Py_DECREF(arr);
 

--- a/python/astra/data2d.py
+++ b/python/astra/data2d.py
@@ -26,7 +26,6 @@
 from . import data2d_c as d
 from .pythonutils import checkArrayForLink
 
-import numpy as np
 
 def clear():
     """Clear all 2D data objects."""
@@ -34,16 +33,16 @@ def clear():
 
 def delete(ids):
     """Delete a 2D object.
-    
+
     :param ids: ID or list of ID's to delete.
     :type ids: :class:`int` or :class:`list`
-    
+
     """
     return d.delete(ids)
 
 def create(datatype, geometry, data=None):
     """Create a 2D object.
-        
+
     :param datatype: Data object type, '-vol' or '-sino'.
     :type datatype: :class:`string`
     :param geometry: Volume or projection geometry.
@@ -51,13 +50,13 @@ def create(datatype, geometry, data=None):
     :param data: Data to fill the constructed object with, either a scalar or array.
     :type data: :class:`float` or :class:`numpy.ndarray`
     :returns: :class:`int` -- the ID of the constructed object.
-    
+
     """
     return d.create(datatype,geometry,data)
 
 def link(datatype, geometry, data):
     """Link a 2D numpy array with the toolbox.
-        
+
     :param datatype: Data object type, '-vol' or '-sino'.
     :type datatype: :class:`string`
     :param geometry: Volume or projection geometry.
@@ -65,71 +64,71 @@ def link(datatype, geometry, data):
     :param data: Numpy array to link
     :type data: :class:`numpy.ndarray`
     :returns: :class:`int` -- the ID of the constructed object.
-    
+
     """
     checkArrayForLink(data)
     return d.create(datatype,geometry,data,True)
 
 def store(i, data):
     """Fill existing 2D object with data.
-    
+
     :param i: ID of object to fill.
     :type i: :class:`int`
     :param data: Data to fill the object with, either a scalar or array.
     :type data: :class:`float` or :class:`numpy.ndarray`
-    
+
     """
     return d.store(i, data)
-    
+
 def get_geometry(i):
     """Get the geometry of a 2D object.
-    
+
     :param i: ID of object.
     :type i: :class:`int`
     :returns: :class:`dict` -- The geometry of object with ID ``i``.
-    
+
     """
     return d.get_geometry(i)
 
 def change_geometry(i, geom):
     """Change the geometry of a 2D object.
-    
+
     :param i: ID of object.
     :type i: :class:`int`
     :param geom: new geometry.
     :type geom: :class:`dict`
-    
+
     """
     return d.change_geometry(i, geom)
-    
+
 def get(i):
     """Get a 2D object.
-    
+
     :param i: ID of object to get.
     :type i: :class:`int`
     :returns: :class:`numpy.ndarray` -- The object data.
-    
+
     """
     return d.get(i)
 
 def get_shared(i):
     """Get a 2D object with memory shared between the ASTRA toolbox and numpy array.
-    
+
     :param i: ID of object to get.
     :type i: :class:`int`
     :returns: :class:`numpy.ndarray` -- The object data.
-    
+
     """
     return d.get_shared(i)
 
 
 def get_single(i):
     """Get a 2D object in single precision.
-    
+
     :param i: ID of object to get.
     :type i: :class:`int`
     :returns: :class:`numpy.ndarray` -- The object data.
-    
+
     """
     return d.get_single(i)
 

--- a/python/astra/data3d.py
+++ b/python/astra/data3d.py
@@ -43,7 +43,8 @@ def create(datatype,geometry,data=None):
     return d.create(datatype,geometry,data)
 
 def link(datatype, geometry, data):
-    """Link a 3D numpy array with the toolbox.
+    """Link a 3D array with ASTRA from another library supporting dlpack,
+    such as numpy or pytorch.
         
     :param datatype: Data object type, '-vol' or '-sino'.
     :type datatype: :class:`string`
@@ -54,10 +55,6 @@ def link(datatype, geometry, data):
     :returns: :class:`int` -- the ID of the constructed object.
     
     """
-    if not isinstance(data,np.ndarray) and not isinstance(data,GPULink):
-        raise TypeError("Input should be a numpy.ndarray or GPULink object")
-    if isinstance(data, np.ndarray):
-        checkArrayForLink(data)
     return d.create(datatype,geometry,data,True)
 
 

--- a/python/astra/data3d.py
+++ b/python/astra/data3d.py
@@ -24,9 +24,7 @@
 # -----------------------------------------------------------------------
 
 from . import data3d_c as d
-import numpy as np
 
-from .pythonutils import GPULink, checkArrayForLink
 
 def create(datatype,geometry,data=None):
     """Create a 3D object.

--- a/python/astra/data3d.py
+++ b/python/astra/data3d.py
@@ -45,15 +45,15 @@ def create(datatype,geometry,data=None):
 def link(datatype, geometry, data):
     """Link a 3D array with ASTRA from another library supporting dlpack,
     such as numpy or pytorch.
-        
+
     :param datatype: Data object type, '-vol' or '-sino'.
     :type datatype: :class:`string`
     :param geometry: Volume or projection geometry.
     :type geometry: :class:`dict`
-    :param data: Numpy array to link
-    :type data: :class:`numpy.ndarray`
-    :returns: :class:`int` -- the ID of the constructed object.
-    
+    :param data: Array to link. Needs to implement the dlpack protocol.
+    :type data: :class:`object`
+    :returns: :class:`int` -- the ID assigned to the linked object.
+
     """
     return d.create(datatype,geometry,data,True)
 
@@ -61,7 +61,7 @@ def link(datatype, geometry, data):
 def get(i):
     """Get a 3D object.
 
-    :param i: ID of object to get.
+    :param i: ID of object to get. Linked GPU arrays are not supported.
     :type i: :class:`int`
     :returns: :class:`numpy.ndarray` -- The object data.
 
@@ -71,7 +71,7 @@ def get(i):
 def get_shared(i):
     """Get a 3D object with memory shared between the ASTRA toolbox and numpy array.
 
-    :param i: ID of object to get.
+    :param i: ID of object to get. Linked GPU arrays are not supported.
     :type i: :class:`int`
     :returns: :class:`numpy.ndarray` -- The object data.
 
@@ -81,7 +81,7 @@ def get_shared(i):
 def get_single(i):
     """Get a 3D object in single precision.
 
-    :param i: ID of object to get.
+    :param i: ID of object to get. Linked GPU arrays are not supported.
     :type i: :class:`int`
     :returns: :class:`numpy.ndarray` -- The object data.
 
@@ -91,7 +91,7 @@ def get_single(i):
 def store(i,data):
     """Fill existing 3D object with data.
 
-    :param i: ID of object to fill.
+    :param i: ID of object to fill. Linked GPU arrays are not supported.
     :type i: :class:`int`
     :param data: Data to fill the object with, either a scalar or array.
     :type data: :class:`float` or :class:`numpy.ndarray`

--- a/python/astra/data3d_c.pyx
+++ b/python/astra/data3d_c.pyx
@@ -68,18 +68,6 @@ def create(datatype,geometry,data=None, link=False):
     cdef unique_ptr[CProjectionGeometry3D] ppGeometry
     cdef CData3D * pDataObject3D
 
-    if link:
-        geom_shape = geom_size(geometry)
-        if isinstance(data, np.ndarray):
-            data_shape = data.shape
-        elif isinstance(data, GPULink):
-            data_shape = ( data.z, data.y, data.x )
-        else:
-            raise TypeError("data should be a numpy.ndarray or a GPULink object")
-        if geom_shape != data_shape:
-            raise ValueError("The dimensions of the data {} do not match those "
-                             "specified in the geometry {}".format(data_shape, geom_shape))
-
     if datatype == '-vol':
         pGeometry = createVolumeGeometry3D(geometry)
         if link:

--- a/python/astra/matlab.py
+++ b/python/astra/matlab.py
@@ -41,7 +41,6 @@ from . import data3d_c
 from . import projector_c
 from . import algorithm_c
 from . import matrix_c
-import numpy as np
 
 
 def astra(command, *args):

--- a/python/astra/src/dlpack.cpp
+++ b/python/astra/src/dlpack.cpp
@@ -26,8 +26,7 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-// TODO: fix include paths
-#include "../../lib/include/dlpack/dlpack.h"
+#include "dlpack/dlpack.h"
 
 #include "astra/Data3D.h"
 

--- a/python/astra/src/dlpack.cpp
+++ b/python/astra/src/dlpack.cpp
@@ -245,6 +245,11 @@ astra::CDataStorage *getDLTensorStorage(PyObject *obj, std::array<int, 3> dims, 
 			return nullptr;
 		}
 
+		// NB: We ignore the DLPACK_FLAG_BITMASK_IS_COPIED flag.
+		// If we ever add explicit support for differentiating between
+		// input and output objects, we may want to return an error
+		// when using a copied tensor for output.
+
 		storage = getDLTensorStorage(tensor_m, dims, error);
 		if (storage) {
 			// All checks passed, so we can officially consume this dltensor

--- a/python/astra/src/dlpack.cpp
+++ b/python/astra/src/dlpack.cpp
@@ -1,0 +1,274 @@
+/*
+-----------------------------------------------------------------------
+Copyright: 2010-2022, imec Vision Lab, University of Antwerp
+           2014-2022, CWI, Amsterdam
+
+Contact: astra@astra-toolbox.com
+Website: http://www.astra-toolbox.com/
+
+This file is part of the ASTRA Toolbox.
+
+
+The ASTRA Toolbox is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The ASTRA Toolbox is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
+
+-----------------------------------------------------------------------
+*/
+
+
+// TODO: fix include paths
+#include "../../lib/include/dlpack/dlpack.h"
+
+#include "astra/Data3D.h"
+
+#include <Python.h>
+#include <cstdio>
+
+template<class DLT>
+class CDataStorageDLPackCPU : public astra::CDataMemory<float> {
+public:
+	CDataStorageDLPackCPU(DLT *tensor);
+	virtual ~CDataStorageDLPackCPU();
+
+protected:
+	DLT *m_pTensor;
+
+};
+
+#ifdef ASTRA_CUDA
+template<class DLT>
+class CDataStorageDLPackGPU : public astra::CDataGPU {
+public:
+	CDataStorageDLPackGPU(DLT* tensor);
+	virtual ~CDataStorageDLPackGPU();
+
+protected:
+	DLT *m_pTensor;
+};
+#endif
+
+template<class DLT>
+CDataStorageDLPackCPU<DLT>::CDataStorageDLPackCPU(DLT *tensor_m)
+	: m_pTensor(tensor_m)
+{
+	// We assume all sanity checks have already been done
+
+	uint8_t* data = static_cast<uint8_t*>(m_pTensor->dl_tensor.data);
+	data += m_pTensor->dl_tensor.byte_offset;
+
+	this->m_pfData = reinterpret_cast<float*>(data);
+}
+
+template<class DLT>
+CDataStorageDLPackCPU<DLT>::~CDataStorageDLPackCPU()
+{
+	if (m_pTensor) {
+		assert(m_pTensor->deleter);
+		m_pTensor->deleter(m_pTensor);
+	}
+	m_pTensor = nullptr;
+
+	// Prevent the parent destructor from deleting this memory
+	m_pfData = nullptr;
+}
+
+#ifdef ASTRA_CUDA
+template<class DLT>
+CDataStorageDLPackGPU<DLT>::CDataStorageDLPackGPU(DLT *tensor_m)
+	: m_pTensor(tensor_m)
+{
+	DLTensor *tensor = &m_pTensor->dl_tensor;
+
+	uint8_t* data = static_cast<uint8_t*>(tensor->data);
+	data += tensor->byte_offset;
+
+	unsigned int pitch = tensor->shape[0];
+	if (tensor->strides)
+		pitch = tensor->strides[1];
+
+	m_hnd = astraCUDA3d::wrapHandle(reinterpret_cast<float*>(data), tensor->shape[2], tensor->shape[1], tensor->shape[0], pitch);
+}
+
+
+template<class DLT>
+CDataStorageDLPackGPU<DLT>::~CDataStorageDLPackGPU()
+{
+	if (m_pTensor) {
+		assert(m_pTensor->deleter);
+		m_pTensor->deleter(m_pTensor);
+	}
+	m_pTensor = nullptr;
+}
+#endif
+
+
+bool checkDLTensor(DLTensor *tensor, std::array<int, 3> dims, bool allowPitch, std::string &error)
+{
+	// data type
+	if (tensor->dtype.code != kDLFloat || tensor->dtype.bits != 32)
+	{
+		error = "Data must be float32";
+		return false;
+	}
+	if (tensor->dtype.lanes != 1) {
+		error = "Data must be single-channel";
+		return false;
+	}
+
+	// shape
+	if (tensor->ndim != 3) {
+		error = "Data must be three-dimensional";
+		return false;
+	}
+
+	if (tensor->shape[0] != dims[2] || tensor->shape[1] != dims[1] ||
+	    tensor->shape[2] != dims[0])
+	{
+		error = astra::StringUtil::format("Data shape (%zd x %zd x %zd) does not match geometry (%d x %d x %d)", tensor->shape[0], tensor->shape[1], tensor->shape[2], dims[2], dims[1], dims[0]);
+		return false;
+	}
+
+	if (tensor->strides) {
+		int64_t acc = 1;
+		for (int i = tensor->ndim-1; i >= 0; --i) {
+			// We don't check this for dimensions where the shape is 1.
+			// There the stride is not relevant, and torch can set it to 1.
+			if (tensor->shape[i] >= 2 && tensor->strides[i] != acc) {
+				if (allowPitch)
+					error = "Data must be contiguous in all dimensions except first";
+				else
+					error = "Data must be contiguous";
+				return false;
+			}
+			if (i == tensor->ndim-1 && allowPitch) {
+				// allow different stride in x. This stride
+				// will be the first valid stride for a lower
+				// axis
+				int j = i-1;
+				while (j >= 0 && tensor->shape[j] < 2)
+					--j;
+				acc *= tensor->strides[j];
+			} else
+				acc *= tensor->shape[i];
+		}
+	}
+
+	error = "";
+	return true;
+}
+
+
+template<class DLT>
+astra::CDataStorage *getDLTensorStorage(DLT *tensor_m, std::array<int, 3> dims, std::string &error)
+{
+	DLTensor *tensor = &tensor_m->dl_tensor;
+
+	switch (tensor->device.device_type) {
+	case kDLCPU:
+	case kDLCUDAHost:
+		if (!checkDLTensor(tensor, dims, false, error))
+			return nullptr;
+		return new CDataStorageDLPackCPU(tensor_m);
+#ifdef ASTRA_CUDA
+	case kDLCUDA:
+	case kDLCUDAManaged:
+		if (!checkDLTensor(tensor, dims, true, error))
+			return nullptr;
+		return new CDataStorageDLPackGPU(tensor_m);
+#endif
+	default:
+		error = "Unsupported dlpack device type";
+		return nullptr;
+	}
+}
+
+astra::CDataStorage *getDLTensorStorage(PyObject *obj, std::array<int, 3> dims, std::string &error)
+{
+	if (!PyCapsule_CheckExact(obj)) {
+		error = "Invalid capsule";
+		return nullptr;
+	}
+
+	astra::CDataStorage *storage = nullptr;
+
+	if (PyCapsule_IsValid(obj, "dltensor")) {
+		// DLPack pre-1.0 unversioned interface
+		void *ptr = PyCapsule_GetPointer(obj, "dltensor");
+		if (!ptr) {
+			error = "Invalid dlpack capsule";
+			return nullptr;
+		}
+		DLManagedTensor *tensor_m = static_cast<DLManagedTensor*>(ptr);
+		storage = getDLTensorStorage(tensor_m, dims, error);
+
+		if (storage) {
+			// All checks passed, so we can officially consume this dltensor
+			PyCapsule_SetName(obj, "used_dltensor");
+		}
+
+	} else if (PyCapsule_IsValid(obj, "dltensor_versioned")) {
+		// DLPack 1.0 versioned interface
+		void *ptr = PyCapsule_GetPointer(obj, "dltensor_versioned");
+		if (!ptr) {
+			error = "Invalid dlpack capsule";
+			return nullptr;
+		}
+		DLManagedTensorVersioned *tensor_m = static_cast<DLManagedTensorVersioned*>(ptr);
+
+		if (tensor_m->version.major > 1) {
+			error = astra::StringUtil::format("Unsupported dlpack version %d.%d", tensor_m->version.major, tensor_m->version.minor);
+			return nullptr;
+		}
+
+		// TODO: handle read-only and copy flags
+		if (tensor_m->flags)
+			printf("unhandled flags: %zx\n", tensor_m->flags);
+
+		storage = getDLTensorStorage(tensor_m, dims, error);
+		if (storage) {
+			// All checks passed, so we can officially consume this dltensor
+			PyCapsule_SetName(obj, "used_dltensor_versioned");
+		}
+	}
+
+	return storage;
+}
+
+astra::CFloat32VolumeData3D* getDLTensor(PyObject *obj, const astra::CVolumeGeometry3D &pGeom, std::string &error)
+{
+	if (!PyCapsule_CheckExact(obj))
+		return nullptr;
+
+	// x,y,z
+	std::array<int, 3> dims{pGeom.getGridColCount(), pGeom.getGridRowCount(), pGeom.getGridSliceCount()};
+
+	astra::CDataStorage *storage = getDLTensorStorage(obj, dims, error);
+	if (!storage)
+		return nullptr;
+
+	return new astra::CFloat32VolumeData3D(pGeom, storage);
+}
+astra::CFloat32ProjectionData3D* getDLTensor(PyObject *obj, const astra::CProjectionGeometry3D &pGeom, std::string &error)
+{
+	if (!PyCapsule_CheckExact(obj))
+		return nullptr;
+
+	// x,y,z
+	std::array<int, 3> dims{pGeom.getDetectorColCount(), pGeom.getProjectionCount(), pGeom.getDetectorRowCount()};
+
+	astra::CDataStorage *storage = getDLTensorStorage(obj, dims, error);
+	if (!storage)
+		return nullptr;
+
+	return new astra::CFloat32ProjectionData3D(pGeom, storage);
+}

--- a/python/astra/src/dlpack.cpp
+++ b/python/astra/src/dlpack.cpp
@@ -230,9 +230,10 @@ astra::CDataStorage *getDLTensorStorage(PyObject *obj, std::array<int, 3> dims, 
 			return nullptr;
 		}
 
-		// TODO: handle read-only and copy flags
-		if (tensor_m->flags)
-			printf("unhandled flags: %zx\n", tensor_m->flags);
+		if (tensor_m->flags & DLPACK_FLAG_BITMASK_READ_ONLY) {
+			error = "Read-only dlpack tensor was provided";
+			return nullptr;
+		}
 
 		storage = getDLTensorStorage(tensor_m, dims, error);
 		if (storage) {

--- a/python/astra/src/dlpack.h
+++ b/python/astra/src/dlpack.h
@@ -1,0 +1,42 @@
+/*
+-----------------------------------------------------------------------
+Copyright: 2010-2022, imec Vision Lab, University of Antwerp
+           2014-2022, CWI, Amsterdam
+
+Contact: astra@astra-toolbox.com
+Website: http://www.astra-toolbox.com/
+
+This file is part of the ASTRA Toolbox.
+
+
+The ASTRA Toolbox is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The ASTRA Toolbox is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
+
+-----------------------------------------------------------------------
+*/
+
+#ifndef ASTRA_PYTHON_SRC_DLPACK_H
+#define ASTRA_PYTHON_SRC_DLPACK_H
+
+namespace astra {
+	class CFloat32VolumeData3D;
+	class CVolumeGeometry3D;
+	class CFloat32ProjectionData3D;
+	class CProjectionGeometry3D;
+}
+
+astra::CFloat32ProjectionData3D* getDLTensor(PyObject *obj, const astra::CProjectionGeometry3D &pGeom, std::string &error);
+astra::CFloat32VolumeData3D* getDLTensor(PyObject *obj, const astra::CVolumeGeometry3D &pGeom, std::string &error);
+void dump_dltensor_info(PyObject *obj);
+
+#endif

--- a/python/astra/utils.pyx
+++ b/python/astra/utils.pyx
@@ -45,10 +45,6 @@ from .PyIncludes cimport *
 from .pythonutils import GPULink, checkArrayForLink
 from .log import AstraError
 
-cdef extern from "CFloat32CustomPython.h":
-    cdef cppclass CDataStoragePython[T](CDataMemory[T]):
-        CDataStoragePython(np.ndarray arrIn)
-
 cdef extern from "Python.h":
     void* PyLong_AsVoidPtr(object)
 

--- a/python/astra/utils.pyx
+++ b/python/astra/utils.pyx
@@ -35,6 +35,7 @@ from libcpp.vector cimport vector
 from libcpp.list cimport list
 from libcpp.utility cimport move
 from cython.operator cimport dereference as deref, preincrement as inc
+from cpython.pycapsule cimport PyCapsule_IsValid
 
 from . cimport PyXMLDocument
 from .PyXMLDocument cimport XMLDocument
@@ -53,6 +54,10 @@ cdef extern from "Python.h":
 
 cdef extern from *:
     XMLConfig* dynamic_cast_XMLConfig "dynamic_cast<astra::XMLConfig*>" (Config*)
+
+cdef extern from "src/dlpack.h":
+    CFloat32VolumeData3D* getDLTensor(obj, const CVolumeGeometry3D &pGeom, string &error)
+    CFloat32ProjectionData3D* getDLTensor(obj, const CProjectionGeometry3D &pGeom, string &error)
 
 
 
@@ -232,63 +237,90 @@ cdef XMLNode2dict(XMLNode node):
     if len(opts)>0: dct['options'] = opts
     return dct
 
+def getDLPackCapsule(data):
+    # backward compatibility: check if the object is a dltensor capsule already
+    if PyCapsule_IsValid(data, "dltensor"):
+        return data
+    if not hasattr(data, "__dlpack__"):
+        return None
+    capsule = None
+    # TODO: investigate the stream argument to __dlpack__().
+    try:
+        capsule = data.__dlpack__(max_version = (1,0))
+    except AttributeError:
+        return None
+    except TypeError:
+        # unsupported max_version argument raises a TypeError
+        pass
+    if capsule is not None:
+        return capsule
+
+    try:
+        capsule = data.__dlpack__()
+    except AttributeError:
+        return None
+    return capsule
+
 cdef CFloat32VolumeData3D* linkVolFromGeometry(const CVolumeGeometry3D &pGeometry, data) except NULL:
     cdef CFloat32VolumeData3D * pDataObject3D = NULL
     cdef CDataStorage * pStorage
-    geom_shape = (pGeometry.getGridSliceCount(), pGeometry.getGridRowCount(), pGeometry.getGridColCount())
-    if isinstance(data, np.ndarray):
-        data_shape = data.shape
-    elif isinstance(data, GPULink):
-        data_shape = (data.z, data.y, data.x)
-    if geom_shape != data_shape:
-        raise ValueError("The dimensions of the data {} do not match those "
-                         "specified in the geometry {}".format(data_shape, geom_shape))
+    cdef string dlerror = b""
 
-    if isinstance(data, np.ndarray):
-        checkArrayForLink(data)
-        if data.dtype == np.float32:
-            pStorage = new CDataStoragePython[float32](data)
-        else:
-            raise NotImplementedError("Unknown data type for link")
-    elif isinstance(data, GPULink):
+    # TODO: investigate the stream argument to __dlpack__().
+    capsule = getDLPackCapsule(data)
+    if capsule is not None:
+        pDataObject3D = getDLTensor(capsule, pGeometry, dlerror)
+        if not pDataObject3D:
+            raise ValueError("Failed to link dlpack array: " + wrap_from_bytes(dlerror))
+        return pDataObject3D
+
+    if isinstance(data, GPULink):
+        geom_shape = (pGeometry.getGridSliceCount(), pGeometry.getGridRowCount(), pGeometry.getGridColCount())
+        data_shape = (data.z, data.y, data.x)
+        if geom_shape != data_shape:
+            raise ValueError("The dimensions of the data {} do not match those "
+                             "specified in the geometry {}".format(data_shape, geom_shape))
+
         IF HAVE_CUDA==True:
             hnd = wrapHandle(<float*>PyLong_AsVoidPtr(data.ptr), data.x, data.y, data.z, data.pitch/4)
             pStorage = new CDataGPU(hnd)
         ELSE:
             raise AstraError("CUDA support is not enabled in ASTRA")
-    else:
-        raise TypeError("data should be a numpy.ndarray or a GPULink object")
-    pDataObject3D = new CFloat32VolumeData3D(pGeometry, pStorage)
-    return pDataObject3D
+        pDataObject3D = new CFloat32VolumeData3D(pGeometry, pStorage)
+        return pDataObject3D
+
+    raise TypeError("Data should be an array with DLPack support, or a GPULink object")
+
 
 cdef CFloat32ProjectionData3D* linkProjFromGeometry(const CProjectionGeometry3D &pGeometry, data) except NULL:
     cdef CFloat32ProjectionData3D * pDataObject3D = NULL
     cdef CDataStorage * pStorage
-    geom_shape = (pGeometry.getDetectorRowCount(), pGeometry.getProjectionCount(), pGeometry.getDetectorColCount())
-    if isinstance(data, np.ndarray):
-        data_shape = data.shape
-    elif isinstance(data, GPULink):
-        data_shape = (data.z, data.y, data.x)
-    if geom_shape != data_shape:
-        raise ValueError("The dimensions of the data {} do not match those "
-                         "specified in the geometry {}".format(data_shape, geom_shape))
+    cdef string dlerror = b""
 
-    if isinstance(data, np.ndarray):
-        checkArrayForLink(data)
-        if data.dtype == np.float32:
-            pStorage = new CDataStoragePython[float32](data)
-        else:
-            raise NotImplementedError("Unknown data type for link")
-    elif isinstance(data, GPULink):
+    # TODO: investigate the stream argument to __dlpack__().
+    capsule = getDLPackCapsule(data)
+    if capsule is not None:
+        pDataObject3D = getDLTensor(capsule, pGeometry, dlerror)
+        if not pDataObject3D:
+            raise ValueError("Failed to link dlpack array: " + wrap_from_bytes(dlerror))
+        return pDataObject3D
+
+    if isinstance(data, GPULink):
+        geom_shape = (pGeometry.getDetectorRowCount(), pGeometry.getProjectionCount(), pGeometry.getDetectorColCount())
+        data_shape = (data.z, data.y, data.x)
+        if geom_shape != data_shape:
+            raise ValueError("The dimensions of the data {} do not match those "
+                             "specified in the geometry {}".format(data_shape, geom_shape))
+
         IF HAVE_CUDA==True:
             hnd = wrapHandle(<float*>PyLong_AsVoidPtr(data.ptr), data.x, data.y, data.z, data.pitch/4)
             pStorage = new CDataGPU(hnd)
         ELSE:
             raise AstraError("CUDA support is not enabled in ASTRA")
-    else:
-        raise TypeError("data should be a numpy.ndarray or a GPULink object")
-    pDataObject3D = new CFloat32ProjectionData3D(pGeometry, pStorage)
-    return pDataObject3D
+        pDataObject3D = new CFloat32ProjectionData3D(pGeometry, pStorage)
+        return pDataObject3D
+
+    raise TypeError("Data should be an array with DLPack support, or a GPULink object")
 
 cdef unique_ptr[CProjectionGeometry3D] createProjectionGeometry3D(geometry) except *:
     cdef XMLConfig *cfg

--- a/python/builder.py
+++ b/python/builder.py
@@ -142,6 +142,10 @@ for m in ext_modules:
     if m.name in ('astra.plugin_c'):
         m.sources.append(os.path.join('.', 'astra', 'src',
                                       'PythonPluginAlgorithmFactory.cpp'))
+    if m.name in ('astra.utils'):
+        m.sources.append(os.path.join('.', 'astra', 'src',
+                                      'dlpack.cpp'))
+
 
 setup(script_args=script_args,
       name='astra-toolbox',

--- a/tests/python/integration/test_dlpack.py
+++ b/tests/python/integration/test_dlpack.py
@@ -1,0 +1,164 @@
+import astra
+import astra.experimental
+import cupy as cp
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import torch
+
+
+DET_SPACING_X = 1.0
+DET_SPACING_Y = 1.0
+DET_ROW_COUNT = 20
+DET_COL_COUNT = 45
+N_ANGLES = 180
+ANGLES = np.linspace(0, 2 * np.pi, N_ANGLES, endpoint=False)
+N_ROWS = 40
+N_COLS = 30
+N_SLICES = 50
+VOL_GEOM = astra.create_vol_geom(N_ROWS, N_COLS, N_SLICES)
+PROJ_GEOM = astra.create_proj_geom('parallel3d', DET_SPACING_X, DET_SPACING_Y,
+                                   DET_ROW_COUNT, DET_COL_COUNT, ANGLES)
+DATA_INIT_VALUE = 1.0
+
+
+def _convert_to_backend(data, backend):
+    if backend == 'numpy':
+        return data
+    elif backend == 'pytorch_cpu':
+        return torch.tensor(data, device='cpu')
+    elif backend == 'pytorch_cuda':
+        return torch.tensor(data, device='cuda')
+    elif backend == 'cupy':
+        return cp.array(data)
+    elif backend == 'jax_cpu':
+        return jax.device_put(data, device=jax.devices('cpu')[0])
+    elif backend == 'jax_cuda':
+        return jax.device_put(data, device=jax.devices('cuda')[0])
+
+
+def _allclose(data, reference):
+    if isinstance(data, torch.Tensor) and data.device.type == 'cuda':
+        data = data.cpu()
+    return np.allclose(data, reference)
+
+
+@pytest.fixture
+def projector():
+    projector_id = astra.create_projector('cuda3d', PROJ_GEOM, VOL_GEOM)
+    yield projector_id
+    astra.projector3d.delete(projector_id)
+
+
+@pytest.fixture
+def vol_data(backend):
+    data = np.full([N_SLICES, N_ROWS, N_COLS], DATA_INIT_VALUE, dtype=np.float32)
+    return _convert_to_backend(data, backend)
+
+
+@pytest.fixture
+def proj_data(backend):
+    data = np.full([DET_ROW_COUNT, N_ANGLES, DET_COL_COUNT], DATA_INIT_VALUE, dtype=np.float32)
+    return _convert_to_backend(data, backend)
+
+
+@pytest.fixture
+def reference_fp():
+    vol_data_id = astra.data3d.create('-vol', VOL_GEOM, DATA_INIT_VALUE)
+    data_id, data = astra.create_sino3d_gpu(vol_data_id, PROJ_GEOM, VOL_GEOM)
+    astra.data3d.delete(data_id)
+    return data
+
+
+@pytest.fixture
+def reference_bp():
+    proj_data_id = astra.data3d.create('-sino', PROJ_GEOM, DATA_INIT_VALUE)
+    data_id, data = astra.create_backprojection3d_gpu(proj_data_id, PROJ_GEOM, VOL_GEOM)
+    astra.data3d.delete(data_id)
+    return data
+
+
+@pytest.fixture
+def proj_data_non_contiguous(backend):
+    data = np.full([N_ANGLES, DET_ROW_COUNT, DET_COL_COUNT], DATA_INIT_VALUE, dtype=np.float32)
+    return _convert_to_backend(data, backend).swapaxes(0, 1)
+
+
+@pytest.fixture
+def vol_geom_singular_dim(singular_dims):
+    dims = [N_ROWS, N_COLS, N_SLICES]
+    for dim in singular_dims.split('-'):
+        if dim == 'rows':
+            dims[0] = 1
+        elif dim == 'cols':
+            dims[1] = 1
+        elif dim == 'slices':
+            dims[2] = 1
+    return astra.create_vol_geom(*dims)
+
+
+@pytest.fixture
+def vol_data_singular_dim(singular_dims, backend):
+    shape = [N_SLICES, N_ROWS, N_COLS]
+    for dim in singular_dims.split('-'):
+        if dim == 'rows':
+            shape[1] = 1
+        elif dim == 'cols':
+            shape[2] = 1
+        elif dim == 'slices':
+            shape[0] = 1
+    data = np.full(shape, DATA_INIT_VALUE, dtype=np.float32)
+    return _convert_to_backend(data, backend)
+
+
+@pytest.fixture
+def vol_data_slice(singular_dims, backend):
+    data = np.full([N_SLICES, N_ROWS, N_COLS], DATA_INIT_VALUE, dtype=np.float32)
+    data = _convert_to_backend(data, backend)
+    for dim in singular_dims.split('-'):
+        if dim == 'rows':
+            data = data[:, 0:1, :]
+        elif dim == 'cols':
+            data = data[:, :, 0:1]
+        elif dim == 'slices':
+            data = data[0:1, :, :]
+    return data
+
+
+@pytest.mark.parametrize('backend', ['numpy', 'pytorch_cpu', 'pytorch_cuda', 'cupy',
+                                     'jax_cpu', 'jax_cuda'])
+class TestAll:
+    def test_backends_fp(self, backend, projector, vol_data, proj_data, reference_fp):
+        astra.experimental.direct_FP3D(projector, vol_data, proj_data)
+        assert _allclose(proj_data, reference_fp)
+
+    def test_backends_bp(self, backend, projector, vol_data, proj_data, reference_bp):
+        astra.experimental.direct_BP3D(projector, vol_data, proj_data)
+        assert _allclose(vol_data, reference_bp)
+
+    def test_non_contiguous(self, backend, proj_data_non_contiguous):
+        if backend.startswith('jax'):
+            pytest.skip('JAX should not produce non-contiguous tensors')
+        with pytest.raises(ValueError):
+            astra.data3d.link('-sino', PROJ_GEOM, proj_data_non_contiguous)
+
+    @pytest.mark.parametrize('singular_dims', [
+        'rows', 'cols', 'slices', 'rows-cols', 'rows-slices', 'cols-slices', 'rows-cols-slices'
+    ])
+    def test_singular_dimensions(self, backend, singular_dims, vol_geom_singular_dim,
+                                 vol_data_singular_dim):
+        astra.data3d.link('-vol', vol_geom_singular_dim, vol_data_singular_dim)
+
+
+@pytest.mark.parametrize('backend', ['pytorch_cuda', 'cupy'])
+@pytest.mark.parametrize('singular_dims', ['rows'])
+def test_allow_pitched(backend, singular_dims, vol_geom_singular_dim, vol_data_slice):
+    astra.data3d.link('-vol', vol_geom_singular_dim, vol_data_slice)
+
+
+@pytest.mark.parametrize('backend', ['numpy'])
+def test_read_only(backend, vol_data):
+    vol_data.flags['WRITEABLE'] = False
+    with pytest.raises(ValueError):
+        astra.data3d.link('-vol', VOL_GEOM, vol_data)


### PR DESCRIPTION
This PR adds initial DLPack support to `astra.data3d.link()`, and to `astra.experimental.direct_FP3D/BP3D`. This makes it possible to directly use data from other libraries supporting the dlpack standard, such as numpy, torch, tensorflow and cupy. It supports CUDA and CPU arrays, and the dlpack 1.0 (versioned) standard as well as the pre-1.0 (unversioned) standard.

The previously existing numpy 3D link functionality now uses this dlpack code. The numpy 2D link functionality is unchanged.