### PR TITLE
Support python freethreading

### DIFF
--- a/build/conda/astra-toolbox/meta.yaml
+++ b/build/conda/astra-toolbox/meta.yaml
@@ -27,7 +27,7 @@ requirements:
   host:
     - setuptools
     - python
-    - cython >=3
+    - cython >=3.1
     - nomkl # [not win]
     - numpy {{ numpy_host }}
     - scipy

--- a/build/containers/podman/setup_manylinux.sh
+++ b/build/containers/podman/setup_manylinux.sh
@@ -12,14 +12,16 @@ ctr=$(buildah from quay.io/pypa/manylinux2014_x86_64:latest)
 setup_cuda $CUDA129
 setup_cuda $CUDA130
 
-buildah run $ctr manylinux-interpreters ensure cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313 cp314-cp314
+buildah run $ctr manylinux-interpreters ensure cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313 cp313-cp313t cp314-cp314 cp314-cp314t
 buildah run $ctr pipx upgrade auditwheel
 setup_pip_install python3.9 setuptools wheel numpy six Cython scipy
 setup_pip_install python3.10 setuptools wheel numpy six Cython scipy
 setup_pip_install python3.11 setuptools wheel numpy six Cython scipy
 setup_pip_install python3.12 setuptools wheel numpy six Cython scipy
 setup_pip_install python3.13 setuptools wheel numpy six Cython scipy
+setup_pip_install python3.13t setuptools wheel numpy six Cython scipy
 setup_pip_install python3.14 setuptools wheel numpy six Cython scipy
+setup_pip_install python3.14t setuptools wheel numpy six Cython scipy
 
 buildah commit $ctr astra-build-manylinux
 

--- a/build/linux/acinclude.m4
+++ b/build/linux/acinclude.m4
@@ -56,7 +56,7 @@ AC_DEFUN([ASTRA_RUN_STOREOUTPUT],[{
   ac_status=$?
   cat $2 >&AS_MESSAGE_LOG_FD
   AS_ECHO(["$as_me:${as_lineno-$LINENO}: \$? = $ac_status"]) >&AS_MESSAGE_LOG_FD
-  test $ac_status = 0;
+  ( exit $ac_status )
  }])
 
 dnl ASTRA_RUN_LOGOUTPUT(command)
@@ -65,7 +65,7 @@ AC_DEFUN([ASTRA_RUN_LOGOUTPUT],[{
   ( $1 ) >&AS_MESSAGE_LOG_FD 2>&1
   ac_status=$?
   AS_ECHO(["$as_me:${as_lineno-$LINENO}: \$? = $ac_status"]) >&AS_MESSAGE_LOG_FD
-  test $ac_status = 0;
+  ( exit $ac_status )
  }])
 
 
@@ -81,6 +81,32 @@ AS_IF([test $? = 0],[$2],[
   $3])
 ])
 
+dnl ASTRA_CHECK_PYTHON_MODULE_VERSION(import-name, minimum version, action-if-ok, action-if-not-ok, action-if-not-checked)
+AC_DEFUN([ASTRA_CHECK_PYTHON_MODULE_VERSION],[
+cat >conftest.py <<_ACEOF
+try:
+  import sys
+  # Not very nice to import from setuptools._vendor,
+  # but not worth it to add an extra dependency for this check.
+  from setuptools._vendor.packaging.version import Version
+  from $1 import __version__ as module_version
+  module_version = Version(module_version)
+  req_version = Version("$2")
+except:
+  # Unable to perform version check (with this method)
+  sys.exit(2)
+
+if module_version >= req_version:
+  sys.exit(0)
+else:
+  sys.exit(1)
+_ACEOF
+  ASTRA_RUN_LOGOUTPUT($PYTHON conftest.py)
+  ac_status=$?
+  AS_IF([test $ac_status = 0],[$3])
+  AS_IF([test $ac_status = 1],[$4])
+  AS_IF([test $ac_status = 2],[$5])
+])
 
 dnl ASTRA_CHECK_NVCC(variable-to-set,cppflags-to-set)
 AC_DEFUN([ASTRA_CHECK_NVCC],[

--- a/build/linux/configure.ac
+++ b/build/linux/configure.ac
@@ -327,6 +327,13 @@ if test x"$with_python" != x -a x"$with_python" != xno; then
     AC_MSG_RESULT(no)
     AC_MSG_ERROR(You need the Cython module to install the ASTRA toolbox for Python)
   fi
+  ASTRA_CHECK_PYTHON_MODULE_VERSION(cython,[3.1],,HAVEPYTHON=no,)
+  # This version check could fail to work; we assume we have a good version in
+  # that case.
+  if test x$HAVEPYTHON = xno; then
+    AC_MSG_RESULT(not >= 3.1)
+    AC_MSG_ERROR(You need Cython >= 3.1 to install the ASTRA toolbox for Python)
+  fi
   AC_MSG_RESULT(yes)
   AC_MSG_CHECKING(for scipy module)
   ASTRA_TRY_PYTHON([import scipy],,HAVEPYTHON=no)

--- a/include/astra/Config.h
+++ b/include/astra/Config.h
@@ -73,7 +73,7 @@ protected:
 	virtual bool getOptionUInt(const std::string &name, unsigned int &iValue) const = 0;
 	virtual bool getOptionBool(const std::string &name, bool &bValue) const = 0;
 	virtual bool getOptionString(const std::string &name, std::string &sValue) const = 0;
-	virtual bool getOptionIntArray(const std::string &name, std::vector<int> &values) const = 0;
+	virtual bool getOptionIntArray(const std::string &name, std::vector<int> &values, bool acceptScalar=false) const = 0;
 
 	virtual std::list<std::string> checkUnparsed(const ConfigCheckData &data) const = 0;
 };
@@ -127,7 +127,7 @@ public:
 	bool getOptionUInt(const std::string &name, unsigned int &iValue, unsigned int iDefaultValue);
 	bool getOptionBool(const std::string &name, bool &bValue, bool bDefaultValue);
 	bool getOptionString(const std::string &name, std::string &sValue, std::string sDefaultValue);
-	bool getOptionIntArray(const std::string &name, std::vector<int> &values);
+	bool getOptionIntArray(const std::string &name, std::vector<int> &values, bool acceptScalar=false);
 
 	// Get and parse an option value as ID. Returns true if the option is
 	// present and successfully parsed. Returns false and -1 if the option is

--- a/include/astra/CudaBackProjectionAlgorithm3D.h
+++ b/include/astra/CudaBackProjectionAlgorithm3D.h
@@ -109,16 +109,15 @@ public:
 	 */
 	virtual std::string description() const;
 
-	/**  
-	 * Sets the index of the used GPU index: first GPU has index 0
+	/** Sets the index/indices of the used GPU(s): first GPU has index 0
 	 *
-	 * @param _iGPUIndex New GPU index.
+	 * @param _GPUIndices New GPU index/indices.
 	 */
-	void setGPUIndex(int _iGPUIndex) { m_iGPUIndex = _iGPUIndex; }
+	void setGPUIndices(const std::vector<int> &_GPUIndices) { m_GPUIndices = _GPUIndices; }
 
 protected:
 
-	int m_iGPUIndex;
+	std::vector<int> m_GPUIndices;
 	int m_iVoxelSuperSampling;
 
 	/** Option to compute the column weights on the fly, divide by

--- a/include/astra/CudaFDKAlgorithm3D.h
+++ b/include/astra/CudaFDKAlgorithm3D.h
@@ -130,16 +130,15 @@ public:
 	 */
 	virtual std::string description() const;
 
-	/**  
-	 * Sets the index of the used GPU index: first GPU has index 0
+	/** Sets the index/indices of the used GPU(s): first GPU has index 0
 	 *
-	 * @param _iGPUIndex New GPU index.
+	 * @param _GPUIndices New GPU index/indices.
 	 */
-	void setGPUIndex(int _iGPUIndex) { m_iGPUIndex = _iGPUIndex; }
+	void setGPUIndices(const std::vector<int> &_GPUIndices) { m_GPUIndices = _GPUIndices; }
 
 protected:
 
-	int m_iGPUIndex;
+	std::vector<int> m_GPUIndices;
 	int m_iVoxelSuperSampling;
 	bool m_bShortScan;
 

--- a/include/astra/CudaForwardProjectionAlgorithm3D.h
+++ b/include/astra/CudaForwardProjectionAlgorithm3D.h
@@ -69,11 +69,11 @@ public:
 	 * @param _pReconstruction	VolumeData3D object containing the volume.
 	 * @return initialization successful?
 	 */
-	bool initialize(CProjector3D* _pProjector, 
-					CFloat32ProjectionData3D* _pSinogram, 
-					CFloat32VolumeData3D* _pReconstruction,
-					int _iGPUindex = -1, int _iDetectorSuperSampling = 1);
-
+	bool initialize(CProjector3D* _pProjector,
+	                CFloat32ProjectionData3D* _pSinogram,
+	                CFloat32VolumeData3D* _pReconstruction,
+	                std::vector<int> _GPUIndices = {},
+	                int _iDetectorSuperSampling = -1);
 
 	/** Perform a number of iterations.
 	 *
@@ -93,18 +93,17 @@ public:
 	 */
 	bool check();
 
-	/**  
-	 * Sets the index of the used GPU index: first GPU has index 0
+	/** Sets the index/indices of the used GPU(s): first GPU has index 0
 	 *
-	 * @param _iGPUIndex New GPU index.
+	 * @param _GPUIndices New GPU index/indices.
 	 */
-	void setGPUIndex(int _iGPUIndex);
+	void setGPUIndices(const std::vector<int> &_GPUIndices) { m_GPUIndices = _GPUIndices; }
 
 protected:
 	CProjector3D* m_pProjector;
 	CFloat32ProjectionData3D* m_pProjections;
 	CFloat32VolumeData3D* m_pVolume;
-	int m_iGPUIndex;
+	std::vector<int> m_GPUIndices;
 	int m_iDetectorSuperSampling;
 
 	void initializeFromProjector();

--- a/include/astra/CudaProjector3D.h
+++ b/include/astra/CudaProjector3D.h
@@ -69,7 +69,7 @@ public:
 	                 Cuda3DProjectionKernel _projectionKernel=ker3d_default,
 	                 int _iVoxelSuperSampling=1,
 	                 int _iDetectorSuperSampling=1,
-	                 int _iGPUIndex=-1);
+	                 std::vector<int> _GPUIndices={});
 
 	/** Initialize the projector with a config object.
 	 *
@@ -83,7 +83,7 @@ public:
 	                Cuda3DProjectionKernel _projectionKernel=ker3d_default,
 	                int _iVoxelSuperSampling=1,
 	                int _iDetectorSuperSampling=1,
-	                int _iGPUIndex=-1);
+	                std::vector<int> _GPUIndices={});
 
 	virtual void computeSingleRayWeights(int _iProjectionIndex,
 	                                     int _iSliceIndex,
@@ -117,14 +117,14 @@ public:
 	Cuda3DProjectionKernel getProjectionKernel() const { return m_projectionKernel; }
 	int getVoxelSuperSampling() const { return m_iVoxelSuperSampling; }
 	int getDetectorSuperSampling() const { return m_iDetectorSuperSampling; }
-	int getGPUIndex() const { return m_iGPUIndex; }
+	const std::vector<int>& getGPUIndices() const { return m_GPUIndices; }
 
 protected:
 
 	Cuda3DProjectionKernel m_projectionKernel;
 	int m_iVoxelSuperSampling;
 	int m_iDetectorSuperSampling;
-	int m_iGPUIndex;
+	std::vector<int> m_GPUIndices;
 
 };
 

--- a/include/astra/Logging.h
+++ b/include/astra/Logging.h
@@ -53,7 +53,7 @@ class _AstraExport CLogger
   static bool m_bEnabledFile;
   static bool m_bEnabledScreen;
   static bool m_bFileProvided;
-  static std::string m_sLastErrMsg;
+  static thread_local std::string m_sLastErrMsg;
   static void _assureIsInitialized();
   static void _setLastErrMsg(const char *sfile, int sline, const char *fmt, va_list ap);
   static void _setLevel(int id, log_level m_eLevel);

--- a/include/astra/XMLConfig.h
+++ b/include/astra/XMLConfig.h
@@ -60,7 +60,7 @@ private:
 	virtual bool getOptionUInt(const std::string &name, unsigned int &iValue) const;
 	virtual bool getOptionBool(const std::string &name, bool &bValue) const;
 	virtual bool getOptionString(const std::string &name, std::string &sValue) const;
-	virtual bool getOptionIntArray(const std::string &name, std::vector<int> &values) const;
+	virtual bool getOptionIntArray(const std::string &name, std::vector<int> &values, bool acceptScalar=false) const;
 
 	virtual std::list<std::string> checkUnparsed(const ConfigCheckData &data) const;
 private:

--- a/python/astra/astra_c.pyx
+++ b/python/astra/astra_c.pyx
@@ -93,9 +93,24 @@ IF HAVE_CUDA==True:
     if memory != 0 and memory < 1024*1024:
         raise AstraError("Setting GPU memory lower than 1MB is not supported")
     params.memory = memory
+
+    # We let Cython convert idx into a std::vector<int>
     params.GPUIndices = idx
+
+    if not params.GPUIndices.empty():
+        ret = setGPUIndex(params.GPUIndices[0])
+    else:
+        ret = True
+
+    # If a single GPU is specified, we clear the globally set GPUIndices in
+    # CompositeGeometryManager, and instead rely on the fact that this GPU
+    # will be set as the active CUDA device. This lets separate threads
+    # set different active GPUs, without the global CompositeGeometryManager
+    # state overriding that.
+    if params.GPUIndices.size() == 1:
+        params.GPUIndices.clear()
+
     setGlobalGPUParams(params)
-    ret = setGPUIndex(params.GPUIndices[0])
     if not ret:
         print("Failed to set GPU " + str(params.GPUIndices[0]))
   def get_gpu_info(idx=-1):

--- a/python/astra/src/PythonPluginAlgorithmFactory.cpp
+++ b/python/astra/src/PythonPluginAlgorithmFactory.cpp
@@ -43,6 +43,27 @@ namespace astra {
 
 void logPythonError();
 
+PyObject *getItemStringRef(PyObject *dict, const char *key)
+{
+#if PY_VERSION_HEX < 0x030d0000
+    // This emulates the behaviour of the Python 3.13+ function
+    // PyDict_GetItemStringRef, but without the thread-safety.
+    // That's no problem since freethreading was introduced with Python 3.13.
+    PyObject *value;
+    value = PyDict_GetItemString(dict, key);
+    if (!value)
+        return nullptr;
+    Py_INCREF(value);
+    return value;
+#else
+    PyObject *value = nullptr;
+    int res = PyDict_GetItemStringRef(dict, key, &value);
+    if (res != 1)
+        return nullptr;
+    return value;
+#endif
+}
+
 CPythonPluginAlgorithmFactory::CPythonPluginAlgorithmFactory(){
     if(!Py_IsInitialized()){
         Py_Initialize();
@@ -122,8 +143,8 @@ bool CPythonPluginAlgorithmFactory::registerPluginClass(PyObject * className){
 }
 
 CAlgorithm * CPythonPluginAlgorithmFactory::getPlugin(const std::string &name){
-    PyObject *className = PyDict_GetItemString(pluginDict, name.c_str());
-    if(className==NULL) return NULL;
+    PyObject *className = getItemStringRef(pluginDict, name.c_str());
+    if (!className) return NULL;
     CPluginAlgorithm *alg = NULL;
     if(PyBytes_Check(className)){
         std::string str = std::string(PyBytes_AsString(className));
@@ -135,6 +156,7 @@ CAlgorithm * CPythonPluginAlgorithmFactory::getPlugin(const std::string &name){
     }else{
         alg = new CPluginAlgorithm(className);
     }
+    Py_DECREF(className);
     return alg;
 }
 
@@ -171,8 +193,8 @@ std::map<std::string, std::string> CPythonPluginAlgorithmFactory::getRegisteredM
 }
 
 std::string CPythonPluginAlgorithmFactory::getHelp(const std::string &name){
-    PyObject *className = PyDict_GetItemString(pluginDict, name.c_str());
-    if(className==NULL){
+    PyObject *className = getItemStringRef(pluginDict, name.c_str());
+    if (!className) {
         ASTRA_ERROR("Plugin %s not found!",name.c_str());
         PyErr_Clear();
         return "";
@@ -185,7 +207,10 @@ std::string CPythonPluginAlgorithmFactory::getHelp(const std::string &name){
     }else{
         pyclass = className;
     }
-    if(pyclass==NULL) return "";
+    if(pyclass==NULL){
+        Py_DECREF(className);
+        return "";
+    }
     if(inspect!=NULL){
         PyObject *retVal = PyObject_CallMethod(inspect,"getdoc","O",pyclass);
         if(retVal!=NULL){
@@ -204,6 +229,7 @@ std::string CPythonPluginAlgorithmFactory::getHelp(const std::string &name){
     if(PyBytes_Check(className)){
         Py_DECREF(pyclass);
     }
+    Py_DECREF(className);
     return ret;
 }
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -2,7 +2,7 @@
 # (And figure out how to not make that ship every single file)
 
 [build-system]
-requires = ["setuptools", "numpy", "Cython"]
+requires = ["setuptools", "numpy", "Cython >= 3.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.astra.nocuda]

--- a/python/setup.py
+++ b/python/setup.py
@@ -35,6 +35,7 @@ from Cython.Distutils import build_ext
 import argparse
 import sys
 import glob
+import sysconfig
 
 
 # Load configuration data from pyproject.toml's tool.astra section,
@@ -162,7 +163,9 @@ def prepare_ext_modules():
                                   'dlpack.cpp'))
         ext = Extension(modulename, sources=sources, libraries=["astra"])
         assert not hasattr(ext, 'cython_directives')
-        ext.cython_directives = {'language_level': "3"}
+        ext.cython_directives = {'language_level': "3" }
+        if sysconfig.get_config_var("Py_GIL_DISABLED") == 1:
+            ext.cython_directives['freethreading_compatible'] = True
         ext_modules.append(ext)
 
     return ext_modules

--- a/src/CompositeGeometryManager.cpp
+++ b/src/CompositeGeometryManager.cpp
@@ -1285,11 +1285,20 @@ public:
 	WorkQueue(CCompositeGeometryManager::TJobSetInternal &_jobs) : m_jobs(_jobs), failed(false) {
 		m_iter = m_jobs.begin();
 	}
-	void flag_failure() {
+	void flag_failure(const std::string &err) {
 		failed = true;
+		lock();
+		// We overwrite any existing error. Might have to change that
+		// if we ever change the Python error capture mechanism.
+		m_error = err;
+		unlock();
 	}
 	bool has_failed() const {
 		return failed;
+	}
+	std::string get_error() const {
+		// (Not thread safe on purpose)
+		return m_error;
 	}
 	bool receive(CCompositeGeometryManager::TJobSetInternal::const_iterator &i) {
 		if (failed)
@@ -1320,6 +1329,7 @@ private:
 	CCompositeGeometryManager::TJobSetInternal::const_iterator m_iter;
 	std::atomic<bool> failed;
 	std::mutex m_mutex;
+	std::string m_error;
 };
 
 struct WorkThreadInfo {
@@ -1336,7 +1346,10 @@ void runEntries(WorkThreadInfo* info)
 		astraCUDA3d::setGPUIndex(info->m_iGPU);
 		if (!doJob(i)) {
 			ASTRA_DEBUG("Thread on GPU %d reporting failure", info->m_iGPU);
-			info->m_queue->flag_failure();
+			// Capture last error message from this thread to
+			// report it back to the main thread.
+			std::string err = CLogger::getLastErrMsg();
+			info->m_queue->flag_failure(err);
 		}
 	}
 	ASTRA_DEBUG("Finishing thread on GPU %d", info->m_iGPU);
@@ -1449,8 +1462,12 @@ bool CCompositeGeometryManager::doJobs(TJobSetInternal &jobset)
 
 		runWorkQueue(wq, m_GPUIndices);
 
-		if (wq.has_failed())
+		if (wq.has_failed()) {
+			std::string err = wq.get_error();
+			if (!err.empty())
+				ASTRA_ERROR("%s", err.c_str());
 			return false;
+		}
 
 	}
 

--- a/src/CompositeGeometryManager.cpp
+++ b/src/CompositeGeometryManager.cpp
@@ -54,10 +54,12 @@ along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
 
 namespace astra {
 
+std::mutex g_GPUParams_mutex;
 SGPUParams* CCompositeGeometryManager::s_params = 0;
 
 CCompositeGeometryManager::CCompositeGeometryManager()
 {
+	std::unique_lock lock{g_GPUParams_mutex};
 	m_iMaxSize = 0;
 
 	if (s_params) {
@@ -1463,6 +1465,7 @@ bool CCompositeGeometryManager::doJobs(TJobSetInternal &jobset)
 //static
 void CCompositeGeometryManager::setGlobalGPUParams(const SGPUParams& params)
 {
+	std::unique_lock lock{g_GPUParams_mutex};
 	delete s_params;
 
 	s_params = new SGPUParams;

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -355,10 +355,10 @@ bool ConfigReader<T>::getOptionString(const std::string &name, std::string &sVal
 }
 
 template<class T>
-bool ConfigReader<T>::getOptionIntArray(const std::string &name, std::vector<int> &values)
+bool ConfigReader<T>::getOptionIntArray(const std::string &name, std::vector<int> &values, bool acceptScalar)
 {
 	values.clear();
-	if (cfg->hasOption(name) && !cfg->getOptionIntArray(name, values)) {
+	if (cfg->hasOption(name) && !cfg->getOptionIntArray(name, values, acceptScalar)) {
 		astra::CLogger::error(__FILE__, __LINE__, "Configuration error in %s: option %s must be an integer array.", objName, name.c_str());
 		return false;
 	}

--- a/src/CudaBackProjectionAlgorithm3D.cpp
+++ b/src/CudaBackProjectionAlgorithm3D.cpp
@@ -51,15 +51,15 @@ namespace astra {
 //----------------------------------------------------------------------------------------
 // Constructor
 CCudaBackProjectionAlgorithm3D::CCudaBackProjectionAlgorithm3D()
-	: m_iGPUIndex(-1), m_iVoxelSuperSampling(1), m_bSIRTWeighting(false)
+	: m_iVoxelSuperSampling(1), m_bSIRTWeighting(false)
 {
 
 }
 
 //----------------------------------------------------------------------------------------
 // Constructor with initialization
-CCudaBackProjectionAlgorithm3D::CCudaBackProjectionAlgorithm3D(CProjector3D* _pProjector, 
-                                                               CFloat32ProjectionData3D* _pProjectionData, 
+CCudaBackProjectionAlgorithm3D::CCudaBackProjectionAlgorithm3D(CProjector3D* _pProjector,
+                                                               CFloat32ProjectionData3D* _pProjectionData,
                                                                CFloat32VolumeData3D* _pReconstruction)
 	: CCudaBackProjectionAlgorithm3D()
 {
@@ -68,7 +68,7 @@ CCudaBackProjectionAlgorithm3D::CCudaBackProjectionAlgorithm3D(CProjector3D* _pP
 
 //----------------------------------------------------------------------------------------
 // Destructor
-CCudaBackProjectionAlgorithm3D::~CCudaBackProjectionAlgorithm3D() 
+CCudaBackProjectionAlgorithm3D::~CCudaBackProjectionAlgorithm3D()
 {
 
 }
@@ -89,7 +89,7 @@ bool CCudaBackProjectionAlgorithm3D::_check()
 void CCudaBackProjectionAlgorithm3D::initializeFromProjector()
 {
 	m_iVoxelSuperSampling = 1;
-	m_iGPUIndex = -1;
+	m_GPUIndices.clear();
 
 	CCudaProjector3D* pCudaProjector = dynamic_cast<CCudaProjector3D*>(m_pProjector);
 	if (!pCudaProjector) {
@@ -98,7 +98,7 @@ void CCudaBackProjectionAlgorithm3D::initializeFromProjector()
 		}
 	} else {
 		m_iVoxelSuperSampling = pCudaProjector->getVoxelSuperSampling();
-		m_iGPUIndex = pCudaProjector->getGPUIndex();
+		m_GPUIndices = pCudaProjector->getGPUIndices();
 	}
 
 }
@@ -123,9 +123,9 @@ bool CCudaBackProjectionAlgorithm3D::initialize(const Config& _cfg)
 	// Deprecated options
 	ok &= CR.getOptionInt("VoxelSuperSampling", m_iVoxelSuperSampling, m_iVoxelSuperSampling);
 	if (CR.hasOption("GPUIndex"))
-		ok &= CR.getOptionInt("GPUIndex", m_iGPUIndex, m_iGPUIndex);
-	else
-		ok &= CR.getOptionInt("GPUindex", m_iGPUIndex, m_iGPUIndex);
+		ok &= CR.getOptionIntArray("GPUIndex", m_GPUIndices, true);
+	else if (CR.hasOption("GPUindex"))
+		ok &= CR.getOptionIntArray("GPUindex", m_GPUIndices, true);
 
 	ok &= CR.getOptionBool("SIRTWeighting", m_bSIRTWeighting, false);
 
@@ -139,9 +139,9 @@ bool CCudaBackProjectionAlgorithm3D::initialize(const Config& _cfg)
 
 //----------------------------------------------------------------------------------------
 // Initialize - C++
-bool CCudaBackProjectionAlgorithm3D::initialize(CProjector3D* _pProjector, 
-								  CFloat32ProjectionData3D* _pSinogram, 
-								  CFloat32VolumeData3D* _pReconstruction)
+bool CCudaBackProjectionAlgorithm3D::initialize(CProjector3D* _pProjector,
+                                                CFloat32ProjectionData3D* _pSinogram,
+                                                CFloat32VolumeData3D* _pReconstruction)
 {
 	assert(!m_bIsInitialized);
 
@@ -280,11 +280,18 @@ bool CCudaBackProjectionAlgorithm3D::run(int _iNrIterations)
 		ASTRA_ASSERT(m_pSinogram->isFloat32Memory());
 		ASTRA_ASSERT(m_pReconstruction->isFloat32Memory());
 
+		// TODO: Warn if multiple GPUs specified but only one is used?
+		int iGPUIndex = -1;
+		if (!m_GPUIndices.empty())
+			iGPUIndex = m_GPUIndices[0];
+
 		return astraCudaBP_SIRTWeighted(m_pReconstruction,
 		                                m_pSinogram,
-		                                m_iGPUIndex, m_iVoxelSuperSampling);
+		                                iGPUIndex, m_iVoxelSuperSampling);
 	} else {
 		CCompositeGeometryManager cgm;
+		if (!m_GPUIndices.empty())
+			cgm.setGPUIndices(m_GPUIndices);
 
 		return cgm.doBP(m_pProjector, pReconMem, pSinoMem);
 	}

--- a/src/CudaCglsAlgorithm3D.cpp
+++ b/src/CudaCglsAlgorithm3D.cpp
@@ -115,7 +115,10 @@ void CCudaCglsAlgorithm3D::initializeFromProjector()
 			ASTRA_WARN("non-CUDA Projector3D passed to CGLS3D_CUDA");
 		}
 	} else {
-		m_iGPUIndex = pCudaProjector->getGPUIndex();
+		// TODO: Warn if multiple GPUs specified but only one is used?
+		std::vector<int> indices = pCudaProjector->getGPUIndices();
+		if (!indices.empty())
+			m_iGPUIndex = indices[0];
 
 		m_params.iRaysPerVoxelDim = pCudaProjector->getVoxelSuperSampling();
 		m_params.iRaysPerDetDim = pCudaProjector->getDetectorSuperSampling();

--- a/src/CudaFDKAlgorithm3D.cpp
+++ b/src/CudaFDKAlgorithm3D.cpp
@@ -46,7 +46,7 @@ namespace astra {
 //----------------------------------------------------------------------------------------
 // Constructor
 CCudaFDKAlgorithm3D::CCudaFDKAlgorithm3D()
-	: m_iGPUIndex(-1), m_iVoxelSuperSampling(1)
+	: m_iVoxelSuperSampling(1)
 {
 
 }
@@ -100,7 +100,7 @@ bool CCudaFDKAlgorithm3D::_check()
 void CCudaFDKAlgorithm3D::initializeFromProjector()
 {
 	m_iVoxelSuperSampling = 1;
-	m_iGPUIndex = -1;
+	m_GPUIndices.clear();
 
 	CCudaProjector3D* pCudaProjector = dynamic_cast<CCudaProjector3D*>(m_pProjector);
 	if (!pCudaProjector) {
@@ -109,7 +109,7 @@ void CCudaFDKAlgorithm3D::initializeFromProjector()
 		}
 	} else {
 		m_iVoxelSuperSampling = pCudaProjector->getVoxelSuperSampling();
-		m_iGPUIndex = pCudaProjector->getGPUIndex();
+		m_GPUIndices = pCudaProjector->getGPUIndices();
 	}
 
 }
@@ -133,9 +133,9 @@ bool CCudaFDKAlgorithm3D::initialize(const Config& _cfg)
 	bool ok = true;
 	ok &= CR.getOptionInt("VoxelSuperSampling", m_iVoxelSuperSampling, m_iVoxelSuperSampling);
 	if (CR.hasOption("GPUIndex"))
-		ok &= CR.getOptionInt("GPUIndex", m_iGPUIndex, m_iGPUIndex);
-	else
-		ok &= CR.getOptionInt("GPUindex", m_iGPUIndex, m_iGPUIndex);
+		ok &= CR.getOptionIntArray("GPUIndex", m_GPUIndices, true);
+	else if (CR.hasOption("GPUindex"))
+		ok &= CR.getOptionIntArray("GPUindex", m_GPUIndices, true);
 	if (!ok)
 		return false;
 
@@ -191,6 +191,8 @@ bool CCudaFDKAlgorithm3D::run(int _iNrIterations)
 	ASTRA_ASSERT(pReconMem);
 
 	CCompositeGeometryManager cgm;
+	if (!m_GPUIndices.empty())
+		cgm.setGPUIndices(m_GPUIndices);
 
 	return cgm.doFDK(m_pProjector, pReconMem, pSinoMem, m_bShortScan, m_filterConfig);
 }

--- a/src/CudaForwardProjectionAlgorithm3D.cpp
+++ b/src/CudaForwardProjectionAlgorithm3D.cpp
@@ -49,15 +49,13 @@ namespace astra {
 
 //----------------------------------------------------------------------------------------
 // Constructor
-CCudaForwardProjectionAlgorithm3D::CCudaForwardProjectionAlgorithm3D() 
+CCudaForwardProjectionAlgorithm3D::CCudaForwardProjectionAlgorithm3D()
 {
 	m_bIsInitialized = false;
-	m_iGPUIndex = -1;
 	m_iDetectorSuperSampling = 1;
 	m_pProjector = 0;
 	m_pProjections = 0;
 	m_pVolume = 0;
-
 }
 
 //----------------------------------------------------------------------------------------
@@ -71,7 +69,7 @@ CCudaForwardProjectionAlgorithm3D::~CCudaForwardProjectionAlgorithm3D()
 void CCudaForwardProjectionAlgorithm3D::initializeFromProjector()
 {
 	m_iDetectorSuperSampling = 1;
-	m_iGPUIndex = -1;
+	m_GPUIndices.clear();
 
 	CCudaProjector3D* pCudaProjector = dynamic_cast<CCudaProjector3D*>(m_pProjector);
 	if (!pCudaProjector) {
@@ -80,7 +78,7 @@ void CCudaForwardProjectionAlgorithm3D::initializeFromProjector()
 		}
 	} else {
 		m_iDetectorSuperSampling = pCudaProjector->getDetectorSuperSampling();
-		m_iGPUIndex = pCudaProjector->getGPUIndex();
+		m_GPUIndices = pCudaProjector->getGPUIndices();
 	}
 }
 
@@ -119,9 +117,9 @@ bool CCudaForwardProjectionAlgorithm3D::initialize(const Config& _cfg)
 	// Deprecated options
 	ok &= CR.getOptionInt("DetectorSuperSampling", m_iDetectorSuperSampling, m_iDetectorSuperSampling);
 	if (CR.hasOption("GPUIndex"))
-		ok &= CR.getOptionInt("GPUIndex", m_iGPUIndex, -1);
-	else
-		ok &= CR.getOptionInt("GPUindex", m_iGPUIndex, -1);
+		ok &= CR.getOptionIntArray("GPUIndex", m_GPUIndices, true);
+	else if (CR.hasOption("GPUindex"))
+		ok &= CR.getOptionIntArray("GPUindex", m_GPUIndices, true);
 	if (!ok)
 		return false;
 
@@ -135,10 +133,11 @@ bool CCudaForwardProjectionAlgorithm3D::initialize(const Config& _cfg)
 }
 
 
-bool CCudaForwardProjectionAlgorithm3D::initialize(CProjector3D* _pProjector, 
-                                  CFloat32ProjectionData3D* _pProjections, 
-                                  CFloat32VolumeData3D* _pVolume,
-                                  int _iGPUindex, int _iDetectorSuperSampling)
+bool CCudaForwardProjectionAlgorithm3D::initialize(CProjector3D* _pProjector,
+                                                   CFloat32ProjectionData3D* _pProjections,
+                                                   CFloat32VolumeData3D* _pVolume,
+                                                   std::vector<int> _GPUIndices,
+                                                   int _iDetectorSuperSampling)
 {
 	m_pProjector = _pProjector;
 	
@@ -148,12 +147,22 @@ bool CCudaForwardProjectionAlgorithm3D::initialize(CProjector3D* _pProjector,
 
 	CCudaProjector3D* pCudaProjector = dynamic_cast<CCudaProjector3D*>(m_pProjector);
 	if (!pCudaProjector) {
-		// TODO: Report
+		if (m_pProjector) {
+			ASTRA_WARN("non-CUDA Projector3D passed to FP3D_CUDA");
+		}
 		m_iDetectorSuperSampling = _iDetectorSuperSampling;
-		m_iGPUIndex = _iGPUindex;
+		m_GPUIndices = _GPUIndices;
 	} else {
-		m_iDetectorSuperSampling = pCudaProjector->getDetectorSuperSampling();
-		m_iGPUIndex = pCudaProjector->getGPUIndex();
+		if (_iDetectorSuperSampling == -1)
+			m_iDetectorSuperSampling = pCudaProjector->getDetectorSuperSampling();
+		else
+			m_iDetectorSuperSampling = _iDetectorSuperSampling;
+
+		if (_GPUIndices.empty())
+			m_GPUIndices = pCudaProjector->getGPUIndices();
+		else
+			m_GPUIndices = _GPUIndices;
+
 	}
 
 	// success
@@ -180,7 +189,6 @@ bool CCudaForwardProjectionAlgorithm3D::check()
 	ASTRA_CONFIG_CHECK(m_pVolume->isInitialized(), "FP3D_CUDA", "Volume Data Object Not Initialized.");
 
 	ASTRA_CONFIG_CHECK(m_iDetectorSuperSampling >= 1, "FP3D_CUDA", "DetectorSuperSampling must be a positive integer.");
-	ASTRA_CONFIG_CHECK(m_iGPUIndex >= -1, "FP3D_CUDA", "GPUIndex must be a non-negative integer.");
 
 	// check compatibility between projector and data classes
 //	ASTRA_CONFIG_CHECK(m_pSinogram->getGeometry()->isEqual(m_pProjector->getProjectionGeometry()), "SIRT_CUDA", "Projection Data not compatible with the specified Projector.");
@@ -207,12 +215,6 @@ bool CCudaForwardProjectionAlgorithm3D::check()
 	return true;
 }
 
-
-void CCudaForwardProjectionAlgorithm3D::setGPUIndex(int _iGPUIndex)
-{
-	m_iGPUIndex = _iGPUIndex;
-}
-
 //----------------------------------------------------------------------------------------
 // Run
 bool CCudaForwardProjectionAlgorithm3D::run(int)
@@ -221,6 +223,8 @@ bool CCudaForwardProjectionAlgorithm3D::run(int)
 	assert(m_bIsInitialized);
 
 	CCompositeGeometryManager cgm;
+	if (!m_GPUIndices.empty())
+		cgm.setGPUIndices(m_GPUIndices);
 
 	return cgm.doFP(m_pProjector, m_pVolume, m_pProjections);
 }

--- a/src/CudaProjector3D.cpp
+++ b/src/CudaProjector3D.cpp
@@ -43,8 +43,7 @@ namespace astra
 CCudaProjector3D::CCudaProjector3D()
 	: m_projectionKernel(ker3d_default),
 	  m_iVoxelSuperSampling(1),
-	  m_iDetectorSuperSampling(1),
-	  m_iGPUIndex(-1)
+	  m_iDetectorSuperSampling(1)
 {
 
 }
@@ -54,12 +53,12 @@ CCudaProjector3D::CCudaProjector3D(const CProjectionGeometry3D &_pProjectionGeom
                                    Cuda3DProjectionKernel _projectionKernel,
                                    int _iVoxelSuperSampling,
                                    int _iDetectorSuperSampling,
-                                   int _iGPUIndex)
+                                   std::vector<int> _GPUIndices)
 	: CProjector3D(_pProjectionGeometry, _pVolumeGeometry),
 	  m_projectionKernel(_projectionKernel),
 	  m_iVoxelSuperSampling(_iVoxelSuperSampling),
 	  m_iDetectorSuperSampling(_iDetectorSuperSampling),
-	  m_iGPUIndex(_iGPUIndex)
+	  m_GPUIndices(_GPUIndices)
 {
 
 }
@@ -112,10 +111,11 @@ bool CCudaProjector3D::initialize(const Config& _cfg)
 	ok &= CR.getOptionInt("VoxelSuperSampling", m_iVoxelSuperSampling, 1);
 	ok &= CR.getOptionInt("DetectorSuperSampling", m_iDetectorSuperSampling, 1);
 
-	if (CR.hasOption("GPUIndex"))
-		ok &= CR.getOptionInt("GPUIndex", m_iGPUIndex, -1);
-	else
-		ok &= CR.getOptionInt("GPUindex", m_iGPUIndex, -1);
+	if (CR.hasOption("GPUIndex")) {
+		ok &= CR.getOptionIntArray("GPUIndex", m_GPUIndices, true);
+	} else {
+		ok &= CR.getOptionIntArray("GPUindex", m_GPUIndices, true);
+	}
 	if (!ok)
 		return false;
 
@@ -128,7 +128,7 @@ bool CCudaProjector3D::initialize(const CProjectionGeometry3D &_pProjectionGeome
                                   Cuda3DProjectionKernel _projectionKernel,
                                   int _iVoxelSuperSampling,
                                   int _iDetectorSuperSampling,
-                                  int _iGPUIndex)
+                                  std::vector<int> _GPUIndices)
 {
 	assert(!m_bIsInitialized);
 
@@ -138,7 +138,7 @@ bool CCudaProjector3D::initialize(const CProjectionGeometry3D &_pProjectionGeome
 	m_projectionKernel = _projectionKernel;
 	m_iVoxelSuperSampling = _iVoxelSuperSampling;
 	m_iDetectorSuperSampling = _iDetectorSuperSampling;
-	m_iGPUIndex = _iGPUIndex;
+	m_GPUIndices = _GPUIndices;
 
 	m_bIsInitialized = _check();
 	return m_bIsInitialized;

--- a/src/CudaSirtAlgorithm3D.cpp
+++ b/src/CudaSirtAlgorithm3D.cpp
@@ -112,7 +112,10 @@ void CCudaSirtAlgorithm3D::initializeFromProjector()
 			ASTRA_WARN("non-CUDA Projector3D passed to SIRT3D_CUDA");
 		}
 	} else {
-		m_iGPUIndex = pCudaProjector->getGPUIndex();
+		// TODO: Warn if multiple GPUs specified but only one is used?
+		std::vector<int> indices = pCudaProjector->getGPUIndices();
+		if (!indices.empty())
+			m_iGPUIndex = indices[0];
 
 		m_params.iRaysPerVoxelDim = pCudaProjector->getVoxelSuperSampling();
 		m_params.iRaysPerDetDim = pCudaProjector->getDetectorSuperSampling();

--- a/src/Logging.cpp
+++ b/src/Logging.cpp
@@ -226,6 +226,6 @@ bool CLogger::setCallbackScreen(void (*cb)(const char *msg, size_t len)){
 bool CLogger::m_bEnabledScreen = true;
 bool CLogger::m_bEnabledFile = true;
 bool CLogger::m_bFileProvided = false;
-std::string CLogger::m_sLastErrMsg;
+thread_local std::string CLogger::m_sLastErrMsg;
 
 }

--- a/src/XMLConfig.cpp
+++ b/src/XMLConfig.cpp
@@ -206,12 +206,28 @@ bool XMLConfig::getOptionString(const std::string &name, std::string &sValue) co
 	return true;
 }
 
-bool XMLConfig::getOptionIntArray(const std::string &name, std::vector<int> &values) const
+bool XMLConfig::getOptionIntArray(const std::string &name, std::vector<int> &values, bool acceptScalar) const
 {
 	values.clear();
 
 	// TODO: Don't go via floats
 	// (But ensure Matlab's default double values do still work)
+
+	if (acceptScalar) {
+		float x = -1;
+		try {
+			x = self.getOptionNumerical(name);
+			int t = static_cast<int>(x);
+			if (t == x) {
+				values.push_back(t);
+				return true;
+			}
+			// fall through to array parsing
+		} catch (const StringUtil::bad_cast &) {
+			// fall through to array parsing
+		}
+	}
+
 	std::vector<float32> tmp;
 	try {
 		tmp = self.getOptionNumericalArray(name);


### PR DESCRIPTION
This adds support for Python's freethreading mode. See https://docs.python.org/3/howto/free-threading-python.html

This requires some functions to be thread-safe that didn't require that before.

Additionally, our `set_gpu_index` interface set global state in a way that wasn't usably in a consistent way from multi-threaded python scripts. In the new approach in this PR, when `set_gpu_index` is called with a single GPU, it affects only the current thread. Calling it with multiple GPUs still has a global effect, so that particular usage doesn't mix well with threads. To handle the case where users want to use different sets of multiple GPUs from different threads, it is now possible to set the GPUIndex option for the `cuda3d` projector or for 3D FP/BP/FDK algorithms to a list of GPU indices.