### PR TITLE
Bugfix for EM_CUDA in creators.create_reconstruction()

### DIFF
--- a/python/astra/creators.py
+++ b/python/astra/creators.py
@@ -516,7 +516,10 @@ def create_reconstruction(rec_type, proj_id, sinogram, iterations=1, use_mask='n
     else:
         sino_id = sinogram
     vol_geom = projector.volume_geometry(proj_id)
-    recon_id = data2d.create('-vol', vol_geom, 0)
+    if rec_type=='EM_CUDA':
+        recon_id = data2d.create('-vol', vol_geom, 1.0)
+    else:
+        recon_id = data2d.create('-vol', vol_geom, 0)
     cfg = astra_dict(rec_type)
     cfg['ProjectorId'] = proj_id
     cfg['ProjectionDataId'] = sino_id


### PR DESCRIPTION
The algorithm option **'EM_CUDA'** in [`astra.creators.create_reconstruction()`](https://github.com/AxelHenningsson/astra-toolbox/blob/9865b32e5ccd79aff1e085003df81e85e3f536d1/python/astra/creators.py#L481) fails to reconstruct anything due to an inital guess of a zero field defined through:
```python
recon_id = data2d.create('-vol', vol_geom, 0)
```
While this inital guess is fine for FBP, SIRT, SART etc, .. for multiplicative updates (as EM is), this need to instead be a volume of ones as:
```python
recon_id = data2d.create('-vol', vol_geom, 1.0)
```
This PR fixes this by adding a check for `rec_type` and reacting apropiately. This PR is 100% backwards compatible, and does not change the api in any way - it simply fixes this bug.

To reproduce the bug:
-----------------------------------------
```python
import astra
import numpy as np
import matplotlib.pyplot as plt
angles = np.linspace(0, np.pi, 180)
proj_geom = astra.create_proj_geom("parallel", 1.0, 32, angles)
vol_geom = astra.create_vol_geom(32, 32)
projector_id = astra.create_projector("cuda", proj_geom, vol_geom)
sample = np.zeros((32, 32), dtype=np.float32)
sample[16:24, 16:24] = 1
id2, sinogram = astra.creators.create_sino(sample, projector_id)
id1, recon = astra.creators.create_reconstruction(
    "EM_CUDA", projector_id, sinogram, iterations=99
)
assert np.alltrue(recon == 0)
plt.style.use('dark_background')
fig, ax = plt.subplots(1, 2, figsize=(14,7))
im = ax[0].imshow(sample)
ax[0].set_title("Sample", fontsize=22)
fig.colorbar(im, ax=ax[0], fraction=0.046, pad=0.04)
im = ax[1].imshow(recon)
ax[1].set_title("EM Reconstruction", fontsize=22)
fig.colorbar(im, ax=ax[1], fraction=0.046, pad=0.04)
plt.tight_layout()
plt.show()
```
![image](https://github.com/user-attachments/assets/f5ebf76e-8e1f-4eb2-bf03-3cbd5f629bde)

With the suggested bugfix
--------------------------------------------------------
Addign in  [`astra.creators.create_reconstruction()`](https://github.com/AxelHenningsson/astra-toolbox/blob/9865b32e5ccd79aff1e085003df81e85e3f536d1/python/astra/creators.py#L481) 
```python
    if rec_type=='EM_CUDA':
        recon_id = data2d.create('-vol', vol_geom, 1.0)
    else:
        recon_id = data2d.create('-vol', vol_geom, 0)
```
we can fix this:
![image](https://github.com/user-attachments/assets/0d223468-f478-4425-bfda-f97ec4d724ff)

