### PR TITLE
Add direct_FP/BP functions

### DIFF
--- a/python/astra/projector.py
+++ b/python/astra/projector.py
@@ -108,3 +108,31 @@ def matrix(i):
 
     """
     return p.matrix(i)
+
+def direct_FP(projector_id, volume, *, out):
+    """Perform a forward projection.
+
+    Input volume and output projection data are pre-allocated tensors,
+    such as numpy arrays, or more generally tensors supporting the DLPack
+    standard. They must satisfy the criteria of astra.data2d.link().
+
+    If the specified projector is a CUDA projector, the input and output
+    tensors can be CPU or GPU tensors.
+    """
+    from astra.experimental import direct_FP2D
+    direct_FP2D(projector_id, volume, out)
+    return out
+
+def direct_BP(projector_id, projection, *, out):
+    """Perform a backprojection.
+
+    Input projection data and output volume are pre-allocated tensors,
+    such as numpy arrays, or more generally tensors supporting the DLPack
+    standard. They must satisfy the criteria of astra.data2d.link().
+
+    If the specified projector is a CUDA projector, the input and output
+    tensors can be CPU or GPU tensors.
+    """
+    from astra.experimental import direct_BP2D
+    direct_BP2D(projector_id, out, projection)
+    return out

--- a/python/astra/projector3d.py
+++ b/python/astra/projector3d.py
@@ -98,3 +98,31 @@ def is_cuda(i):
 
     """
     return p.is_cuda(i)
+
+def direct_FP(projector_id, volume, *, out):
+    """Perform a forward projection.
+
+    Input volume and output projection data are pre-allocated tensors,
+    such as numpy arrays, or more generally tensors supporting the DLPack
+    standard. They must satisfy the criteria of astra.data3d.link().
+
+    If the specified projector is a CUDA projector, the input and output
+    tensors can be CPU or GPU tensors.
+    """
+    from astra.experimental import direct_FP3D
+    direct_FP3D(projector_id, volume, out)
+    return out
+
+def direct_BP(projector_id, projection, *, out):
+    """Perform a backprojection.
+
+    Input projection data and output volume are pre-allocated tensors,
+    such as numpy arrays, or more generally tensors supporting the DLPack
+    standard. They must satisfy the criteria of astra.data3d.link().
+
+    If the specified projector is a CUDA projector, the input and output
+    tensors can be CPU or GPU tensors.
+    """
+    from astra.experimental import direct_BP3D
+    direct_BP3D(projector_id, out, projection)
+    return out

--- a/tests/python/unit/test_experimental.py
+++ b/tests/python/unit/test_experimental.py
@@ -99,6 +99,14 @@ class TestAll:
         assert not np.allclose(vol_buffer_iter2, 0.0)
         assert not np.allclose(vol_buffer, vol_buffer_iter2)
 
+    def test_direct_FP(self, proj_geom, projector, vol_data, proj_buffer):
+        astra.projector3d.direct_FP(projector, vol_data, out=proj_buffer)
+        assert not np.allclose(proj_buffer, 0.0)
+
+    def test_direct_BP(self, proj_geom, projector, proj_data, vol_buffer):
+        astra.projector3d.direct_BP(projector, proj_data, out=vol_buffer)
+        assert not np.allclose(vol_buffer, 0.0)
+
     def test_composite_FP3D(self, proj_geom, projector, vol_data, proj_buffer):
         vol_ids = [astra.data3d.create('-vol', VOL_GEOM, vol_data) for _ in range(2)]
         proj_ids = [astra.data3d.create('-sino', proj_geom, proj_buffer) for _ in range(2)]

--- a/tests/python/unit/test_experimental_2d.py
+++ b/tests/python/unit/test_experimental_2d.py
@@ -97,3 +97,16 @@ class TestAll:
         astra.data2d.delete(vol_data_id)
         assert np.allclose(vol_buffer, vol_data_ref)
 
+    def test_direct_FP(self, proj_geom, projector, vol_data, proj_buffer):
+        astra.projector.direct_FP(projector, vol_data, out=proj_buffer)
+        assert not np.allclose(proj_buffer, 0.0)
+        proj_data_id, proj_data_ref = astra.create_sino(vol_data, projector)
+        astra.data2d.delete(proj_data_id)
+        assert np.allclose(proj_buffer, proj_data_ref)
+
+    def test_direct_BP(self, proj_geom, projector, proj_data, vol_buffer):
+        astra.projector.direct_BP(projector, proj_data, out=vol_buffer)
+        assert not np.allclose(vol_buffer, 0.0)
+        vol_data_id, vol_data_ref = astra.create_backprojection(proj_data, projector)
+        astra.data2d.delete(vol_data_id)
+        assert np.allclose(vol_buffer, vol_data_ref)


### PR DESCRIPTION
These functions provide an interface to call FP/BP directly on pre-allocated numpy arrays, pytorch tensors and other DLPack-supporting tensors.

This was supported by functions in `astra.experimental` already. These new functions provide a more permanent interface, but the functions in `astra.experimental` will stay for the foreseeable future because they have external users.