### PR TITLE
fix: update numpy LAPACK import to use _umath_linalg instead of lapack_lite

### DIFF
--- a/matlab/mex/astra_mex_plugin_c.cpp
+++ b/matlab/mex/astra_mex_plugin_c.cpp
@@ -47,7 +47,8 @@ static void fixLapackLoading()
     // to use its internal lapack library instead of
     // Matlab's MKL library to avoid errors. To do this,
     // we set Python's dlopen flags to RTLD_NOW|RTLD_DEEPBIND
-    // and import 'numpy.linalg.lapack_lite' here. We reset
+    // and import 'numpy.linalg._umath_linalg' (which links against
+    // numpy's internal LAPACK) here. We reset
     // Python's dlopen flags afterwards.
     PyObject *sys = PyImport_ImportModule("sys");
     if (sys != NULL) {
@@ -55,7 +56,7 @@ static void fixLapackLoading()
         if (curFlags != NULL) {
             PyObject *retVal = PyObject_CallMethod(sys, "setdlopenflags", "i", 10); // RTLD_NOW|RTLD_DEEPBIND
             if (retVal != NULL) {
-                PyObject *lapack = PyImport_ImportModule("numpy.linalg.lapack_lite");
+                PyObject *lapack = PyImport_ImportModule("numpy.linalg._umath_linalg");
                 if (lapack != NULL) {
                     Py_DECREF(lapack);
                 }


### PR DESCRIPTION
NumPy is currently deprecating the `numpy.linalg.lapack_lite` module. 

This PR updates the `fixLapackLoading` to import `numpy.linalg._umath_linalg` instead. `_umath_linalg` is NumPy's primary internal LAPACK extension, so it achieves the exact same goal without relying on a deprecated module. 


Reference: https://github.com/numpy/numpy/pull/32015