### PR TITLE
Add support for 2D GPU dlpack tensors

### DIFF
--- a/cuda/3d/arith3d.cu
+++ b/cuda/3d/arith3d.cu
@@ -290,6 +290,7 @@ bool processVol3D(astra::CData3D *out, const astra::CData3D *in, const Stream &s
 	dim3 gridSize((dims[0]+15)/16, (dims[1]+511)/512);
 	float *pfOut = (float*)outs->getPtr().ptr;
 	unsigned int outPitch = outs->getPtr().pitch / sizeof(float);
+	assert(outs->getPtr().pitch == ins->getPtr().pitch);
 	const float *pfIn = (const float*)ins->getPtr().ptr;
 	unsigned int step = outs->getPtr().pitch/sizeof(float) * dims[1];
 
@@ -320,6 +321,7 @@ bool processVol3D(astra::CData3D *out, const astra::CData3D *in, float fParam, c
 	dim3 gridSize((dims[0]+15)/16, (dims[1]+511)/512);
 	float *pfOut = (float*)outs->getPtr().ptr;
 	unsigned int outPitch = outs->getPtr().pitch / sizeof(float);
+	assert(outs->getPtr().pitch == ins->getPtr().pitch);
 	const float *pfIn = (const float*)ins->getPtr().ptr;
 	unsigned int step = outs->getPtr().pitch/sizeof(float) * dims[1];
 
@@ -354,6 +356,8 @@ bool processVol3D(astra::CData3D *out, const astra::CData3D *in1, const astra::C
 	dim3 gridSize((dims[0]+15)/16, (dims[1]+511)/512);
 	float *pfOut = (float*)outs->getPtr().ptr;
 	unsigned int outPitch = outs->getPtr().pitch / sizeof(float);
+	assert(outs->getPtr().pitch == in1s->getPtr().pitch);
+	assert(outs->getPtr().pitch == in2s->getPtr().pitch);
 	const float *pfIn1 = (const float*)in1s->getPtr().ptr;
 	const float *pfIn2 = (const float*)in2s->getPtr().ptr;
 	unsigned int step = outs->getPtr().pitch/sizeof(float) * dims[1];
@@ -390,6 +394,8 @@ bool processVol3D(astra::CData3D *out, const astra::CData3D *in1, const astra::C
 	dim3 gridSize((dims[0]+15)/16, (dims[1]+511)/512);
 	float *pfOut = (float*)outs->getPtr().ptr;
 	unsigned int outPitch = outs->getPtr().pitch / sizeof(float);
+	assert(outs->getPtr().pitch == in1s->getPtr().pitch);
+	assert(outs->getPtr().pitch == in2s->getPtr().pitch);
 	const float *pfIn1 = (const float*)in1s->getPtr().ptr;
 	const float *pfIn2 = (const float*)in2s->getPtr().ptr;
 	unsigned int step = outs->getPtr().pitch/sizeof(float) * dims[1];

--- a/cuda/dlpack_support.cu
+++ b/cuda/dlpack_support.cu
@@ -50,14 +50,16 @@ CDataStorageDLPackGPU<DLT>::CDataStorageDLPackGPU(DLT *tensor_m)
 {
 	DLTensor *tensor = &m_pTensor->dl_tensor;
 
+	assert(tensor->ndim >= 2);
+
 	uint8_t* data = static_cast<uint8_t*>(tensor->data);
 	data += tensor->byte_offset;
-	unsigned int pitch = tensor->shape[2];
+	unsigned int pitch = tensor->shape[tensor->ndim-1];
 
 	ptr.ptr = data;
-	ptr.xsize = sizeof(float) * tensor->shape[2];
+	ptr.xsize = sizeof(float) * tensor->shape[tensor->ndim-1];
 	ptr.pitch = sizeof(float) * pitch;
-	ptr.ysize = tensor->shape[1];
+	ptr.ysize = tensor->shape[tensor->ndim-2];
 }
 
 

--- a/include/astra/Data.h
+++ b/include/astra/Data.h
@@ -94,10 +94,11 @@ public:
 	CDataStorage *getStorage() { return m_storage; }
 	const CDataStorage *getStorage() const { return m_storage; }
 
-	// Convenience functions as this is the common case
 	bool isFloat32Memory() const { return m_storage->isMemory() && m_storage->isFloat32(); }
 	float32 *getFloat32Memory() { return isFloat32Memory() ? dynamic_cast<CDataMemory<float32>*>(m_storage)->getData() : nullptr; }
 	const float32 *getFloat32Memory() const { return isFloat32Memory() ? dynamic_cast<const CDataMemory<float32>*>(m_storage)->getData() : nullptr; }
+
+	bool isFloat32GPU() const { return m_storage->isGPU() && m_storage->isFloat32(); }
 
 	// Legacy function. Maybe remove?
 	bool isInitialized() const { return true; }

--- a/python/astra/PyIncludes.pxd
+++ b/python/astra/PyIncludes.pxd
@@ -134,11 +134,11 @@ cdef extern from "astra/Algorithm.h" namespace "astra":
         bool isInitialized()
 
 cdef extern from "astra/ReconstructionAlgorithm2D.h" namespace "astra":
-    cdef cppclass CReconstructionAlgorithm2D:
+    cdef cppclass CReconstructionAlgorithm2D(CAlgorithm):
         bool getResidualNorm(float32&)
 
 cdef extern from "astra/ReconstructionAlgorithm3D.h" namespace "astra":
-    cdef cppclass CReconstructionAlgorithm3D:
+    cdef cppclass CReconstructionAlgorithm3D(CAlgorithm):
         bool getResidualNorm(float32&)
 
 cdef extern from "astra/Projector2D.h" namespace "astra":

--- a/python/astra/experimental.pyx
+++ b/python/astra/experimental.pyx
@@ -85,22 +85,16 @@ IF HAVE_CUDA==True:
             CCudaBackProjectionAlgorithm()
             bool initialize(CProjector2D*, CFloat32ProjectionData2D*, CFloat32VolumeData2D*)
 
-
-
     from . cimport PyProjector3DManager
     from .PyProjector3DManager cimport CProjector3DManager
     from . cimport PyData3DManager
     from .PyData3DManager cimport CData3DManager
-    from . cimport PyData2DManager
-    from .PyData2DManager cimport CData2DManager
 
-    cdef CProjector3DManager * manProj3D = <CProjector3DManager * >PyProjector3DManager.getSingletonPtr()
-    cdef CData2DManager * man2d = <CData2DManager * >PyData2DManager.getSingletonPtr()
-    cdef CData3DManager * man3d = <CData3DManager * >PyData3DManager.getSingletonPtr()
 
     def do_composite(projector_id, vol_ids, proj_ids, mode, t):
         if mode != MODE_ADD and mode != MODE_SET:
             raise AstraError("Internal error: wrong composite mode")
+        cdef CData3DManager * man3d = <CData3DManager * >PyData3DManager.getSingletonPtr()
         cdef EJobMode eMode = mode;
         cdef vector[CFloat32VolumeData3D *] vol
         cdef CFloat32VolumeData3D * pVolObject
@@ -121,6 +115,7 @@ IF HAVE_CUDA==True:
                 raise AstraError("Data object not initialized properly")
             proj.push_back(pProjObject)
         cdef CCompositeGeometryManager m
+        cdef CProjector3DManager * manProj3D = <CProjector3DManager * >PyProjector3DManager.getSingletonPtr()
         cdef CProjector3D * projector = manProj3D.get(projector_id) # may be NULL
         cdef bool ret = True
         if t == "FP":
@@ -149,6 +144,7 @@ IF HAVE_CUDA==True:
     def accumulate_FDK(projector_id, vol_id, proj_id):
         cdef CFloat32VolumeData3D * pVolObject
         cdef CFloat32ProjectionData3D * pProjObject
+        cdef CData3DManager * man3d = <CData3DManager * >PyData3DManager.getSingletonPtr()
         pVolObject = dynamic_cast_vol_mem(man3d.get(vol_id))
         if pVolObject == NULL:
             raise AstraError("Data object not found")
@@ -160,6 +156,7 @@ IF HAVE_CUDA==True:
         if not pProjObject.isInitialized():
             raise AstraError("Data object not initialized properly")
         cdef CCompositeGeometryManager m
+        cdef CProjector3DManager * manProj3D = <CProjector3DManager * >PyProjector3DManager.getSingletonPtr()
         cdef CProjector3D * projector = manProj3D.get(projector_id) # may be NULL
         cdef SFilterConfig filterConfig
         filterConfig.m_eType = FILTER_RAMLAK
@@ -176,6 +173,7 @@ IF HAVE_CUDA==True:
         if mode != MODE_ADD and mode != MODE_SET:
             raise AstraError("Internal error: wrong composite mode")
         cdef EJobMode eMode = mode
+        cdef CProjector3DManager * manProj3D = <CProjector3DManager * >PyProjector3DManager.getSingletonPtr()
         cdef CProjector3D * projector = manProj3D.get(projector_id)
         if projector == NULL:
             raise AstraError("Projector not found")

--- a/python/astra/experimental.pyx
+++ b/python/astra/experimental.pyx
@@ -28,9 +28,24 @@
 include "config.pxi"
 
 from . cimport utils
+from .PyIncludes cimport *
 from .utils import wrap_from_bytes
 from .utils cimport createProjectionGeometry3D
+from .utils cimport linkVolFromGeometry2D, linkProjFromGeometry2D
 from .log import AstraError
+
+from . cimport PyProjector2DManager
+from .PyProjector2DManager cimport CProjector2DManager
+
+cdef extern from "astra/ForwardProjectionAlgorithm.h" namespace "astra":
+    cdef cppclass CForwardProjectionAlgorithm(CAlgorithm):
+        CForwardProjectionAlgorithm(CProjector2D*, CFloat32VolumeData2D*, CFloat32ProjectionData2D*)
+cdef extern from "astra/BackProjectionAlgorithm.h" namespace "astra":
+    cdef cppclass CBackProjectionAlgorithm(CReconstructionAlgorithm2D):
+        CBackProjectionAlgorithm(CProjector2D*, CFloat32ProjectionData2D*, CFloat32VolumeData2D*)
+
+
+
 
 IF HAVE_CUDA==True:
 
@@ -59,6 +74,16 @@ IF HAVE_CUDA==True:
     cdef extern from *:
         CFloat32VolumeData3D * dynamic_cast_vol_mem "dynamic_cast<astra::CFloat32VolumeData3D*>" (CData3D * )
         CFloat32ProjectionData3D * dynamic_cast_proj_mem "dynamic_cast<astra::CFloat32ProjectionData3D*>" (CData3D * )
+        CCudaProjector2D* dynamic_cast_cuda_projector "dynamic_cast<astra::CCudaProjector2D*>" (CProjector2D*)
+
+    cdef extern from "astra/CudaForwardProjectionAlgorithm.h" namespace "astra":
+        cdef cppclass CCudaForwardProjectionAlgorithm(CAlgorithm):
+            CCudaForwardProjectionAlgorithm()
+            bool initialize(CProjector2D*, CFloat32VolumeData2D*, CFloat32ProjectionData2D*)
+    cdef extern from "astra/CudaBackProjectionAlgorithm.h" namespace "astra":
+        cdef cppclass CCudaBackProjectionAlgorithm(CReconstructionAlgorithm2D):
+            CCudaBackProjectionAlgorithm()
+            bool initialize(CProjector2D*, CFloat32ProjectionData2D*, CFloat32VolumeData2D*)
 
 
 
@@ -66,8 +91,11 @@ IF HAVE_CUDA==True:
     from .PyProjector3DManager cimport CProjector3DManager
     from . cimport PyData3DManager
     from .PyData3DManager cimport CData3DManager
+    from . cimport PyData2DManager
+    from .PyData2DManager cimport CData2DManager
 
-    cdef CProjector3DManager * manProj = <CProjector3DManager * >PyProjector3DManager.getSingletonPtr()
+    cdef CProjector3DManager * manProj3D = <CProjector3DManager * >PyProjector3DManager.getSingletonPtr()
+    cdef CData2DManager * man2d = <CData2DManager * >PyData2DManager.getSingletonPtr()
     cdef CData3DManager * man3d = <CData3DManager * >PyData3DManager.getSingletonPtr()
 
     def do_composite(projector_id, vol_ids, proj_ids, mode, t):
@@ -93,7 +121,7 @@ IF HAVE_CUDA==True:
                 raise AstraError("Data object not initialized properly")
             proj.push_back(pProjObject)
         cdef CCompositeGeometryManager m
-        cdef CProjector3D * projector = manProj.get(projector_id) # may be NULL
+        cdef CProjector3D * projector = manProj3D.get(projector_id) # may be NULL
         cdef bool ret = True
         if t == "FP":
             with nogil:
@@ -132,7 +160,7 @@ IF HAVE_CUDA==True:
         if not pProjObject.isInitialized():
             raise AstraError("Data object not initialized properly")
         cdef CCompositeGeometryManager m
-        cdef CProjector3D * projector = manProj.get(projector_id) # may be NULL
+        cdef CProjector3D * projector = manProj3D.get(projector_id) # may be NULL
         cdef SFilterConfig filterConfig
         filterConfig.m_eType = FILTER_RAMLAK
         cdef bool ret = True
@@ -148,7 +176,7 @@ IF HAVE_CUDA==True:
         if mode != MODE_ADD and mode != MODE_SET:
             raise AstraError("Internal error: wrong composite mode")
         cdef EJobMode eMode = mode
-        cdef CProjector3D * projector = manProj.get(projector_id)
+        cdef CProjector3D * projector = manProj3D.get(projector_id)
         if projector == NULL:
             raise AstraError("Projector not found")
         cdef CFloat32VolumeData3D * pVol = linkVolFromGeometry3D(projector.getVolumeGeometry(), vol)
@@ -181,10 +209,10 @@ IF HAVE_CUDA==True:
 
         :param projector_id: A 3D projector object handle
         :type datatype: :class:`int`
-        :param vol: The input data, as either a numpy array, or a GPULink object
-        :type datatype: :class:`numpy.ndarray` or :class:`astra.data3d.GPULink`
-        :param proj: The pre-allocated output data, either numpy array or GPULink
-        :type datatype: :class:`numpy.ndarray` or :class:`astra.data3d.GPULink`
+        :param vol: The input data, as either a numpy array, or other DLPack object
+        :type datatype: :class:`numpy.ndarray`
+        :param proj: The pre-allocated output data, either numpy array, or other DLPack object
+        :type datatype: :class:`numpy.ndarray`
         """
         direct_FPBP3D(projector_id, vol, proj, MODE_SET, "FP")
 
@@ -193,10 +221,10 @@ IF HAVE_CUDA==True:
 
         :param projector_id: A 3D projector object handle
         :type datatype: :class:`int`
-        :param vol: The pre-allocated output data, as either a numpy array, or a GPULink object
-        :type datatype: :class:`numpy.ndarray` or :class:`astra.data3d.GPULink`
-        :param proj: The input data, either numpy array or GPULink
-        :type datatype: :class:`numpy.ndarray` or :class:`astra.data3d.GPULink`
+        :param vol: The pre-allocated output data, as either a numpy array, or other DLPack object
+        :type datatype: :class:`numpy.ndarray`
+        :param proj: The input data, either numpy array, or other DLPack objects
+        :type datatype: :class:`numpy.ndarray`
         """
         direct_FPBP3D(projector_id, vol, proj, MODE_SET, "BP")
 
@@ -213,5 +241,105 @@ IF HAVE_CUDA==True:
         ppGeometry = createProjectionGeometry3D(geometry)
         ppGeometry.get().projectPoint(x, y, z, angle, u, v)
         return (u, v)
+
+    def direct_FPBP2D(projector_id, vol, proj, t):
+        cdef CProjector2DManager * manProj2D = <CProjector2DManager * >PyProjector2DManager.getSingletonPtr()
+        cdef CProjector2D * projector = manProj2D.get(projector_id)
+        if projector == NULL:
+            raise AstraError("Projector not found")
+        cdef CFloat32VolumeData2D * pVol = linkVolFromGeometry2D(projector.getVolumeGeometry(), vol)
+        cdef CFloat32ProjectionData2D * pProj = linkProjFromGeometry2D(projector.getProjectionGeometry(), proj)
+        cdef CAlgorithm *pAlg = NULL
+        cdef CCudaProjector2D *pCudaProj = dynamic_cast_cuda_projector(projector)
+        cdef bool ret = True
+        cdef CCudaForwardProjectionAlgorithm * pf
+        cdef CCudaBackProjectionAlgorithm * pb
+
+        try:
+            if pCudaProj == NULL:
+                if t == "FP":
+                    pAlg = new CForwardProjectionAlgorithm(projector, pVol, pProj)
+                elif t == "BP":
+                    pAlg = new CBackProjectionAlgorithm(projector, pProj, pVol)
+                else:
+                    raise AstraError("Internal error: wrong op type")
+            else:
+                if t == "FP":
+                    pf = new CCudaForwardProjectionAlgorithm()
+                    pf.initialize(projector, pVol, pProj)
+                    pAlg = pf
+                elif t == "BP":
+                    pb = new CCudaBackProjectionAlgorithm()
+                    pb.initialize(projector, pProj, pVol)
+                    pAlg = pb
+                else:
+                    raise AstraError("Internal error: wrong op type")
+
+            if not pAlg.isInitialized():
+                raise AstraError("Failed to initialize algorithm")
+
+            with nogil:
+                pAlg.run(1)
+        finally:
+            del pVol
+            del pProj
+            del pAlg
+
+ELSE:
+
+    def direct_FPBP2D(projector_id, vol, proj, t):
+        cdef CProjector2DManager * manProj2D = <CProjector2DManager * >PyProjector2DManager.getSingletonPtr()
+        cdef CProjector2D * projector = manProj2D.get(projector_id)
+        if projector == NULL:
+            raise AstraError("Projector not found")
+        cdef CFloat32VolumeData2D * pVol = linkVolFromGeometry2D(projector.getVolumeGeometry(), vol)
+        cdef CFloat32ProjectionData2D * pProj = linkProjFromGeometry2D(projector.getProjectionGeometry(), proj)
+        cdef CAlgorithm *pAlg = NULL
+        cdef bool ret = True
+
+        try:
+            if t == "FP":
+                pAlg = new CForwardProjectionAlgorithm(projector, pVol, pProj)
+            elif t == "BP":
+                pAlg = new CBackProjectionAlgorithm(projector, pProj, pVol)
+            else:
+                raise AstraError("Internal error: wrong op type")
+
+            if not pAlg.isInitialized():
+                raise AstraError("Failed to initialize algorithm")
+
+            with nogil:
+                pAlg.run(1)
+        finally:
+            del pVol
+            del pProj
+            del pAlg
+
+
+
+
+def direct_FP2D(projector_id, vol, proj):
+    """Perform a 2D forward projection with pre-allocated input/output.
+
+    :param projector_id: A 2D projector object handle
+    :type datatype: :class:`int`
+    :param vol: The input data, as either a numpy array, or other DLPack object
+    :type datatype: :class:`numpy.ndarray`
+    :param proj: The pre-allocated output data, either numpy array, or other DLPack object
+    :type datatype: :class:`numpy.ndarray`
+    """
+    direct_FPBP2D(projector_id, vol, proj, "FP")
+
+def direct_BP2D(projector_id, vol, proj):
+    """Perform a 2D back projection with pre-allocated input/output.
+
+    :param projector_id: A 2D projector object handle
+    :type datatype: :class:`int`
+    :param vol: The pre-allocated output data, as either a numpy array, or other DLPack object
+    :type datatype: :class:`numpy.ndarray`
+    :param proj: The input data, either numpy array, or other DLPack objects
+    :type datatype: :class:`numpy.ndarray`
+    """
+    direct_FPBP2D(projector_id, vol, proj, "BP")
 
 

--- a/python/astra/utils.pyx
+++ b/python/astra/utils.pyx
@@ -269,10 +269,6 @@ cdef CFloat32VolumeData2D* linkVolFromGeometry2D(const CVolumeGeometry2D &pGeome
         pDataObject2D = getDLTensor(capsule, pGeometry, dlerror)
         if not pDataObject2D:
             raise ValueError("Failed to link dlpack array: " + wrap_from_bytes(dlerror))
-        # TODO: Refactoring 2D GPU algorithms to support this
-        # (And add checks to the CPU algorithms that data is in host memory)
-        if not pDataObject2D.isFloat32Memory():
-            raise ValueError("For 2D objects, linking GPU tensors is not yet supported.")
         return pDataObject2D
 
     raise TypeError("Data should be an array with DLPack support")
@@ -289,10 +285,6 @@ cdef CFloat32ProjectionData2D* linkProjFromGeometry2D(const CProjectionGeometry2
         pDataObject2D = getDLTensor(capsule, pGeometry, dlerror)
         if not pDataObject2D:
             raise ValueError("Failed to link dlpack array: " + wrap_from_bytes(dlerror))
-        # TODO: Refactoring 2D GPU algorithms to support this
-        # (And add checks to the CPU algorithms that data is in host memory)
-        if not pDataObject2D.isFloat32Memory():
-            raise ValueError("For 2D objects, linking GPU tensors is not yet supported.")
         return pDataObject2D
 
     raise TypeError("Data should be an array with DLPack support")

--- a/src/ArtAlgorithm.cpp
+++ b/src/ArtAlgorithm.cpp
@@ -70,6 +70,12 @@ bool CArtAlgorithm::_check()
 		}
 	}
 
+	ASTRA_CONFIG_CHECK(m_pSinogram->isFloat32Memory(), "ART", "Projection data object not a float32 host memory object");
+	ASTRA_CONFIG_CHECK(m_pReconstruction->isFloat32Memory(), "ART", "Reconstruction data object not a float32 host memory object");
+
+	ASTRA_CONFIG_CHECK(!m_bUseSinogramMask || m_pSinogramMask->isFloat32Memory(), "ART", "Projection mask object not a float32 host memory object");
+	ASTRA_CONFIG_CHECK(!m_bUseReconstructionMask || m_pReconstructionMask->isFloat32Memory(), "ART", "Reconstruction mask object not a float32 host memory object");
+
 	// success
 	return true;
 }

--- a/src/BackProjectionAlgorithm.cpp
+++ b/src/BackProjectionAlgorithm.cpp
@@ -69,6 +69,12 @@ bool CBackProjectionAlgorithm::_check()
 	// check base class
 	ASTRA_CONFIG_CHECK(CReconstructionAlgorithm2D::_check(), "BP", "Error in ReconstructionAlgorithm2D initialization");
 
+	ASTRA_CONFIG_CHECK(m_pSinogram->isFloat32Memory(), "BP", "Projection data object not a float32 host memory object");
+	ASTRA_CONFIG_CHECK(m_pReconstruction->isFloat32Memory(), "BP", "Reconstruction data object not a float32 host memory object");
+
+	ASTRA_CONFIG_CHECK(!m_bUseSinogramMask || m_pSinogramMask->isFloat32Memory(), "BP", "Projection mask object not a float32 host memory object");
+	ASTRA_CONFIG_CHECK(!m_bUseReconstructionMask || m_pReconstructionMask->isFloat32Memory(), "BP", "Reconstruction mask object not a float32 host memory object");
+
 	return true;
 }
 

--- a/src/CglsAlgorithm.cpp
+++ b/src/CglsAlgorithm.cpp
@@ -79,6 +79,12 @@ bool CCglsAlgorithm::_check()
 	// check base class
 	ASTRA_CONFIG_CHECK(CReconstructionAlgorithm2D::_check(), "CGLS", "Error in ReconstructionAlgorithm2D initialization");
 
+	ASTRA_CONFIG_CHECK(m_pSinogram->isFloat32Memory(), "CGLS", "Projection data object not a float32 host memory object");
+	ASTRA_CONFIG_CHECK(m_pReconstruction->isFloat32Memory(), "CGLS", "Reconstruction data object not a float32 host memory object");
+
+	ASTRA_CONFIG_CHECK(!m_bUseSinogramMask || m_pSinogramMask->isFloat32Memory(), "CGLS", "Projection mask object not a float32 host memory object");
+	ASTRA_CONFIG_CHECK(!m_bUseReconstructionMask || m_pReconstructionMask->isFloat32Memory(), "CGLS", "Reconstruction mask object not a float32 host memory object");
+
 	return true;
 }
 

--- a/src/CudaBackProjectionAlgorithm.cpp
+++ b/src/CudaBackProjectionAlgorithm.cpp
@@ -86,7 +86,7 @@ bool CCudaBackProjectionAlgorithm::run(int /*_iNrIterations*/)
 {
 	assert(m_bIsInitialized);
 
-	bool ok;
+	bool ok = true;
 
 	std::array<int, 2> volDims = m_pReconstruction->getShape();
 	std::array<int, 2> projDims = m_pSinogram->getShape();
@@ -109,13 +109,30 @@ bool CCudaBackProjectionAlgorithm::run(int /*_iNrIterations*/)
 	}
 	CData2D *D_projData = new CData2D(projDims[0], projDims[1], s);
 
-	ok = astraCUDA::copyToGPUMemory(m_pSinogram, D_projData);
+	if (m_pSinogram->isFloat32Memory()) {
+		ok &= astraCUDA::copyToGPUMemory(m_pSinogram, D_projData);
+	} else if (m_pSinogram->isFloat32GPU()) {
+		// TODO: re-use memory instead of copying
+		// (need to ensure everything works when pitches are not consistent)
+		ok &= astraCUDA::assignGPUMemory(D_projData, m_pSinogram);
+	} else {
+		ok = false;
+	}
 
 	if (ok)
 		ok &= callBP(D_volData, D_projData, 1.0f);
 
-	if (ok)
-		ok &= astraCUDA::copyFromGPUMemory(m_pReconstruction, D_volData);
+	if (ok) {
+		if (m_pReconstruction->isFloat32Memory()) {
+			ok &= astraCUDA::copyFromGPUMemory(m_pReconstruction, D_volData);
+		} else if (m_pReconstruction->isFloat32GPU()) {
+			// TODO: re-use memory instead of copying
+			// (need to ensure everything works when pitches are not consistent)
+			ok &= astraCUDA::assignGPUMemory(m_pReconstruction, D_volData);
+		} else {
+			ok = false;
+		}
+	}
 
 	astraCUDA::freeGPUMemory(D_volData);
 	astraCUDA::freeGPUMemory(D_projData);

--- a/src/CudaCglsAlgorithm.cpp
+++ b/src/CudaCglsAlgorithm.cpp
@@ -173,17 +173,34 @@ bool CCudaCglsAlgorithm::run(int iterations)
 
 	m_bBuffersInitialized = true;
 
-	ASTRA_ASSERT(m_pSinogram->isFloat32Memory());
-	bool ok = astraCUDA::copyToGPUMemory(m_pSinogram, D_projData);
+	bool ok = true;
+
+	if (m_pSinogram->isFloat32Memory()) {
+		ok &= astraCUDA::copyToGPUMemory(m_pSinogram, D_projData);
+	} else if (m_pSinogram->isFloat32GPU()) {
+		// TODO: re-use memory instead of copying
+		// (need to ensure everything works when pitches are not consistent)
+		ok &= astraCUDA::assignGPUMemory(D_projData, m_pSinogram);
+	} else {
+		ok = false;
+	}
+	if (!ok)
+		return false;
 
 	if (m_bUseReconstructionMask) {
 		ASTRA_ASSERT(m_pReconstructionMask->isFloat32Memory());
 		ok &= astraCUDA::copyToGPUMemory(m_pReconstructionMask, D_volMaskData);
 	}
 
-	ASTRA_ASSERT(m_pReconstruction->isFloat32Memory());
-	ok &= astraCUDA::copyToGPUMemory(m_pReconstruction, D_volData);
-
+	if (m_pReconstruction->isFloat32Memory()) {
+		ok &= astraCUDA::copyToGPUMemory(m_pReconstruction, D_volData);
+	} else if (m_pReconstruction->isFloat32GPU()) {
+		// TODO: re-use memory instead of copying
+		// (need to ensure everything works when pitches are not consistent)
+		ok &= astraCUDA::assignGPUMemory(D_volData, m_pReconstruction);
+	} else {
+		ok = false;
+	}
 	if (!ok)
 		return false;
 
@@ -248,7 +265,17 @@ bool CCudaCglsAlgorithm::run(int iterations)
 
 	}
 
-	ok &= astraCUDA::copyFromGPUMemory(m_pReconstruction, D_volData);
+	if (ok) {
+		if (m_pReconstruction->isFloat32Memory()) {
+			ok &= astraCUDA::copyFromGPUMemory(m_pReconstruction, D_volData);
+		} else if (m_pReconstruction->isFloat32GPU()) {
+			// TODO: re-use memory instead of copying
+			// (need to ensure everything works when pitches are not consistent)
+			ok &= astraCUDA::assignGPUMemory(m_pReconstruction, D_volData);
+		} else {
+			ok = false;
+		}
+	}
 	if (!ok)
 		return false;
 

--- a/src/CudaCglsAlgorithm3D.cpp
+++ b/src/CudaCglsAlgorithm3D.cpp
@@ -91,6 +91,11 @@ bool CCudaCglsAlgorithm3D::_check()
 	ASTRA_CONFIG_CHECK(!m_bUseMaxConstraint, "CGLS3D", "MaxConstraint is not supported");
 	ASTRA_CONFIG_CHECK(!m_bUseSinogramMask, "CGLS3D", "SinogramMask is not supported");
 
+	ASTRA_CONFIG_CHECK(m_pSinogram->isFloat32Memory(), "CGLS3D", "Projection data object not a float32 host memory object");
+	ASTRA_CONFIG_CHECK(m_pReconstruction->isFloat32Memory(), "CGLS3D", "Reconstruction data object not a float32 host memory object");
+
+	ASTRA_CONFIG_CHECK(!m_bUseReconstructionMask || m_pReconstructionMask->isFloat32Memory(), "CGLS3D", "Reconstruction mask object not a float32 host memory object");
+
 	return true;
 }
 

--- a/src/CudaEMAlgorithm.cpp
+++ b/src/CudaEMAlgorithm.cpp
@@ -180,16 +180,35 @@ bool CCudaEMAlgorithm::run(int _iNrIterations)
 	if (m_iGPUIndex != -1)
 		astraCUDA::setGPUIndex(m_iGPUIndex);
 
+	bool ok = true;
+
 	if (!m_bBuffersInitialized) {
 		precomputeWeights();
 		m_bBuffersInitialized = true;
 	}
 
-	ASTRA_ASSERT(m_pSinogram->isFloat32Memory());
-	bool ok = astraCUDA::copyToGPUMemory(m_pSinogram, D_projData);
+	if (m_pSinogram->isFloat32Memory()) {
+		ok &= astraCUDA::copyToGPUMemory(m_pSinogram, D_projData);
+	} else if (m_pSinogram->isFloat32GPU()) {
+		// TODO: re-use memory instead of copying
+		// (need to ensure everything works when pitches are not consistent)
+		ok &= astraCUDA::assignGPUMemory(D_projData, m_pSinogram);
+	} else {
+		ok = false;
+	}
 
-	ASTRA_ASSERT(m_pReconstruction->isFloat32Memory());
-	ok &= astraCUDA::copyToGPUMemory(m_pReconstruction, D_volData);
+	if (!ok)
+		return false;
+
+	if (m_pReconstruction->isFloat32Memory()) {
+		ok &= astraCUDA::copyToGPUMemory(m_pReconstruction, D_volData);
+	} else if (m_pReconstruction->isFloat32GPU()) {
+		// TODO: re-use memory instead of copying
+		// (need to ensure everything works when pitches are not consistent)
+		ok &= astraCUDA::assignGPUMemory(D_volData, m_pReconstruction);
+	} else {
+		ok = false;
+	}
 
 	if (!ok)
 		return false;
@@ -213,7 +232,19 @@ bool CCudaEMAlgorithm::run(int _iNrIterations)
 
 	}
 
-	ok &= astraCUDA::copyFromGPUMemory(m_pReconstruction, D_volData);
+	if (ok) {
+		if (m_pReconstruction->isFloat32Memory()) {
+			ok &= astraCUDA::copyFromGPUMemory(m_pReconstruction, D_volData);
+		} else if (m_pReconstruction->isFloat32GPU()) {
+			// TODO: re-use memory instead of copying
+			// (need to ensure everything works when pitches are not consistent)
+			ok &= astraCUDA::assignGPUMemory(m_pReconstruction, D_volData);
+		} else {
+			ok = false;
+		}
+	}
+
+
 	if (!ok)
 		return false;
 

--- a/src/CudaFilteredBackProjectionAlgorithm.cpp
+++ b/src/CudaFilteredBackProjectionAlgorithm.cpp
@@ -163,7 +163,7 @@ bool CCudaFilteredBackProjectionAlgorithm::run(int /*_iNrIterations*/)
 {
 	assert(m_bIsInitialized);
 
-	bool ok;
+	bool ok = true;
 
 	std::array<int, 2> volDims = m_pReconstruction->getShape();
 	std::array<int, 2> projDims = m_pSinogram->getShape();
@@ -186,7 +186,15 @@ bool CCudaFilteredBackProjectionAlgorithm::run(int /*_iNrIterations*/)
 	}
 	CData2D *D_projData = new CData2D(projDims[0], projDims[1], s);
 
-	ok = astraCUDA::copyToGPUMemory(m_pSinogram, D_projData);
+	if (m_pSinogram->isFloat32Memory()) {
+		ok &= astraCUDA::copyToGPUMemory(m_pSinogram, D_projData);
+	} else if (m_pSinogram->isFloat32GPU()) {
+		// TODO: re-use memory instead of copying
+		// (need to ensure everything works when pitches are not consistent)
+		ok &= astraCUDA::assignGPUMemory(D_projData, m_pSinogram);
+	} else {
+		ok = false;
+	}
 
 	astraCUDA::SProjectorParams2D params = m_params;
 	float fPixelArea = m_pReconstruction->getGeometry().getPixelArea();
@@ -195,8 +203,18 @@ bool CCudaFilteredBackProjectionAlgorithm::run(int /*_iNrIterations*/)
 	if (ok)
 		ok &= FBP(D_volData, D_projData, m_geometry, params, m_filter, m_bShortScan);
 
-	if (ok)
-		ok &= astraCUDA::copyFromGPUMemory(m_pReconstruction, D_volData);
+	if (ok) {
+		if (m_pReconstruction->isFloat32Memory()) {
+			ok &= astraCUDA::copyFromGPUMemory(m_pReconstruction, D_volData);
+		} else if (m_pReconstruction->isFloat32GPU()) {
+			// TODO: re-use memory instead of copying
+			// (need to ensure everything works when pitches are not consistent)
+			ok &= astraCUDA::assignGPUMemory(m_pReconstruction, D_volData);
+		} else {
+			ok = false;
+		}
+	}
+
 
 	astraCUDA::freeGPUMemory(D_volData);
 	astraCUDA::freeGPUMemory(D_projData);

--- a/src/CudaForwardProjectionAlgorithm.cpp
+++ b/src/CudaForwardProjectionAlgorithm.cpp
@@ -173,7 +173,7 @@ bool CCudaForwardProjectionAlgorithm::run(int)
 	// check initialized
 	assert(m_bIsInitialized);
 
-	bool ok;
+	bool ok = true;
 
 	const CVolumeGeometry2D &pVolGeom = m_pVolume->getGeometry();
 	const CProjectionGeometry2D &pProjGeom = m_pSinogram->getGeometry();
@@ -206,13 +206,30 @@ bool CCudaForwardProjectionAlgorithm::run(int)
 	}
 	CData2D *D_projData = new CData2D(projDims[0], projDims[1], s);
 
-	ok = astraCUDA::copyToGPUMemory(m_pVolume, D_volData);
+	if (m_pVolume->isFloat32Memory()) {
+		ok &= astraCUDA::copyToGPUMemory(m_pVolume, D_volData);
+	} else if (m_pVolume->isFloat32GPU()) {
+		// TODO: re-use memory instead of copying
+		// (need to ensure everything works when pitches are not consistent)
+		ok &= astraCUDA::assignGPUMemory(D_volData, m_pVolume);
+	} else {
+		ok = false;
+	}
 
 	if (ok)
 		ok &= astraCUDA::FP(D_projData, D_volData, geom, params);
 
-	if (ok)
-		ok &= astraCUDA::copyFromGPUMemory(m_pSinogram, D_projData);
+	if (ok) {
+		if (m_pSinogram->isFloat32Memory()) {
+			ok &= astraCUDA::copyFromGPUMemory(m_pSinogram, D_projData);
+		} else if (m_pSinogram->isFloat32GPU()) {
+			// TODO: re-use memory instead of copying
+			// (need to ensure everything works when pitches are not consistent)
+			ok &= astraCUDA::assignGPUMemory(m_pSinogram, D_projData);
+		} else {
+			ok = false;
+		}
+	}
 
 	astraCUDA::freeGPUMemory(D_volData);
 	astraCUDA::freeGPUMemory(D_projData);

--- a/src/CudaSartAlgorithm.cpp
+++ b/src/CudaSartAlgorithm.cpp
@@ -225,9 +225,9 @@ bool CCudaSartAlgorithm::run(int _iNrIterations)
 	if (m_iGPUIndex != -1)
 		astraCUDA::setGPUIndex(m_iGPUIndex);
 
+	bool ok = true;
 
 	if (!m_bBuffersInitialized) {
-		bool ok = true;
 		if (!m_bUseReconstructionMask)
 			ok = precomputeWeights();
 		if (!ok)
@@ -235,14 +235,33 @@ bool CCudaSartAlgorithm::run(int _iNrIterations)
 		m_bBuffersInitialized = true;
 	}
 
-	ASTRA_ASSERT(m_pSinogram->isFloat32Memory());
-	bool ok = astraCUDA::copyToGPUMemory(m_pSinogram, D_projData);
+	if (m_pSinogram->isFloat32Memory()) {
+		ok &= astraCUDA::copyToGPUMemory(m_pSinogram, D_projData);
+	} else if (m_pSinogram->isFloat32GPU()) {
+		// TODO: re-use memory instead of copying
+		// (need to ensure everything works when pitches are not consistent)
+		ok &= astraCUDA::assignGPUMemory(D_projData, m_pSinogram);
+	} else {
+		ok = false;
+	}
+
+	if (!ok)
+		return false;
+
 	if (m_bUseReconstructionMask) {
 		ASTRA_ASSERT(m_pReconstructionMask->isFloat32Memory());
 		ok &= astraCUDA::copyToGPUMemory(m_pReconstructionMask, D_volMaskData);
 	}
-	ASTRA_ASSERT(m_pReconstruction->isFloat32Memory());
-	ok &= astraCUDA::copyToGPUMemory(m_pReconstruction, D_volData);
+
+	if (m_pReconstruction->isFloat32Memory()) {
+		ok &= astraCUDA::copyToGPUMemory(m_pReconstruction, D_volData);
+	} else if (m_pReconstruction->isFloat32GPU()) {
+		// TODO: re-use memory instead of copying
+		// (need to ensure everything works when pitches are not consistent)
+		ok &= astraCUDA::assignGPUMemory(D_volData, m_pReconstruction);
+	} else {
+		ok = false;
+	}
 
 	if (!ok)
 		return false;
@@ -295,7 +314,18 @@ bool CCudaSartAlgorithm::run(int _iNrIterations)
 
 	}
 
-	ok &= astraCUDA::copyFromGPUMemory(m_pReconstruction, D_volData);
+	if (ok) {
+		if (m_pReconstruction->isFloat32Memory()) {
+			ok &= astraCUDA::copyFromGPUMemory(m_pReconstruction, D_volData);
+		} else if (m_pReconstruction->isFloat32GPU()) {
+			// TODO: re-use memory instead of copying
+			// (need to ensure everything works when pitches are not consistent)
+			ok &= astraCUDA::assignGPUMemory(m_pReconstruction, D_volData);
+		} else {
+			ok = false;
+		}
+	}
+
 	if (!ok)
 		return false;
 

--- a/src/CudaSirtAlgorithm.cpp
+++ b/src/CudaSirtAlgorithm.cpp
@@ -303,9 +303,18 @@ bool CCudaSirtAlgorithm::run(int _iNrIterations)
 		m_bBuffersInitialized = true;
 	}
 
-	ASTRA_ASSERT(m_pSinogram->isFloat32Memory());
+	if (m_pSinogram->isFloat32Memory()) {
+		ok &= astraCUDA::copyToGPUMemory(m_pSinogram, D_projData);
+	} else if (m_pSinogram->isFloat32GPU()) {
+		// TODO: re-use memory instead of copying
+		// (need to ensure everything works when pitches are not consistent)
+		ok &= astraCUDA::assignGPUMemory(D_projData, m_pSinogram);
+	} else {
+		ok = false;
+	}
 
-	ok &= astraCUDA::copyToGPUMemory(m_pSinogram, D_projData);
+	if (!ok)
+		return false;
 
 	if (m_bUseReconstructionMask) {
 		ASTRA_ASSERT(m_pReconstructionMask->isFloat32Memory());
@@ -316,8 +325,15 @@ bool CCudaSirtAlgorithm::run(int _iNrIterations)
 		ok &= astraCUDA::copyToGPUMemory(m_pSinogramMask, D_projMaskData);
 	}
 
-	ASTRA_ASSERT(m_pReconstruction->isFloat32Memory());
-	ok &= astraCUDA::copyToGPUMemory(m_pReconstruction, D_volData);
+	if (m_pReconstruction->isFloat32Memory()) {
+		ok &= astraCUDA::copyToGPUMemory(m_pReconstruction, D_volData);
+	} else if (m_pReconstruction->isFloat32GPU()) {
+		// TODO: re-use memory instead of copying
+		// (need to ensure everything works when pitches are not consistent)
+		ok &= astraCUDA::assignGPUMemory(D_volData, m_pReconstruction);
+	} else {
+		ok = false;
+	}
 
 	if (!ok)
 		return false;
@@ -362,7 +378,18 @@ bool CCudaSirtAlgorithm::run(int _iNrIterations)
 			astraCUDA::processData<astraCUDA::opClampMaxMask>(D_volData, D_maxMaskData);
 	}
 
-	ok &= astraCUDA::copyFromGPUMemory(m_pReconstruction, D_volData);
+	if (ok) {
+		if (m_pReconstruction->isFloat32Memory()) {
+			ok &= astraCUDA::copyFromGPUMemory(m_pReconstruction, D_volData);
+		} else if (m_pReconstruction->isFloat32GPU()) {
+			// TODO: re-use memory instead of copying
+			// (need to ensure everything works when pitches are not consistent)
+			ok &= astraCUDA::assignGPUMemory(m_pReconstruction, D_volData);
+		} else {
+			ok = false;
+		}
+	}
+
 	if (!ok)
 		return false;
 

--- a/src/CudaSirtAlgorithm3D.cpp
+++ b/src/CudaSirtAlgorithm3D.cpp
@@ -87,6 +87,11 @@ bool CCudaSirtAlgorithm3D::_check()
 	// check base class
 	ASTRA_CONFIG_CHECK(CReconstructionAlgorithm3D::_check(), "SIRT3D", "Error in ReconstructionAlgorithm3D initialization");
 
+	ASTRA_CONFIG_CHECK(m_pSinogram->isFloat32Memory(), "SIRT3D", "Projection data object not a float32 host memory object");
+	ASTRA_CONFIG_CHECK(m_pReconstruction->isFloat32Memory(), "SIRT3D", "Reconstruction data object not a float32 host memory object");
+
+	ASTRA_CONFIG_CHECK(!m_bUseSinogramMask || m_pSinogramMask->isFloat32Memory(), "SIRT3D", "Projection mask object not a float32 host memory object");
+	ASTRA_CONFIG_CHECK(!m_bUseReconstructionMask || m_pReconstructionMask->isFloat32Memory(), "SIRT3D", "Reconstruction mask object not a float32 host memory object");
 
 	return true;
 }

--- a/src/FilteredBackProjectionAlgorithm.cpp
+++ b/src/FilteredBackProjectionAlgorithm.cpp
@@ -140,6 +140,9 @@ bool CFilteredBackProjectionAlgorithm::_check()
 
 	ASTRA_CONFIG_CHECK(checkCustomFilterSize(m_filterConfig, m_pSinogram->getGeometry()), "FBP", "Filter size mismatch");
 
+	ASTRA_CONFIG_CHECK(m_pSinogram->isFloat32Memory(), "FBP", "Projection data object not a float32 host memory object");
+	ASTRA_CONFIG_CHECK(m_pReconstruction->isFloat32Memory(), "FBP", "Reconstruction data object not a float32 host memory object");
+
 	// success
 	return true;
 }

--- a/src/ForwardProjectionAlgorithm.cpp
+++ b/src/ForwardProjectionAlgorithm.cpp
@@ -86,6 +86,12 @@ bool CForwardProjectionAlgorithm::_check()
 	ASTRA_CONFIG_CHECK(m_pSinogram->getGeometry().isEqual(m_pProjector->getProjectionGeometry()), "ForwardProjection", "Projection Data not compatible with the specified Projector.");
 	ASTRA_CONFIG_CHECK(m_pVolume->getGeometry().isEqual(m_pProjector->getVolumeGeometry()), "ForwardProjection", "Volume Data not compatible with the specified Projector.");
 
+	ASTRA_CONFIG_CHECK(m_pSinogram->isFloat32Memory(), "ForwardProjection", "Projection data object not a float32 host memory object");
+	ASTRA_CONFIG_CHECK(m_pVolume->isFloat32Memory(), "ForwardProjection", "Volume data object not a float32 host memory object");
+
+	ASTRA_CONFIG_CHECK(!m_bUseSinogramMask || m_pSinogramMask->isFloat32Memory(), "ForwardProjection", "Projection mask object not a float32 host memory object");
+	ASTRA_CONFIG_CHECK(!m_bUseVolumeMask || m_pVolumeMask->isFloat32Memory(), "ForwardProjection", "Volume mask object not a float32 host memory object");
+
 	// success
 	return true;
 }

--- a/src/ReconstructionAlgorithm3D.cpp
+++ b/src/ReconstructionAlgorithm3D.cpp
@@ -205,6 +205,9 @@ bool CReconstructionAlgorithm3D::_check()
 	ASTRA_CONFIG_CHECK(m_pReconstruction->getGeometry()->isEqual(m_pProjector->getVolumeGeometry()), "Reconstruction3D", "Reconstruction Data not compatible with the specified Projector.");
 #endif
 
+	ASTRA_CONFIG_CHECK(!m_bUseSinogramMask || m_pSinogramMask, "Reconstruction3D", "Projection mask object not valid");
+	ASTRA_CONFIG_CHECK(!m_bUseReconstructionMask || m_pReconstructionMask, "Reconstruction3D", "Reconstruction mask object not valid");
+
 	// success
 	return true;
 }

--- a/src/SartAlgorithm.cpp
+++ b/src/SartAlgorithm.cpp
@@ -207,6 +207,12 @@ bool CSartAlgorithm::_check()
 		ASTRA_CONFIG_CHECK(0 <= m_piProjectionOrder[i] && m_piProjectionOrder[i] < m_pProjector->getProjectionGeometry().getProjectionAngleCount(), "SART", "Projection Order out of range.");
 	}
 
+	ASTRA_CONFIG_CHECK(m_pSinogram->isFloat32Memory(), "SART", "Projection data object not a float32 host memory object");
+	ASTRA_CONFIG_CHECK(m_pReconstruction->isFloat32Memory(), "SART", "Reconstruction data object not a float32 host memory object");
+
+	ASTRA_CONFIG_CHECK(!m_bUseSinogramMask || m_pSinogramMask->isFloat32Memory(), "SART", "Projection mask object not a float32 host memory object");
+	ASTRA_CONFIG_CHECK(!m_bUseReconstructionMask || m_pReconstructionMask->isFloat32Memory(), "SART", "Reconstruction mask object not a float32 host memory object");
+
 	return true;
 }
 

--- a/src/SirtAlgorithm.cpp
+++ b/src/SirtAlgorithm.cpp
@@ -85,6 +85,12 @@ bool CSirtAlgorithm::_check()
 	ASTRA_CONFIG_CHECK(m_pDiffSinogram, "SIRT", "Invalid DiffSinogram Object");
 	ASTRA_CONFIG_CHECK(m_pDiffSinogram->isInitialized(), "SIRT", "Invalid DiffSinogram Object");
 
+	ASTRA_CONFIG_CHECK(m_pSinogram->isFloat32Memory(), "SIRT", "Projection data object not a float32 host memory object");
+	ASTRA_CONFIG_CHECK(m_pReconstruction->isFloat32Memory(), "SIRT", "Reconstruction data object not a float32 host memory object");
+
+	ASTRA_CONFIG_CHECK(!m_bUseSinogramMask || m_pSinogramMask->isFloat32Memory(), "SIRT", "Projection mask object not a float32 host memory object");
+	ASTRA_CONFIG_CHECK(!m_bUseReconstructionMask || m_pReconstructionMask->isFloat32Memory(), "SIRT", "Reconstruction mask object not a float32 host memory object");
+
 	return true;
 }
 

--- a/tests/python/integration/test_dlpack2d.py
+++ b/tests/python/integration/test_dlpack2d.py
@@ -3,15 +3,12 @@ import astra.experimental
 import numpy as np
 import pytest
 
-DET_SPACING_X = 1.0
-DET_SPACING_Y = 1.0
-DET_ROW_COUNT = 20
-DET_COL_COUNT = 45
+DET_SPACING = 1.0
+DET_COUNT = 45
 N_ANGLES = 180
 ANGLES = np.linspace(0, 2 * np.pi, N_ANGLES, endpoint=False)
 N_ROWS = 40
 N_COLS = 30
-N_SLICES = 50
 DATA_INIT_VALUE = 1.0
 
 
@@ -35,42 +32,32 @@ def _convert_to_backend(data, backend):
         return jax.device_put(data, device=jax.devices('cuda')[0])
 
 
-@pytest.fixture(params=['full', 'singleton_rows', 'singleton_cols', 'singleton_slices',
-                        'singleton_rows_cols', 'singleton_rows_slices', 'singleton_cols_slices',
-                        'singleton_rows_cols_slices'])
+@pytest.fixture(params=['full', 'singleton_rows', 'singleton_cols', 'singleton_rows_cols'])
 def vol_geom(request):
     if request.param == 'full':
-        return astra.create_vol_geom(N_ROWS, N_COLS, N_SLICES)
+        return astra.create_vol_geom(N_ROWS, N_COLS)
     elif request.param.startswith('singleton'):
-        dims = [N_SLICES, N_ROWS, N_COLS]
+        dims = [N_ROWS, N_COLS]
         for dim in request.param.split('_')[1:]:
             if dim == 'rows':
-                dims[1] = 1
-            elif dim == 'cols':
-                dims[2] = 1
-            elif dim == 'slices':
                 dims[0] = 1
+            elif dim == 'cols':
+                dims[1] = 1
         return astra.create_vol_geom(*dims)
 
 
-@pytest.fixture(params=['full', 'singleton_rows', 'singleton_angles', 'singleton_cols',
-                        'singleton_rows_angles', 'singleton_rows_cols', 'singleton_angles_cols',
-                        'singleton_rows_angles_cols'])
+@pytest.fixture(params=['full', 'singleton_angles', 'singleton_cols', 'singleton_angles_cols'])
 def proj_geom(request):
     if request.param == 'full':
-        return astra.create_proj_geom('parallel3d', DET_SPACING_X, DET_SPACING_Y,
-                                      DET_ROW_COUNT, DET_COL_COUNT, ANGLES)
+        return astra.create_proj_geom('parallel', DET_SPACING, DET_COUNT, ANGLES)
     elif request.param.startswith('singleton'):
-        rows, n_angles, cols = DET_ROW_COUNT, N_ANGLES, DET_COL_COUNT
+        n_angles, cols = N_ANGLES, DET_COUNT
         for dim in request.param.split('_')[1:]:
-            if dim == 'rows':
-                rows = 1
-            elif dim == 'angles':
+            if dim == 'angles':
                 n_angles = 1
             elif dim == 'cols':
                 cols = 1
-        return astra.create_proj_geom('parallel3d', DET_SPACING_X, DET_SPACING_Y,
-                                      rows, cols, ANGLES[:n_angles])
+        return astra.create_proj_geom('parallel', DET_SPACING, cols, ANGLES[:n_angles])
 
 
 @pytest.fixture
@@ -89,24 +76,24 @@ def proj_data(backend, proj_geom):
 
 @pytest.fixture
 def projector(vol_geom, proj_geom):
-    projector_id = astra.create_projector('cuda3d', proj_geom, vol_geom)
+    projector_id = astra.create_projector('cuda', proj_geom, vol_geom)
     yield projector_id
-    astra.projector3d.delete(projector_id)
+    astra.projector.delete(projector_id)
 
 
 @pytest.fixture
-def reference_fp(vol_geom, proj_geom):
-    vol_data_id = astra.data3d.create('-vol', vol_geom, DATA_INIT_VALUE)
-    data_id, data = astra.create_sino3d_gpu(vol_data_id, proj_geom, vol_geom)
-    astra.data3d.delete(data_id)
+def reference_fp(vol_geom, projector):
+    vol_data_id = astra.data2d.create('-vol', vol_geom, DATA_INIT_VALUE)
+    data_id, data = astra.create_sino(vol_data_id, projector)
+    astra.data2d.delete(data_id)
     return data
 
 
 @pytest.fixture
-def reference_bp(vol_geom, proj_geom):
-    proj_data_id = astra.data3d.create('-sino', proj_geom, DATA_INIT_VALUE)
-    data_id, data = astra.create_backprojection3d_gpu(proj_data_id, proj_geom, vol_geom)
-    astra.data3d.delete(data_id)
+def reference_bp(proj_geom, projector):
+    proj_data_id = astra.data2d.create('-sino', proj_geom, DATA_INIT_VALUE)
+    data_id, data = astra.create_backprojection(proj_data_id, projector)
+    astra.data2d.delete(data_id)
     return data
 
 
@@ -121,24 +108,24 @@ def proj_data_non_contiguous(backend, proj_geom):
                                      'jax_cpu', 'jax_cuda'])
 class TestAll:
     def test_backends_fp(self, backend, projector, vol_data, proj_data, reference_fp):
-        astra.experimental.direct_FP3D(projector, vol_data, proj_data)
+        astra.experimental.direct_FP2D(projector, vol_data, proj_data)
         if backend.startswith('pytorch'):
             proj_data = proj_data.cpu()
         assert np.allclose(proj_data, reference_fp)
 
     def test_backends_bp(self, backend, projector, vol_data, proj_data, reference_bp):
-        astra.experimental.direct_BP3D(projector, vol_data, proj_data)
+        astra.experimental.direct_BP2D(projector, vol_data, proj_data)
         if backend.startswith('pytorch'):
             vol_data = vol_data.cpu()
         assert np.allclose(vol_data, reference_bp)
-    
+
     @pytest.mark.parametrize('proj_geom', ['full'], indirect=True)
     def test_non_contiguous(self, backend, proj_geom, proj_data_non_contiguous):
         if backend.startswith('jax'):
             # JAX should not produce non-contiguous tensors, so nothing to test
             return
         with pytest.raises(ValueError):
-            astra.data3d.link('-sino', proj_geom, proj_data_non_contiguous)        
+            astra.data2d.link('-sino', proj_geom, proj_data_non_contiguous)
 
 
 @pytest.mark.parametrize('backend', ['numpy'])
@@ -148,4 +135,4 @@ def test_read_only(backend, vol_geom, vol_data):
     # BufferError for numpy < 2 which doesn't support exporting read-only arrays
     # ValueError for numpy >= 2 where astra rejects the read-only array
     with pytest.raises((ValueError, BufferError)):
-        astra.data3d.link('-vol', vol_geom, vol_data)
+        astra.data2d.link('-vol', vol_geom, vol_data)

--- a/tests/python/integration/test_dlpack3d.py
+++ b/tests/python/integration/test_dlpack3d.py
@@ -1,0 +1,151 @@
+import astra
+import astra.experimental
+import numpy as np
+import pytest
+
+DET_SPACING_X = 1.0
+DET_SPACING_Y = 1.0
+DET_ROW_COUNT = 20
+DET_COL_COUNT = 45
+N_ANGLES = 180
+ANGLES = np.linspace(0, 2 * np.pi, N_ANGLES, endpoint=False)
+N_ROWS = 40
+N_COLS = 30
+N_SLICES = 50
+DATA_INIT_VALUE = 1.0
+
+
+def _convert_to_backend(data, backend):
+    if backend == 'numpy':
+        return data
+    elif backend == 'pytorch_cpu':
+        import torch
+        return torch.tensor(data, device='cpu')
+    elif backend == 'pytorch_cuda':
+        import torch
+        return torch.tensor(data, device='cuda')
+    elif backend == 'cupy':
+        import cupy as cp
+        return cp.array(data)
+    elif backend == 'jax_cpu':
+        import jax
+        return jax.device_put(data, device=jax.devices('cpu')[0])
+    elif backend == 'jax_cuda':
+        import jax
+        return jax.device_put(data, device=jax.devices('cuda')[0])
+
+
+@pytest.fixture(params=['full', 'singleton_rows', 'singleton_cols', 'singleton_slices',
+                        'singleton_rows_cols', 'singleton_rows_slices', 'singleton_cols_slices',
+                        'singleton_rows_cols_slices'])
+def vol_geom(request):
+    if request.param == 'full':
+        return astra.create_vol_geom(N_ROWS, N_COLS, N_SLICES)
+    elif request.param.startswith('singleton'):
+        dims = [N_SLICES, N_ROWS, N_COLS]
+        for dim in request.param.split('_')[1:]:
+            if dim == 'rows':
+                dims[1] = 1
+            elif dim == 'cols':
+                dims[2] = 1
+            elif dim == 'slices':
+                dims[0] = 1
+        return astra.create_vol_geom(*dims)
+
+
+@pytest.fixture(params=['full', 'singleton_rows', 'singleton_angles', 'singleton_cols',
+                        'singleton_rows_angles', 'singleton_rows_cols', 'singleton_angles_cols',
+                        'singleton_rows_angles_cols'])
+def proj_geom(request):
+    if request.param == 'full':
+        return astra.create_proj_geom('parallel3d', DET_SPACING_X, DET_SPACING_Y,
+                                      DET_ROW_COUNT, DET_COL_COUNT, ANGLES)
+    elif request.param.startswith('singleton'):
+        rows, n_angles, cols = DET_ROW_COUNT, N_ANGLES, DET_COL_COUNT
+        for dim in request.param.split('_')[1:]:
+            if dim == 'rows':
+                rows = 1
+            elif dim == 'angles':
+                n_angles = 1
+            elif dim == 'cols':
+                cols = 1
+        return astra.create_proj_geom('parallel3d', DET_SPACING_X, DET_SPACING_Y,
+                                      rows, cols, ANGLES[:n_angles])
+
+
+@pytest.fixture
+def vol_data(backend, vol_geom):
+    shape = astra.geom_size(vol_geom)
+    data = np.full(shape, DATA_INIT_VALUE, dtype=np.float32)
+    return _convert_to_backend(data, backend)
+
+
+@pytest.fixture
+def proj_data(backend, proj_geom):
+    shape = astra.geom_size(proj_geom)
+    data = np.full(shape, DATA_INIT_VALUE, dtype=np.float32)
+    return _convert_to_backend(data, backend)
+
+
+@pytest.fixture
+def projector(vol_geom, proj_geom):
+    projector_id = astra.create_projector('cuda3d', proj_geom, vol_geom)
+    yield projector_id
+    astra.projector3d.delete(projector_id)
+
+
+@pytest.fixture
+def reference_fp(vol_geom, proj_geom):
+    vol_data_id = astra.data3d.create('-vol', vol_geom, DATA_INIT_VALUE)
+    data_id, data = astra.create_sino3d_gpu(vol_data_id, proj_geom, vol_geom)
+    astra.data3d.delete(data_id)
+    return data
+
+
+@pytest.fixture
+def reference_bp(vol_geom, proj_geom):
+    proj_data_id = astra.data3d.create('-proj3d', proj_geom, DATA_INIT_VALUE)
+    data_id, data = astra.create_backprojection3d_gpu(proj_data_id, proj_geom, vol_geom)
+    astra.data3d.delete(data_id)
+    return data
+
+
+@pytest.fixture
+def proj_data_non_contiguous(backend, proj_geom):
+    shape = astra.geom_size(proj_geom)
+    data = np.full(shape, DATA_INIT_VALUE, dtype=np.float32)
+    return _convert_to_backend(data, backend).swapaxes(0, 1)
+
+
+@pytest.mark.parametrize('backend', ['numpy', 'pytorch_cpu', 'pytorch_cuda', 'cupy',
+                                     'jax_cpu', 'jax_cuda'])
+class TestAll:
+    def test_backends_fp(self, backend, projector, vol_data, proj_data, reference_fp):
+        astra.experimental.direct_FP3D(projector, vol_data, proj_data)
+        if backend.startswith('pytorch'):
+            proj_data = proj_data.cpu()
+        assert np.allclose(proj_data, reference_fp)
+
+    def test_backends_bp(self, backend, projector, vol_data, proj_data, reference_bp):
+        astra.experimental.direct_BP3D(projector, vol_data, proj_data)
+        if backend.startswith('pytorch'):
+            vol_data = vol_data.cpu()
+        assert np.allclose(vol_data, reference_bp)
+    
+    @pytest.mark.parametrize('proj_geom', ['full'], indirect=True)
+    def test_non_contiguous(self, backend, proj_geom, proj_data_non_contiguous):
+        if backend.startswith('jax'):
+            # JAX should not produce non-contiguous tensors, so nothing to test
+            return
+        with pytest.raises(ValueError):
+            astra.data3d.link('-proj3d', proj_geom, proj_data_non_contiguous)
+
+
+@pytest.mark.parametrize('backend', ['numpy'])
+@pytest.mark.parametrize('vol_geom', ['full'], indirect=True)
+def test_read_only(backend, vol_geom, vol_data):
+    vol_data.flags['WRITEABLE'] = False
+    # BufferError for numpy < 2 which doesn't support exporting read-only arrays
+    # ValueError for numpy >= 2 where astra rejects the read-only array
+    with pytest.raises((ValueError, BufferError)):
+        astra.data3d.link('-vol', vol_geom, vol_data)

--- a/tests/python/unit/test_experimental_2d.py
+++ b/tests/python/unit/test_experimental_2d.py
@@ -1,0 +1,99 @@
+import astra
+import astra.experimental
+import numpy as np
+import pytest
+
+MODE_ADD = 0
+MODE_SET = 1
+
+DET_SPACING = 1.0
+DET_COUNT = 45
+N_ANGLES = 180
+ANGLES = np.linspace(0, 2 * np.pi, N_ANGLES, endpoint=False)
+SOURCE_ORIGIN = 100
+ORIGIN_DET = 100
+N_ROWS = 40
+N_COLS = 30
+N_SLICES = 50
+VOL_SHIFT = 1, 2
+VOL_GEOM = astra.create_vol_geom(
+    N_ROWS, N_COLS,
+    -N_COLS/2 + VOL_SHIFT[0], N_COLS/2 + VOL_SHIFT[0],
+    -N_ROWS/2 + VOL_SHIFT[1], N_ROWS/2 + VOL_SHIFT[1])
+
+
+@pytest.fixture(scope='module')
+def proj_geom(request):
+    if request.param == 'parallel':
+        return astra.create_proj_geom('parallel', DET_SPACING, DET_COUNT, ANGLES)
+    elif request.param == 'parallel_vec':
+        geom = astra.create_proj_geom('parallel', DET_SPACING, DET_COUNT, ANGLES)
+        return astra.geom_2vec(geom)
+    elif request.param == 'fanflat':
+        return astra.create_proj_geom('fanflat', DET_SPACING,
+                                      DET_COUNT, ANGLES,
+                                      SOURCE_ORIGIN, ORIGIN_DET)
+    elif request.param == 'fanflat_vec':
+        geom = astra.create_proj_geom('fanflat', DET_SPACING,
+                                      DET_COUNT, ANGLES,
+                                      SOURCE_ORIGIN, ORIGIN_DET)
+        return astra.geom_2vec(geom)
+    elif request.param == 'short_scan':
+        cone_angle = np.arctan2(0.5 * DET_COUNT * DET_SPACING, SOURCE_ORIGIN + ORIGIN_DET)
+        angles = np.linspace(0, np.pi + 2 * cone_angle, 180)
+        return astra.create_proj_geom('fanflat', DET_SPACING, DET_COUNT, angles,
+                                      SOURCE_ORIGIN, ORIGIN_DET)
+
+
+@pytest.fixture
+def projector(proj_geom, proj_type):
+    if proj_type == 'gpu':
+        projector_id = astra.create_projector('cuda', proj_geom, VOL_GEOM)
+    elif 'fanflat' in proj_geom['type']:
+        projector_id = astra.create_projector('line_fanflat', proj_geom, VOL_GEOM)
+    else:
+        projector_id = astra.create_projector('linear', proj_geom, VOL_GEOM)
+
+    yield projector_id
+    astra.projector.delete(projector_id)
+
+
+@pytest.fixture
+def vol_data():
+    return np.ones([N_ROWS, N_COLS], dtype=np.float32)
+
+
+@pytest.fixture
+def vol_buffer():
+    return np.zeros([N_ROWS, N_COLS], dtype=np.float32)
+
+
+@pytest.fixture
+def proj_data():
+    return np.ones([N_ANGLES, DET_COUNT], dtype=np.float32)
+
+
+@pytest.fixture
+def proj_buffer():
+    return np.zeros([N_ANGLES, DET_COUNT], dtype=np.float32)
+
+
+@pytest.mark.parametrize(
+    'proj_geom', ['parallel', 'parallel_vec', 'fanflat', 'fanflat_vec'], indirect=True
+)
+@pytest.mark.parametrize('proj_type,', ['cpu', 'gpu'])
+class TestAll:
+    def test_direct_FP2D(self, proj_geom, projector, vol_data, proj_buffer):
+        astra.experimental.direct_FP2D(projector, vol_data, proj_buffer)
+        assert not np.allclose(proj_buffer, 0.0)
+        proj_data_id, proj_data_ref = astra.create_sino(vol_data, projector)
+        astra.data2d.delete(proj_data_id)
+        assert np.allclose(proj_buffer, proj_data_ref)
+
+    def test_direct_BP2D(self, proj_geom, projector, proj_data, vol_buffer):
+        astra.experimental.direct_BP2D(projector, vol_buffer, proj_data)
+        assert not np.allclose(vol_buffer, 0.0)
+        vol_data_id, vol_data_ref = astra.create_backprojection(proj_data, projector)
+        astra.data2d.delete(vol_data_id)
+        assert np.allclose(vol_buffer, vol_data_ref)
+


### PR DESCRIPTION
This adds support for dlpack GPU tensors to our 2D algorithms.

Also add `astra.experimental.direct_FP2D` and `direct_BP2D`, mirroring the existing 3D functions.

For the moment the 2D algorithms still allocate separate GPU buffers too, and do an on-device memcpy. For that to change, we need to ensure everything still works with external pointers not allocated by `cudaMallocPitch` and/or inconsistent pitches.