### PR TITLE
Use cuda-pathfinder to load CUDA shared libs

### DIFF
--- a/build/linux/Makefile.in
+++ b/build/linux/Makefile.in
@@ -373,6 +373,7 @@ PYTHON_PY_PLUGINS=\
 PYTHON_PYX=\
 	astra/algorithm_c.pyx \
 	astra/astra_c.pyx \
+	astra/config_c.pyx \
 	astra/data2d_c.pyx \
 	astra/data3d_c.pyx \
 	astra/experimental.pyx \

--- a/build/msvc/build_python3.bat
+++ b/build/msvc/build_python3.bat
@@ -23,8 +23,6 @@ set INCLUDE=%R%\include;%R%\lib\include;%CUDA_PATH%\include;%INCLUDE%
 set ASTRA_CONFIG=windows_cuda
 copy ..\build\msvc\bin\x64\Release_CUDA\AstraCuda64.lib astra.lib
 copy ..\build\msvc\bin\x64\Release_CUDA\AstraCuda64.dll astra
-copy "%CUDA_PATH_V12_8%\bin\cudart64_12.dll" astra
-copy "%CUDA_PATH_V12_8%\bin\cufft64_11.dll" astra
 "%B_WINPYTHON3%\python" -m pip wheel --no-build-isolation --no-deps --no-cache-dir .
 
 pause

--- a/build/pypi/build.sh
+++ b/build/pypi/build.sh
@@ -4,7 +4,6 @@ set -e
 
 BRANCH=master
 URL=https://github.com/astra-toolbox/astra-toolbox
-CUDA_RPATHS='$ORIGIN/../nvidia/cuda_runtime/lib:$ORIGIN/../nvidia/cufft/lib'
 
 echo "Cloning from ${URL}"
 echo "        branch: ${BRANCH}"
@@ -19,9 +18,7 @@ for PYTHON_VERSION in 3.9 3.10 3.11 3.12 3.13; do
     ./configure --with-python=python${PYTHON_VERSION} \
                 --with-cuda=/usr/local/cuda-12.5 \
                 --with-install-type=module
-    make -j 20 ASTRA_CONFIG=pypi_linux_cuda libastra.la
-    patchelf --set-rpath $CUDA_RPATHS .libs/$(source libastra.la; echo $dlname)
-    make -j 20 ASTRA_CONFIG=pypi_linux_cuda py
+    make -j 20 ASTRA_CONFIG=pypi_linux_cuda libastra.la py
     auditwheel repair --plat manylinux2014_x86_64 --exclude "libcudart.so.*" --exclude "libcufft.so.*" python/dist/*.whl
     mv wheelhouse/*.whl /out
     make clean

--- a/python/astra/__init__.py
+++ b/python/astra/__init__.py
@@ -23,6 +23,13 @@
 #
 # -----------------------------------------------------------------------
 
+# Load CUDA shared libs
+from . import config_c as c
+if c.have_cuda():
+    from cuda.pathfinder import load_nvidia_dynamic_lib
+    load_nvidia_dynamic_lib('cudart')
+    load_nvidia_dynamic_lib('cufft')
+
 # Import astra module first to make error message less confusing in case of import error
 from . import astra
 

--- a/python/astra/config_c.pyx
+++ b/python/astra/config_c.pyx
@@ -1,0 +1,34 @@
+# -----------------------------------------------------------------------
+# Copyright: 2010-2022, imec Vision Lab, University of Antwerp
+#            2013-2022, CWI, Amsterdam
+#
+# Contact: astra@astra-toolbox.com
+# Website: http://www.astra-toolbox.com/
+#
+# This file is part of the ASTRA Toolbox.
+#
+#
+# The ASTRA Toolbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# The ASTRA Toolbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with the ASTRA Toolbox. If not, see <http://www.gnu.org/licenses/>.
+#
+# -----------------------------------------------------------------------
+#
+# distutils: language = c++
+
+include "config.pxi"
+
+def have_cuda():
+    IF HAVE_CUDA==True:
+        return True
+    ELSE:
+        return False

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,6 +9,7 @@ build-backend = "setuptools.build_meta"
 cuda = false
 
 [tool.astra.cuda]
+install_requires = ['cuda-pathfinder>=1.3.2,<2.0']
 cuda = true
 
 [tool.astra.linux_module]
@@ -16,17 +17,20 @@ extra_lib = [ 'astra/libastra.so*' ]
 cuda = false
 
 [tool.astra.linux_module_cuda]
+install_requires = ['cuda-pathfinder>=1.3.2,<2.0']
 extra_lib = [ 'astra/libastra.so*' ]
 cuda = true
 
 [tool.astra.windows_cuda]
-extra_lib = [ 'astra/AstraCuda64.dll', 'astra/cudart64_12.dll', 'astra/cufft64_11.dll' ]
+install_requires = ['cuda-pathfinder>=1.3.2,<2.0', 'nvidia-cuda-runtime-cu12==12.8.90', 'nvidia-cufft-cu12==11.3.3.83']
+extra_lib = [ 'astra/AstraCuda64.dll' ]
 cuda = true
 
 [tool.astra.pypi_linux_cuda]
-install_requires = ['nvidia-cuda-runtime-cu12==12.5.82', 'nvidia-cufft-cu12==11.2.3.61']
+install_requires = ['cuda-pathfinder>=1.3.2,<2.0', 'nvidia-cuda-runtime-cu12==12.5.82', 'nvidia-cufft-cu12==11.2.3.61']
 extra_lib = [ 'astra/libastra.so*' ]
 cuda = true
 
 [tool.astra.conda_cuda]
+install_requires = ['cuda-pathfinder>=1.3.2,<2.0']
 cuda = true


### PR DESCRIPTION
This PR loads CUDA shared libs at runtime using `cuda-pathfinder`. Same idea as #584 with the goal of beeing able to produce windows PyPI packages, but now using cuda-pathfinder as suggested in #51.

The idea of the config_c module is to have access to `HAVE_CUDA` at runtime to decide if CUDA needs to be loaded. This had to be separate that it can be loaded before modules that link the CUDA libraries.