### PR TITLE
Improve CGM splitting strategy

### DIFF
--- a/src/CompositeGeometryManager.cpp
+++ b/src/CompositeGeometryManager.cpp
@@ -67,37 +67,6 @@ CCompositeGeometryManager::CCompositeGeometryManager()
 }
 
 
-// JOB:
-//
-// VolumePart
-// ProjectionPart
-// FP-or-BP
-// SET-or-ADD
-
-
-// Running a set of jobs:
-//
-// [ Assume OUTPUT Parts in a single JobSet don't alias?? ]
-// Group jobs by output Part
-// One thread per group?
-
-// Automatically split parts if too large
-// Performance model for odd-sized tasks?
-// Automatically split parts if not enough tasks to fill available GPUs
-
-
-// Splitting:
-// Constraints:
-//   number of sub-parts divisible by N
-//   max size of sub-parts
-
-// For splitting on both input and output side:
-//   How to divide up memory? (Optimization problem; compute/benchmark)
-//   (First approach: 0.5/0.5)
-
-
-
-
 
 class _AstraExport CGPUMemory {
 public:
@@ -1313,7 +1282,7 @@ public:
 
 		unlock();
 
-		return true;	
+		return true;
 	}
 	void lock() {
 		m_mutex.lock();


### PR DESCRIPTION
This improves the CGM splitting strategy in two ways:

We now do two passes: first split along all dimensions only on maxBlockDim, and then split again along the first axis on memory size. This avoids the case where an initial split on memory size would later turn out to be unncessary after splits on maxBlockDim.

Also, we now take into account when volumes are already allocated on the GPU (when using the new DLPack interface) and don't reserve memory unnecessarily.