### PR TITLE
Fix filterData handling for numpy arrays in create_reconstruction

### DIFF
--- a/python/astra/creators.py
+++ b/python/astra/creators.py
@@ -539,11 +539,11 @@ def create_reconstruction(rec_type, proj_id, sinogram, iterations=1, use_mask='n
         cfg['options']['ReconstructionMaskId'] = mask_id
     if not filterType == None:
         cfg['FilterType'] = filterType
-    if not filterData == None:
+    if filterData is not None:
         if isinstance(filterData, np.ndarray):
             nexpow = int(
                 pow(2, math.ceil(math.log(2 * proj_geom['DetectorCount'], 2))))
-            filtSize = nexpow / 2 + 1
+            filtSize = nexpow // 2 + 1
             filt_proj_geom = create_proj_geom(
                 'parallel', 1.0, filtSize, proj_geom['ProjectionAngles'])
             filt_id = data2d.create('-sino', filt_proj_geom, filterData)
@@ -564,7 +564,7 @@ def create_reconstruction(rec_type, proj_id, sinogram, iterations=1, use_mask='n
         data2d.delete(sino_id)
     if use_mask == 'yes' and isinstance(mask, np.ndarray):
         data2d.delete(mask_id)
-    if not filterData == None:
+    if filterData is not None:
         if isinstance(filterData, np.ndarray):
             data2d.delete(filt_id)
     if returnData:

--- a/python/astra/tests.py
+++ b/python/astra/tests.py
@@ -99,6 +99,72 @@ def test_CUDA():
   if not (ok1 and ok2 and ok3):
     raise RuntimeError("Test failed")
 
+def _test_filterData_none(rec_type='SIRT'):
+  import astra
+  import numpy as np
+  vg = astra.create_vol_geom(64, 64)
+  pg = astra.create_proj_geom('parallel', 1.0, 128,
+    np.linspace(0, np.pi, 180, endpoint=False, dtype=np.float64))
+  proj_id = astra.create_projector('linear', pg, vg)
+  sino = np.zeros((180, 128), dtype=np.float32)
+  rec_id = astra.create_reconstruction(
+    rec_type, proj_id, sino, iterations=1,
+    filterType=None, filterData=None, returnData=False)
+  astra.algorithm.delete(rec_id)
+  astra.projector.delete(proj_id)
+  return True
+
+def _test_filterData_ndarray(rec_type='SIRT'):
+  import astra
+  import numpy as np
+  vg = astra.create_vol_geom(64, 64)
+  pg = astra.create_proj_geom('parallel', 1.0, 128,
+    np.linspace(0, np.pi, 180, endpoint=False, dtype=np.float64))
+  proj_id = astra.create_projector('linear', pg, vg)
+  sino = np.zeros((180, 128), dtype=np.float32)
+  # Shape is (angles, filtSize) where filtSize = nexpow // 2 + 1
+  filt_id = np.ones((180, 129), dtype=np.float32)
+  rec_id = astra.create_reconstruction(
+    rec_type, proj_id, sino, iterations=1,
+    filterType='projection', filterData=filt_id, returnData=False)
+  astra.algorithm.delete(rec_id)
+  astra.projector.delete(proj_id)
+  return True
+
+def _test_filterData_filtSize_is_int():
+  import astra
+  import numpy as np
+  import math
+  pg = astra.create_proj_geom('parallel', 1.0, 128,
+    np.linspace(0, np.pi, 180, endpoint=False, dtype=np.float64))
+  nexpow = int(pow(2, math.ceil(math.log(2 * pg['DetectorCount'], 2))))
+  filt_size = nexpow // 2 + 1
+  filt_pg = astra.create_proj_geom('parallel', 1.0, filt_size, pg['ProjectionAngles'])
+  assert isinstance(filt_size, int), "filtSize should be int, got %s" % type(filt_size)
+  assert isinstance(filt_pg['DetectorCount'], int), \
+    "DetectorCount should be int, got %s" % type(filt_pg['DetectorCount'])
+  return True
+
+def test_filterData():
+  """Test filterData parameter handling in create_reconstruction"""
+
+  import astra
+  import numpy as np
+  print("Testing filterData=None (no filter)... ", end="", flush=True)
+  assert _test_filterData_none()
+  print("Ok")
+  print("Testing filterData=np.ndarray (custom filter)... ", end="", flush=True)
+  try:
+    assert _test_filterData_ndarray()
+    print("Ok")
+  except ValueError as e:
+    print("FAILED: %s" % e)
+    raise
+  print("Testing filtSize integer type... ", end="", flush=True)
+  assert _test_filterData_filtSize_is_int()
+  print("Ok")
+
+
 def test():
   """Perform a very basic functionality test"""
 


### PR DESCRIPTION
## Bug 1: `filterData` as numpy array raises ValueError

When `filterData` is passed as a `numpy.ndarray` (as documented), the check:

```python
if not filterData == None:
```

evaluates `filterData == None` element-wise, producing a boolean array. `not` on a boolean array raises:

```
ValueError: The truth value of an array with more than one element is ambiguous
```

**Fix**: Use `is not None` — the standard Python/NumPy idiom for None checks.

Both occurrences fixed (line 542 for sinogram creation, line 567 for cleanup).

## Bug 2: `filtSize` computed as float

```python
filtSize = nexpow / 2 + 1
```

In Python 3 `/` returns `float` (e.g. `129.0`), but `DetectorCount` expects `int`.

**Fix**: Use integer division `//`.

## Verification

Verified against conda-installed ASTRA (CPU-only, no CUDA needed):
- Without fix: `ValueError` raised immediately when `filterData` is a numpy array
- With fix: `filterData=None`, `filterData=np.ndarray`, `filterData=int` ID all pass

## Tests added

- `test_filterData_none` — regression: `filterData=None` works
- `test_filterData_ndarray` — numpy `ndarray` filterData is accepted
- `test_filterData_filtSize_is_int` — `filtSize` is computed as int (not float)
- `test_filterData` — runner that calls all three