### PR TITLE
Add 2d_weighting projection kernel to 3D backprojections

### DIFF
--- a/cuda/3d/fdk.cu
+++ b/cuda/3d/fdk.cu
@@ -466,8 +466,7 @@ bool FDK(cudaPitchedPtr D_volumeData,
 		return false;
 
 	// Perform BP
-
-	params.bFDKWeighting = true;
+	assert(params.projKernel == ker3d_fdk_weighting);
 
 	//ok = FDK_BP(D_volumeData, D_projData, fSrcOrigin, fDetOrigin, 0.0f, 0.0f, fDetUSize, fDetVSize, dims, pfAngles);
 	ok = ConeBP(D_volumeData, D_projData, dims, angles, params);

--- a/cuda/3d/par3d_bp.cu
+++ b/cuda/3d/par3d_bp.cu
@@ -224,7 +224,15 @@ bool transferConstants(const SPar3DProjection* angles, unsigned int iProjAngles,
 		p[i].fNumV.z = det3z(r,u) / fDen;
 		p[i].fNumV.w = det3(r,d,u) / fDen;
 
-		s[i] = 1.0 / scaled_cross3(u,v,Vec3(params.fVolScaleX,params.fVolScaleY,params.fVolScaleZ)).norm();
+		if (params.projKernel == ker3d_2d_weighting) {
+			// We set the scale here to approximate the adjoint
+			// of a 2d parallel beam kernel. To be used when only
+			// operating on a single slice.
+			Vec3 ev(0, 0, 1);
+			s[i] = 1.0 / scaled_cross3(u,ev,Vec3(params.fVolScaleX,params.fVolScaleY,params.fVolScaleZ)).norm();
+		} else {
+			s[i] = 1.0 / scaled_cross3(u,v,Vec3(params.fVolScaleX,params.fVolScaleY,params.fVolScaleZ)).norm();
+		}
 	}
 
 	ok &= checkCuda(cudaMemcpyToSymbolAsync(gC_C, p, iProjAngles*sizeof(DevPar3DParams), 0, cudaMemcpyHostToDevice, stream), "transferConstants transfer C");

--- a/include/astra/cuda/3d/astra3d.h
+++ b/include/astra/cuda/3d/astra3d.h
@@ -51,6 +51,8 @@ class AstraSIRT3d_internal;
 using astraCUDA3d::Cuda3DProjectionKernel;
 using astraCUDA3d::ker3d_default;
 using astraCUDA3d::ker3d_sum_square_weights;
+using astraCUDA3d::ker3d_fdk_weighting;
+using astraCUDA3d::ker3d_2d_weighting;
 using astraCUDA3d::SPar3DProjection;
 using astraCUDA3d::SConeProjection;
 

--- a/include/astra/cuda/3d/dims3d.h
+++ b/include/astra/cuda/3d/dims3d.h
@@ -39,7 +39,9 @@ using astra::SPar3DProjection;
 
 enum Cuda3DProjectionKernel {
 	ker3d_default = 0,
-	ker3d_sum_square_weights
+	ker3d_sum_square_weights,
+	ker3d_fdk_weighting,
+	ker3d_2d_weighting
 };
 
 
@@ -57,8 +59,7 @@ struct SProjectorParams3D {
 	    iRaysPerDetDim(1), iRaysPerVoxelDim(1),
 	    fOutputScale(1.0f),
 	    fVolScaleX(1.0f), fVolScaleY(1.0f), fVolScaleZ(1.0f),
-	    ker(ker3d_default),
-	    bFDKWeighting(false)
+	    projKernel(ker3d_default)
 	{ }
 
 	unsigned int iRaysPerDetDim;
@@ -67,8 +68,7 @@ struct SProjectorParams3D {
 	float fVolScaleX;
 	float fVolScaleY;
 	float fVolScaleZ;
-	Cuda3DProjectionKernel ker;
-	bool bFDKWeighting;
+	Cuda3DProjectionKernel projKernel;
 };
 
 }

--- a/include/astra/cuda/3d/mem3d.h
+++ b/include/astra/cuda/3d/mem3d.h
@@ -111,7 +111,7 @@ bool copyIntoArray(MemHandle3D &handle, MemHandle3D &subdata, const SSubDimensio
 
 bool FP(const astra::CProjectionGeometry3D* pProjGeom, MemHandle3D &projData, const astra::CVolumeGeometry3D* pVolGeom, MemHandle3D &volData, int iDetectorSuperSampling, astra::Cuda3DProjectionKernel projKernel);
 
-bool BP(const astra::CProjectionGeometry3D* pProjGeom, MemHandle3D &projData, const astra::CVolumeGeometry3D* pVolGeom, MemHandle3D &volData, int iVoxelSuperSampling);
+bool BP(const astra::CProjectionGeometry3D* pProjGeom, MemHandle3D &projData, const astra::CVolumeGeometry3D* pVolGeom, MemHandle3D &volData, int iVoxelSuperSampling, astra::Cuda3DProjectionKernel projKernel);
 
 bool FDK(const astra::CProjectionGeometry3D* pProjGeom, MemHandle3D &projData, const astra::CVolumeGeometry3D* pVolGeom, MemHandle3D &volData, bool bShortScan, const astra::SFilterConfig &filterConfig, float fOutputScale = 1.0f);
 

--- a/src/CompositeGeometryManager.cpp
+++ b/src/CompositeGeometryManager.cpp
@@ -1146,7 +1146,7 @@ static bool doJob(const CCompositeGeometryManager::TJobSetInternal::const_iterat
 
 			ASTRA_DEBUG("CCompositeGeometryManager::doJobs: doing BP");
 
-			ok = astraCUDA3d::BP(((CCompositeGeometryManager::CProjectionPart*)j.pInput.get())->pGeom, srcMem->hnd, ((CCompositeGeometryManager::CVolumePart*)output)->pGeom, dstMem->hnd, voxelSuperSampling);
+			ok = astraCUDA3d::BP(((CCompositeGeometryManager::CProjectionPart*)j.pInput.get())->pGeom, srcMem->hnd, ((CCompositeGeometryManager::CVolumePart*)output)->pGeom, dstMem->hnd, voxelSuperSampling, projKernel);
 			if (!ok) {
 				ASTRA_ERROR("Error performing sub-BP");
 				return false;

--- a/src/CudaProjector3D.cpp
+++ b/src/CudaProjector3D.cpp
@@ -110,6 +110,8 @@ bool CCudaProjector3D::initialize(const Config& _cfg)
 		m_projectionKernel = ker3d_default;
 	} else if (sProjKernel == "sum_square_weights") {
 		m_projectionKernel = ker3d_sum_square_weights;
+	} else if (sProjKernel == "2d_weighting") {
+		m_projectionKernel = ker3d_2d_weighting;
 	} else {
 		ASTRA_ERROR("Unknown ProjectionKernel");
 		return false;


### PR DESCRIPTION
This weights the backprojection to approximate the adjoint of the forward projection when using the 3d kernels to perform 2d operations (with a single slice in the Z direction).
