### PR TITLE
Fix building with clang

### DIFF
--- a/include/astra/Data3D.h
+++ b/include/astra/Data3D.h
@@ -175,10 +175,6 @@ public:
 
 #endif
 
-template class CDataMemory<float32>;
-template class CData3DObject<CProjectionGeometry3D>;
-template class CData3DObject<CVolumeGeometry3D>;
-
 // Utility functions that create CDataMemory and Data3D objects together
 _AstraExport CFloat32ProjectionData3D *createCFloat32ProjectionData3DMemory(const CProjectionGeometry3D &geom);
 _AstraExport CFloat32ProjectionData3D *createCFloat32ProjectionData3DMemory(std::unique_ptr<CProjectionGeometry3D> &&geom);

--- a/include/astra/Float32Data2D.h
+++ b/include/astra/Float32Data2D.h
@@ -40,8 +40,6 @@ public:
 	T* m_fPtr;
 };
 
-template class CCustomMemory<float32>;
-
 typedef CCustomMemory<float32> CFloat32CustomMemory;
 
 /** 

--- a/src/Data3D.cpp
+++ b/src/Data3D.cpp
@@ -111,5 +111,8 @@ CFloat32VolumeData3D *createCFloat32VolumeData3DMemory(std::unique_ptr<CVolumeGe
 	return new CFloat32VolumeData3D(std::move(geom), storage);
 }
 
+template class CDataMemory<float32>;
+template class CData3DObject<CProjectionGeometry3D>;
+template class CData3DObject<CVolumeGeometry3D>;
 
 }

--- a/src/Float32Data2D.cpp
+++ b/src/Float32Data2D.cpp
@@ -590,7 +590,6 @@ std::string CFloat32Data2D::description() const
 	return res.str();
 }
 
-
-
+template class CCustomMemory<float32>;
 
 } // end namespace astra


### PR DESCRIPTION
If I interpret what's happening correctly, with clang methods of template classes don't get instantiated if the class itself is instantiated before methods definition.