### PR TITLE
Parse int array XML node directly where appropriate

### DIFF
--- a/include/astra/Utilities.h
+++ b/include/astra/Utilities.h
@@ -80,6 +80,10 @@ _AstraExport std::vector<float> stringToFloatVector(const std::string& s);
 //< Throw exception on failure.
 _AstraExport std::vector<double> stringToDoubleVector(const std::string& s);
 
+//< Parse comma/semicolon-separated string as int vector.
+//< Throw exception on failure.
+_AstraExport std::vector<int> stringToIntVector(const std::string& s);
+
 template<typename T>
 _AstraExport std::vector<T> stringToVector(const std::string& s);
 

--- a/include/astra/XMLNode.h
+++ b/include/astra/XMLNode.h
@@ -129,6 +129,7 @@ public:
 	 */ 
 	std::vector<float32> getContentNumericalArray() const;
 	std::vector<double> getContentNumericalArrayDouble() const;
+	std::vector<int> getContentNumericalArrayInt() const;
 
 
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -363,7 +363,7 @@ bool ConfigReader<T>::getOptionIntArray(const std::string &name, std::vector<int
 		return false;
 	}
 
-	markNodeParsed(name);
+	markOptionParsed(name);
 	return true;
 }
 

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -143,6 +143,10 @@ std::vector<double> stringToDoubleVector(const std::string &s)
 {
 	return stringToNumericVector<double>(s);
 }
+std::vector<int> stringToIntVector(const std::string &s)
+{
+	return stringToNumericVector<int>(s);
+}
 
 template<typename T>
 std::vector<T> stringToVector(const std::string& s)

--- a/src/XMLConfig.cpp
+++ b/src/XMLConfig.cpp
@@ -128,19 +128,10 @@ bool XMLConfig::getIntArray(const std::string &name, std::vector<int> &values) c
 	XMLNode node = self.getSingleNode(name);
 	if (!node)
 		return false;
-	// TODO: Don't go via doubles
-	std::vector<double> tmp;
 	try {
-		tmp = node.getContentNumericalArrayDouble();
+		values = node.getContentNumericalArrayInt();
 	} catch (const StringUtil::bad_cast &e) {
 		return false;
-	}
-	values.resize(tmp.size());
-	for (size_t i = 0; i < tmp.size(); ++i) {
-		int t = static_cast<int>(tmp[i]);
-		if (t != tmp[i])
-			return false;
-		values[i] = t;
 	}
 	return true;
 }
@@ -212,11 +203,8 @@ bool XMLConfig::getOptionIntArray(const std::string &name, std::vector<int> &val
 	std::list<XMLNode> nodes = self.getNodes("Option");
 	for (XMLNode &it : nodes) {
 		if (it.getAttribute("key") == name) {
-			std::vector<std::string> data = it.getContentArray();
-			values.resize(data.size());
 			try {
-				for (size_t i = 0; i < data.size(); ++i)
-					values[i] = StringUtil::stringToInt(data[i]);
+				values = it.getContentNumericalArrayInt();
 			} catch (const StringUtil::bad_cast &e) {
 				return false;
 			}

--- a/src/XMLNode.cpp
+++ b/src/XMLNode.cpp
@@ -184,6 +184,11 @@ vector<double> XMLNode::getContentNumericalArrayDouble() const
 	return StringUtil::stringToDoubleVector(getContent());
 }
 
+vector<int> XMLNode::getContentNumericalArrayInt() const
+{
+	return StringUtil::stringToIntVector(getContent());
+}
+
 //-----------------------------------------------------------------------------	
 // Is attribute?
 bool XMLNode::hasAttribute(string _sName) const

--- a/tests/python/unit/test_algorithms_2d.py
+++ b/tests/python/unit/test_algorithms_2d.py
@@ -243,7 +243,6 @@ class TestOptionsCPU:
     def test_sart_projection_order(self, proj_geom, projector, projection_order):
         options = {'ProjectionOrder': projection_order}
         if projection_order == 'custom':
-            pytest.xfail('Known bug')
             # Set projection order to 0, 5, 10, ..., 175, 1, 6, 11, ... , 176, 2, 7, ...
             proj_order_list = np.arange(N_ANGLES).reshape(-1, 5).T.flatten()
             options['ProjectionOrderList'] = proj_order_list
@@ -256,11 +255,10 @@ class TestOptionsCPU:
     def test_art_ray_order(self, proj_geom, projector, ray_order):
         options = {'RayOrder': ray_order}
         if ray_order == 'custom':
-            pytest.xfail('Known bug')
             # Every combination of (projection_id, detector_id)
             all_rays = np.mgrid[:N_ANGLES, :DET_COUNT].T.reshape(-1, 2)
             ray_order_list = np.random.permutation(all_rays).flatten()
-            options['ProjectionOrderList'] = ray_order_list
+            options['RayOrderList'] = ray_order_list
         algorithm_config = make_algorithm_config(algorithm_type='ART', proj_geom=proj_geom,
                                                  projector=projector, options=options)
         reconstruction = get_algorithm_output(algorithm_config)


### PR DESCRIPTION
This PR resolves a TODO for parsing integer arrays from XML config directly without going via doubles/strings.

This fixes a bug where launching SART and ART algorithms with "custom" projection/ray order would cause a segfault, because the generic string parsing XMLNode::getContentArray method tries to parse "listsize" attribute:

https://github.com/astra-toolbox/astra-toolbox/blob/df57d55d8a4cde393a620de0460fb63672010f7d/src/XMLNode.cpp#L158

This attribute is not created for projection/ray order options, most likely as the result of:

https://github.com/astra-toolbox/astra-toolbox/commit/fff7470f1d74b0085355130350fa834ea8d37069#diff-5914c62d2c761f105ba2a64876acefab0466188c5c905a5db7e3749528c64abcL96