### PR TITLE
CUDA DLLs from PyPI for Python wheel in Windows

### DIFF
--- a/build/msvc/build_python3.bat
+++ b/build/msvc/build_python3.bat
@@ -23,8 +23,6 @@ set INCLUDE=%R%\include;%R%\lib\include;%CUDA_PATH%\include;%INCLUDE%
 set ASTRA_CONFIG=windows_cuda
 copy ..\build\msvc\bin\x64\Release_CUDA\AstraCuda64.lib astra.lib
 copy ..\build\msvc\bin\x64\Release_CUDA\AstraCuda64.dll astra
-copy "%CUDA_PATH_V12_8%\bin\cudart64_12.dll" astra
-copy "%CUDA_PATH_V12_8%\bin\cufft64_11.dll" astra
 "%B_WINPYTHON3%\python" -m pip wheel --no-build-isolation --no-deps --no-cache-dir .
 
 pause

--- a/python/astra/__init__.py
+++ b/python/astra/__init__.py
@@ -23,6 +23,13 @@
 #
 # -----------------------------------------------------------------------
 
+# On Windows, set CUDA DLL search path
+import os
+if os.name == 'nt':
+    nvidia_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'nvidia')
+    os.add_dll_directory(os.path.join(nvidia_path, 'cuda_runtime', 'bin'))
+    os.add_dll_directory(os.path.join(nvidia_path, 'cufft', 'bin'))
+
 # Import astra module first to make error message less confusing in case of import error
 from . import astra
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -20,7 +20,8 @@ extra_lib = [ 'astra/libastra.so*' ]
 cuda = true
 
 [tool.astra.windows_cuda]
-extra_lib = [ 'astra/AstraCuda64.dll', 'astra/cudart64_12.dll', 'astra/cufft64_11.dll' ]
+install_requires = ['nvidia-cuda-runtime-cu12==12.8.90', 'nvidia-cufft-cu12==11.3.3.83']
+extra_lib = [ 'astra/AstraCuda64.dll' ]
 cuda = true
 
 [tool.astra.pypi_linux_cuda]


### PR DESCRIPTION
This is some prototyping to use the CUDA DDLs from the official `nvidia-cuda-runtime-cu12` and `nvidia-cufft-cu12` PyPI packages instead of bundling them in the astra-toolbox wheel. This hopefully allows to fix #51 and deploy astra-toolbox on PyPI also for Windows.

The idea is to use `os.add_dll_directory` to find the CUDA DDLs, the paths are similar to setting RPATH on Linux here:
https://github.com/astra-toolbox/astra-toolbox/blob/efd3920f52b8d7b3972e403d38d51f70a89c5e97/build/pypi/build.sh#L7

The pinned versions for the cuda packages `nvidia-cuda-runtime-cu12==12.8.90` and `nvidia-cufft-cu12==11.3.3.83` are from the March 2025 CUDA release. These are the exact same DLLs as shipped with the CUDA version used here:
https://github.com/astra-toolbox/astra-toolbox/blob/efd3920f52b8d7b3972e403d38d51f70a89c5e97/build/containers/windows/provision-cuda.ps1#L24

~Note: I submitted the Windows build fixes as a separate PR #583, please ignore this changes here.~